### PR TITLE
Reduce Co2 emissions per km

### DIFF
--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -1867,7 +1867,7 @@ export default {
             );
         },
         CO2String() {
-            return Math.floor(this.trip.distance / 1000) * 1.5 + ' Kg';
+            return Math.floor(this.trip.distance / 1000) * 0.15 + ' Kg';
         },
         otherTripDistanceString() {
             return Math.floor(this.otherTrip.trip.distance / 1000) + ' Km';
@@ -1886,7 +1886,7 @@ export default {
         },
         otherTripCO2String() {
             return (
-                Math.floor(this.otherTrip.trip.distance / 1000) * 1.5 + ' Kg'
+                Math.floor(this.otherTrip.trip.distance / 1000) * 0.15 + ' Kg'
             );
         },
         tripCardTheme() {


### PR DESCRIPTION
Fix for [#246](https://github.com/STS-Rosario/carpoolear/issues/246). Based on standard carbon emission data, 0.15 kg CO2 per kilometer is the correct value for an average passenger car. The value 1.5 kg/km is 10 times higher.