### PR TITLE
Fix return trip description validation

### DIFF
--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -2288,7 +2288,6 @@ export default {
                     }
                 }
 
-                // Validate return trip description
                 if (!this.otherTrip.trip.description) {
                     this.otherTrip.commentError.state = true;
                     this.otherTrip.commentError.message = this.$t('olvidasteDescripcion');


### PR DESCRIPTION
Add validation for return trip description. Currently the post is allowed without a description causing it to hang on the server side.