### PR TITLE
Fix/chat profile image

### DIFF
--- a/src/components/views/ConversationChat.vue
+++ b/src/components/views/ConversationChat.vue
@@ -275,16 +275,13 @@ export default {
     .list-group-item {
         border: 0;
     }
-    .list-group {
-        overflow: hidden;
-    }
     .list-group-item:last-child {
         border-top: 1px solid #ddd;
         bottom: 0;
         left: 0;
         width: 100%;
         position: fixed;
-    }    
+    }
     .conversation_chat .input-group-btn:last-child > .btn {
         height: 44px;
     }
@@ -296,8 +293,8 @@ export default {
         margin-bottom: 1em;
     }
     #messagesWrapper {
-        padding-top: 45px;
-        padding-bottom: 60px;
+        padding-top: 0;
+        padding-bottom: 65px;
     }
 }
 </style>


### PR DESCRIPTION
Fix a bug where the chat profile image on mobiles shows up blank:

<img width="552" height="255" alt="image" src="https://github.com/user-attachments/assets/c5c6d648-84b6-45bc-86b2-ba848c180801" />
