### PR TITLE
Update browserslist

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,14 +137,8 @@
     "webpack-merge": "^4.2.1",
     "xml2js": "^0.4.19"
   },
-  "browserslist": {
-    "production": [
-      "last 2 version",
-      "ie 9"
-    ],
-    "development": [
-      "last 2 version",
-      "ie 9"
-    ]
-  }
+  "browserslist": [
+    "defaults and fully supports es6-module",
+    ">0.5% in AR and not dead"
+  ]
 }


### PR DESCRIPTION
Our current browserslist configuration targets only 56.4% of the
[global audience](https://browsersl.ist/#q=%22browserslist%22%3A+%5B%0A++%22last+2+version%22%2C%0A++%22ie+9%22%0A%5D) and 43.8% of [Argentina's audience](https://browsersl.ist/#q=%22browserslist%22%3A+%5B%0A++%22last+2+version%22%2C%0A++%22ie+9%22%0A%5D&region=AR).

With the new configuration we increment that to 86.6% of the
[global audience](https://browsersl.ist/#q=%22browserslist%22%3A+%5B%0A++%22defaults+and+fully+supports+es6-module%22%2C%0A++%22%3E0.5%25+in+AR+and+not+dead%22%0A%5D) and 92.6% of [Argentina's audience](https://browsersl.ist/#q=%22browserslist%22%3A+%5B%0A++%22defaults+and+fully+supports+es6-module%22%2C%0A++%22%3E0.5%25+in+AR+and+not+dead%22%0A%5D&region=AR).