### PR TITLE
Replace $set with direct assignment (Vue 3 migration)

### DIFF
--- a/src/components/elements/CoordinateTrip.vue
+++ b/src/components/elements/CoordinateTrip.vue
@@ -212,17 +212,13 @@ export default {
         doRequest(isReturnTrip = false) {
             if (this.$redirectToIdentityValidationIfRequired()) return;
             if (this.config.module_coordinate_by_message) {
-                this.$set(
-                    this.sending,
-                    isReturnTrip ? 'returnTrip' : 'trip',
-                    true
-                );
+                this.sending[isReturnTrip ? 'returnTrip' : 'trip'] = true;
                 let trip = isReturnTrip
                     ? this.conversation.return_trip
                     : this.conversation.trip;
                 this.make(trip.id)
                     .then((response) => {
-                        this.$set(trip, 'request', 'send');
+                        trip.request = 'send';
                     })
                     .catch((error) => {
                         if (this.$checkError(error, 'identity_validation_required')) {
@@ -233,11 +229,7 @@ export default {
                         }
                     })
                     .finally(() => {
-                        this.$set(
-                            this.sending,
-                            isReturnTrip ? 'returnTrip' : 'trip',
-                            false
-                        );
+                        this.sending[isReturnTrip ? 'returnTrip' : 'trip'] = false;
                     });
             }
         },
@@ -249,11 +241,7 @@ export default {
                         this.$t('seguroBajarteViaje')
                     )
                 ) {
-                    this.$set(
-                        this.sending,
-                        isReturnTrip ? 'trip' : 'returnTrip',
-                        true
-                    );
+                    this.sending[isReturnTrip ? 'trip' : 'returnTrip'] = true;
                     let trip = isReturnTrip
                         ? this.conversation.return_trip
                         : this.conversation.trip;
@@ -288,11 +276,7 @@ export default {
                             );
                         })
                         .finally(() => {
-                            this.$set(
-                                this.sending,
-                                isReturnTrip ? 'trip' : 'returnTrip',
-                                false
-                            );
+                            this.sending[isReturnTrip ? 'trip' : 'returnTrip'] = false;
                         });
                 }
             }

--- a/src/components/sections/FriendsRequest.vue
+++ b/src/components/sections/FriendsRequest.vue
@@ -142,13 +142,13 @@ export default {
         },
 
         onAddClick(user) {
-            this.$set(this.idRequesting, user.id, true);
+            this.idRequesting[user.id] = true;
             this.request(user.id).then(
                 () => {
-                    this.$set(this.idRequesting, user.id, false);
+                    this.idRequesting[user.id] = false;
                 },
                 () => {
-                    this.$set(this.idRequesting, user.id, false);
+                    this.idRequesting[user.id] = false;
                 }
             );
         },

--- a/src/components/sections/OnBoarding.vue
+++ b/src/components/sections/OnBoarding.vue
@@ -150,18 +150,14 @@ export default {
             this.endActions();
         },
         endActions() {
-            this.$set(document.documentElement.style, 'overflow', 'auto');
-            this.$set(document.body, 'scroll', 'yes');
+            document.documentElement.style.overflow = 'auto';
+            document.body.style.scroll = 'yes';
             this.setFirstTimeAppOpenInDevice();
         }
     },
     watch: {
         cardNumber(value) {
-            this.$set(
-                this.styleContainerObject,
-                'transform',
-                `translate(${(value - 1) * -100}vw)`
-            );
+            this.styleContainerObject.transform = `translate(${(value - 1) * -100}vw)`;
         }
     }
 };

--- a/src/components/views/ConversationChat.vue
+++ b/src/components/views/ConversationChat.vue
@@ -192,7 +192,7 @@ export default {
             if (!editor) return;
             const text = (editor.invoke('getMarkdown') || '').trim();
             if (text.length) {
-                this.$set(this.sending, 'message', true);
+                this.sending.message = true;
                 this.send(text)
                     .catch((err) => {
                         if (this.$checkError(err, 'identity_validation_required')) {
@@ -203,7 +203,7 @@ export default {
                         }
                     })
                     .finally(() => {
-                        this.$set(this.sending, 'message', false);
+                        this.sending.message = false;
                         this.$forceUpdate();
                     });
                 editor.invoke('setMarkdown', '');

--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -2043,14 +2043,14 @@ export default {
             getTrip: 'getTrip'
         }),
         setIsPassenger(value) {
-            this.$set(this.trip, 'is_passenger', value);
+            this.trip.is_passenger = value;
         },
         changeOtherTripDate(date) {
-            this.$set(this.otherTrip.dateError, 'state', false);
+            this.otherTrip.dateError.state = false;
             this.otherTrip.dateAnswer = date;
         },
         changeDate(date) {
-            this.$set(this.dateError, 'state', false);
+            this.dateError.state = false;
             this.dateAnswer = date;
         },
         jumpToError() {

--- a/src/components/views/Trip.vue
+++ b/src/components/views/Trip.vue
@@ -512,7 +512,7 @@ export default {
         },
         deleteTrip() {
             if (window.confirm(this.$t('seguroCancelar'))) {
-                this.$set(this.sending, 'deleteAction', true);
+                this.sending.deleteAction = true;
                 this.remove(this.trip.id)
                     .then(() => {
                         dialogs.message(this.$t('viajeCancelado'), {
@@ -525,7 +525,7 @@ export default {
                         dialogs.message(this.$t('errorAlCancelar'), {
                             estado: 'error'
                         });
-                        this.$set(this.sending, 'deleteAction', false);
+                        this.sending.deleteAction = false;
                     });
             }
         },
@@ -620,7 +620,7 @@ export default {
         },
 
         toUserMessages(user) {
-            this.$set(this.sending, 'sendMessageAction', true);
+            this.sending.sendMessageAction = true;
             let data = {
                 user: user,
                 tripId: this.trip.is_passenger ? undefined : this.trip.id
@@ -634,7 +634,7 @@ export default {
                 })
                 .catch((error) => {
                     console.error(error);
-                    this.$set(this.sending, 'sendMessageAction', false);
+                    this.sending.sendMessageAction = false;
                 });
         },
 
@@ -678,7 +678,7 @@ export default {
                     this.toMessages();
                     return;
                 }
-                this.$set(this.sending, 'requestAction', true);
+                this.sending.requestAction = true;
                 this.showModalRequestSeat = false;
                 this.make(this.trip.id)
                     .then((response) => {
@@ -693,14 +693,14 @@ export default {
                         }
                     })
                     .finally(() => {
-                        this.$set(this.sending, 'requestAction', false);
+                        this.sending.requestAction = false;
                     });
             }
         },
 
         cancelRequest() {
             if (window.confirm(this.$t('seguroBajarteViaje'))) {
-                this.$set(this.sending, 'requestAction', true);
+                this.sending.requestAction = true;
                 this.cancel({ user: this.user, trip: this.trip })
                     .then(() => {
                         dialogs.message(this.$t('teHasBajadoViaje'));
@@ -716,7 +716,7 @@ export default {
                         );
                     })
                     .finally(() => {
-                        this.$set(this.sending, 'requestAction', false);
+                        this.sending.requestAction = false;
                     });
             }
         },

--- a/src/components/views/UsersCrud.vue
+++ b/src/components/views/UsersCrud.vue
@@ -820,8 +820,8 @@ export default {
             if (this.newInfo.nro_doc && this.newInfo.nro_doc.length > 0 && this.newInfo.nro_doc.length < 7) {
                 // this.dniError.state = true;
                 // this.dniError.message = 'El DNI que ingresaste no es válido.';
-                this.$set(this.dniError, 'state', true);
-                this.$set(this.dniError, 'message', 'asdasdasdasd');
+                this.dniError.state = true;
+                this.dniError.message = 'asdasdasdasd';
 
                 globalError = true;
             }


### PR DESCRIPTION
Replaced 26 this.$set() calls with direct property assignment. Vue 3's Proxy-based reactivity system detects property additions automatically.

Closes #317 