### PR TITLE
Rename directive hooks to Vue 3 API

### DIFF
--- a/src/directives/autofocus.js
+++ b/src/directives/autofocus.js
@@ -1,5 +1,5 @@
 export default {
-    inserted: function (el) {
+    mounted: function (el) {
         el.focus();
     }
 };

--- a/src/directives/dateFormatter.js
+++ b/src/directives/dateFormatter.js
@@ -71,7 +71,7 @@ const keyDownHandler = function (event) {
 };
 
 export default {
-    bind: function (el, binding, node) {
+    beforeMount: function (el, binding, node) {
         numberFormatter[el.id] = {};
         numberFormatter[el.id].name = el.id;
         numberFormatter[el.id].value = el.value;
@@ -85,7 +85,7 @@ export default {
         el.addEventListener('keydown', keyDownHandler, false);
         el.addEventListener('input', inputHandler, false);
     },
-    unbind: function (el, binding, node) {
+    unmounted: function (el, binding, node) {
         el.removeEventListener('keydown', keyDownHandler, false);
         el.removeEventListener('input', inputHandler, false);
         numberFormatter[el.id] = undefined;

--- a/src/directives/debounceInput.js
+++ b/src/directives/debounceInput.js
@@ -6,11 +6,11 @@ const inputHandler = debounce(function () {
 }, 800);
 
 export default {
-    bind: function (el, binding, node) {
+    beforeMount: function (el, binding, node) {
         debounceFunction = binding.value;
         el.addEventListener('input', inputHandler, false);
     },
-    unbind: function (el, binding, node) {
+    unmounted: function (el, binding, node) {
         el.removeEventListener('input', inputHandler, false);
     }
 };

--- a/src/directives/fancyCheckbox.js
+++ b/src/directives/fancyCheckbox.js
@@ -8,11 +8,11 @@ function wrapElement(el) {
 }
 
 export default {
-    inserted: function (el, binding, node) {
+    mounted: function (el, binding, node) {
         wrapElement(el);
     },
-    update: function (el, binding, node) {
+    updated: function (el, binding, node) {
         // wrapElement(el);
     },
-    unbind: function (el, binding, node) {}
+    unmounted: function (el, binding, node) {}
 };

--- a/src/directives/imageSrc.js
+++ b/src/directives/imageSrc.js
@@ -15,13 +15,13 @@ function changePhoto(el, binding, node) {
 }
 
 export default {
-    inserted: function (el, binding, node) {
+    mounted: function (el, binding, node) {
         changePhoto(el, binding, node);
     },
-    update: function (el, binding, node) {
+    updated: function (el, binding, node) {
         changePhoto(el, binding, node);
     },
-    unbind: function (el, binding, node) {
+    unmounted: function (el, binding, node) {
         el.style.backgroundImage = null;
     }
 };

--- a/src/directives/numberFormatter.js
+++ b/src/directives/numberFormatter.js
@@ -171,7 +171,7 @@ const beforeInputHandler = function (event) {
 };
 
 export default {
-    bind: function (el, binding, node) {
+    beforeMount: function (el, binding, node) {
         // Ensure element has an ID (required for the directive to work)
         if (!el.id) {
             console.warn('numberMask directive requires element to have an id attribute');
@@ -203,7 +203,7 @@ export default {
             el.addEventListener('beforeinput', beforeInputHandler, false);
         }
     },
-    update: function (el, binding, node) {
+    updated: function (el, binding, node) {
         // Update context and expression if they changed
         if (numberFormatter[el.id]) {
             numberFormatter[el.id].context = node.context;
@@ -216,7 +216,7 @@ export default {
             formatNumber(el.id);
         }
     },
-    unbind: function (el, binding, node) {
+    unmounted: function (el, binding, node) {
         if (!el.id || !numberFormatter[el.id]) {
             return;
         }


### PR DESCRIPTION
Renamed Vue 2 directive lifecycle hooks to Vue 3 equivalents:
- bind → beforeMount
- inserted → mounted
- update → updated
- unbind → unmounted

Closes #319 