### PR TITLE
Fix: Add empty point for intermediary locations in update mode

### DIFF
--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -2073,8 +2073,7 @@ export default {
                 place: null,
                 json: null,
                 location: null,
-                error: new Error(),
-                id: new Date().getTime()
+                error: new Error()
             };
             this.points.splice(this.points.length - 1, 0, newPoint);
         }


### PR DESCRIPTION
When updating a trip, show an empty intermediary location by default. Users may not figure out they need to update an existing intermediary location in order to add a new one.