### PR TITLE
fix: When posting a new trip check if this.cars is defined before accessing the car id

### DIFF
--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -2315,7 +2315,7 @@ export default {
                 to_town: last(points).address,
                 trip_date: tripObj.dateAnswer + ' ' + tripObj.time + ':00',
                 estimated_time: estimatedTime,
-                car_id: this.cars.length > 0 ? this.cars[0].id : undefined
+                car_id: this.cars && this.cars.length > 0 ? this.cars[0].id : undefined
             };
 
             return Object.assign({}, tripObj.trip, tripInfo);


### PR DESCRIPTION
`this.cars` is null when creating a new trip on a fresh install. Accessing this.car.length then creates an error, which prevents the trip from being posted.