### PR TITLE
Rename beforeDestroy to beforeUnmount (Vue 3 migration)

### DIFF
--- a/src/components/Dropdown.vue
+++ b/src/components/Dropdown.vue
@@ -109,7 +109,7 @@ export default {
         document.addEventListener('click', this.handleOutsideClick);
     },
 
-    beforeDestroy() {
+    beforeUnmount() {
         document.removeEventListener('click', this.handleOutsideClick);
     }
 };

--- a/src/components/IdentityValidationCountdownBanner.vue
+++ b/src/components/IdentityValidationCountdownBanner.vue
@@ -72,7 +72,7 @@ export default {
             this.now = Date.now();
         }, 1000);
     },
-    beforeDestroy() {
+    beforeUnmount() {
         if (this.ticker) clearInterval(this.ticker);
     },
     methods: {

--- a/src/components/elements/Tab.vue
+++ b/src/components/elements/Tab.vue
@@ -48,7 +48,7 @@ export default {
     mounted: function () {
         this.$parent.registerTab(this);
     },
-    beforeDestroy: function () {
+    beforeUnmount: function () {
         this.$parent.removeTab(this);
     },
     ready: function () {

--- a/src/components/sections/FriendsRequest.vue
+++ b/src/components/sections/FriendsRequest.vue
@@ -161,7 +161,7 @@ export default {
         bus.on('back-click', this.onBackClick);
     },
 
-    beforeDestroy() {
+    beforeUnmount() {
         bus.off('back-click', this.onBackClick);
     },
     components: {

--- a/src/components/sections/ManualIdentityValidation.vue
+++ b/src/components/sections/ManualIdentityValidation.vue
@@ -319,7 +319,7 @@ export default {
         this.fetchCost();
         this.fetchStatus();
     },
-    beforeDestroy() {
+    beforeUnmount() {
         this.stopPollingStatus();
     }
 };

--- a/src/components/sections/SearchTrip.vue
+++ b/src/components/sections/SearchTrip.vue
@@ -235,7 +235,7 @@ export default {
         this.$refs['to_town'].$el.addEventListener('input', this.checkInput);
     },
     updated() {},
-    beforeDestroy() {
+    beforeUnmount() {
         this.$refs['from_town'].$el.removeEventListener(
             'input',
             this.checkInput

--- a/src/components/sections/UpdateProfile.vue
+++ b/src/components/sections/UpdateProfile.vue
@@ -1215,7 +1215,7 @@ export default {
             console.log('exception', ex);
         }
     },
-    beforeDestroy() {
+    beforeUnmount() {
         bus.off('date-change', this.dateChange);
     },
     components: {

--- a/src/components/views/About.vue
+++ b/src/components/views/About.vue
@@ -199,7 +199,7 @@ export default {
         bus.on('back-click', this.onBackClick);
     },
 
-    beforeDestroy() {
+    beforeUnmount() {
         bus.off('back-click', this.onBackClick);
     },
 

--- a/src/components/views/ConversationChat.vue
+++ b/src/components/views/ConversationChat.vue
@@ -256,7 +256,7 @@ export default {
             });
         }
     },
-    beforeDestroy() {
+    beforeUnmount() {
         bus.off('back-click', this.onBackClick);
     },
     mounted() {

--- a/src/components/views/ConversationList.vue
+++ b/src/components/views/ConversationList.vue
@@ -287,7 +287,7 @@ export default {
         }
     },
 
-    beforeDestroy() {
+    beforeUnmount() {
         this.thread.stop();
         this.select(null);
     },

--- a/src/components/views/Login.vue
+++ b/src/components/views/Login.vue
@@ -500,7 +500,7 @@ export default {
         });
     },
 
-    beforeDestroy() {
+    beforeUnmount() {
         bus.off('clear-click', this.onClearClick);
     },
 

--- a/src/components/views/MyTrips.vue
+++ b/src/components/views/MyTrips.vue
@@ -429,7 +429,7 @@ export default {
             });
         });
     },
-    beforeDestroy() {
+    beforeUnmount() {
         bus.off('request-status-changed');
     },
     computed: {

--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -1879,7 +1879,7 @@ export default {
             this.trips_created_by_user_amount = result.data.trips_created_by_user_amount;
         });
     },
-    beforeDestroy() {},
+    beforeUnmount() {},
 
     computed: {
         ...mapState(useAuthStore, {

--- a/src/components/views/Profile.vue
+++ b/src/components/views/Profile.vue
@@ -132,7 +132,7 @@ export default {
         this.updateProfile();
         bus.on('back-click', this.onBackClick);
     },
-    beforeDestroy() {
+    beforeUnmount() {
         bus.off('back-click', this.onBackClick);
     }
 };

--- a/src/components/views/Register.vue
+++ b/src/components/views/Register.vue
@@ -781,7 +781,7 @@ export default {
         document.head.appendChild(recaptchaScript);
     },
 
-    beforeDestroy() {
+    beforeUnmount() {
         console.log(this.$route.name);
         if (this.$route.name === 'terms') {
             this.saveRegisterData(this.$data);

--- a/src/components/views/ResetPassword.vue
+++ b/src/components/views/ResetPassword.vue
@@ -156,7 +156,7 @@ export default {
         bus.on('back-click', this.onBackClick);
     },
 
-    beforeDestroy() {
+    beforeUnmount() {
         bus.off('back-click', this.onBackClick);
     },
 

--- a/src/components/views/TermsAndConditions.vue
+++ b/src/components/views/TermsAndConditions.vue
@@ -36,7 +36,7 @@ export default {
             router.back();
         }
     },
-    beforeDestroy() {
+    beforeUnmount() {
         bus.off('back-click', this.onBackClick);
     }
 };

--- a/src/components/views/Trips.vue
+++ b/src/components/views/Trips.vue
@@ -709,7 +709,7 @@ export default {
     updated(a) {
         // {{ $t('pendienteNoSeLimpiaBuscador') }}
     },
-    beforeDestroy() {
+    beforeUnmount() {
         bus.off('search-click', this.onSearchButton);
         bus.off('clear-click', this.onClearButton);
         bus.off('scroll-bottom', this.onScrollBottom);

--- a/src/components/views/UsersCrud.vue
+++ b/src/components/views/UsersCrud.vue
@@ -912,7 +912,7 @@ export default {
         }
     },
 
-    beforeDestroy() {
+    beforeUnmount() {
         this.thread.stop();
         this.select(null);
     },

--- a/src/components/views/transactions.vue
+++ b/src/components/views/transactions.vue
@@ -64,7 +64,7 @@ export default {
         });
     },
 
-    beforeDestroy() {
+    beforeUnmount() {
         bus.off('back-click', this.onBackClick);
     },
 


### PR DESCRIPTION
Renamed all 20 lifecycle hooks to use beforeUnmount, the Vue 3 equivalent. While @vue/compat shims the old name, removing it is required for the Vue 3 migration.

Closes #316 