### PR TITLE
Fix: Re-enable trip duration calculation

### DIFF
--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -2098,7 +2098,6 @@ export default {
         this.trip.allow_animals = !(trip.allow_animals > 0);
         this.trip.allow_smoking = !(trip.allow_smoking > 0);
         
-        // Calculate route to get duration and other trip info
         this.calcRoute();
     },
 


### PR DESCRIPTION
Automatically calculate trip duration when editing a trip. If there was any reason for disabling the functionality previously, however, then feel free to close this PR.