### PR TITLE
Replace .sync with v-model (Vue 3 migration)

### DIFF
--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -378,8 +378,8 @@
                             </div>
                             <div class="trip-weekly-schedule" v-if="useWeeklySchedule && config.weekly_schedule">
                                 <WeeklySchedule
-                                    :weeklySchedule.sync="weeklySchedule"
-                                    :weeklyScheduleTime.sync="weeklyScheduleTime"
+                                    v-model:weeklySchedule="weeklySchedule"
+                                    v-model:weeklyScheduleTime="weeklyScheduleTime"
                                     :readonly="false"
                                     :theme="tripCardTheme"
                                     :hasError="timeError.state"
@@ -1143,8 +1143,8 @@
                             </div>
                             <div class="trip-weekly-schedule" v-if="useWeeklySchedule && config.weekly_schedule">
                                 <WeeklySchedule
-                                    :weeklySchedule.sync="weeklySchedule"
-                                    :weeklyScheduleTime.sync="weeklyScheduleReturnTime"
+                                    v-model:weeklySchedule="weeklySchedule"
+                                    v-model:weeklyScheduleTime="weeklyScheduleReturnTime"
                                     :readonly="false"
                                     :theme="tripCardTheme"
                                     :hasError="otherTrip.timeError.state"


### PR DESCRIPTION
Replaced 4 .sync modifier usages with v-model:propName syntax. Vue 3 unified .sync with v-model syntax.

Closes #318 