### PR TITLE
Changed maxlenght to 1000

### DIFF
--- a/src/components/RatePending.vue
+++ b/src/components/RatePending.vue
@@ -26,7 +26,7 @@
                 </div>
             </div>
             <div class="rate--comment-box" v-show="expanded">
-                <textarea maxlength="330" class="rate_comment" v-model="comment" placeholder="Incluya un comentario..."></textarea>
+                <textarea maxlength="1000" class="rate_comment" v-model="comment" placeholder="Incluya un comentario..."></textarea>
                 <button class="btn btn-primary" @click="makeVote" :disabled="sending"> Calificar </button>
             </div>
         </div>

--- a/src/components/sections/UpdateProfile.vue
+++ b/src/components/sections/UpdateProfile.vue
@@ -46,7 +46,7 @@
                 </div>-->
                 <div class="form-group">
                     <label for="input-description">Acerca de mi <span class="required-field-flag" title="Campo requerido">(*)</span><span class="description"> Contale de vos al resto de los carpooleros así te suman a sus viajes! Qué te gusta hacer, en qué andas metido ahora, si estás con alguna idea, si te gustan los colores, etc.</span></label>
-                    <textarea maxlength="280" v-model="user.description" placeholder="Descripción" :class="{'has-error': descError.state }" ></textarea>
+                    <textarea maxlength="1000" v-model="user.description" placeholder="Descripción" :class="{'has-error': descError.state }" ></textarea>
                     <span class="error textarea" v-if="descError.state"> {{descError.message}} </span>
                 </div>
                 <div class="form-group">

--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -111,7 +111,7 @@ Tengamos un buen viaje cuidándonos entre todos :D">
                             </div>
                             <div class="trip-comment">
                                 <label for="trip_comment"  class="label-for-group"> Comentario para los pasajeros </label>
-                                <textarea maxlength="280" v-model="trip.description" id="trp_comment" class="form-control"></textarea>
+                                <textarea maxlength="1000" v-model="trip.description" id="trp_comment" class="form-control"></textarea>
                                 <span class="error" v-if="commentError.state"> {{commentError.message}} </span>
                             </div>
                         </div>


### PR DESCRIPTION
Changed maxlenght to 1000 for comments in trips, profile and ratings. 
DB right now allows 
65000 chars for the comment field in the rating table
1000 chars for the description field in the users table
1500 chars for the description field in the trips table