### PR TITLE
Replace Vue event bus with mitt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "lodash": "^4.18.1",
         "marked": "^4.0.19",
         "minimist": "^1.2.0",
+        "mitt": "^3.0.1",
         "node-notifier": "^5.4.1",
         "pinia": "^2.3.1",
         "qrcode": "^1.5.3",
@@ -15875,6 +15876,12 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
     },
     "node_modules/moment": {
       "version": "2.30.1",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "lodash": "^4.18.1",
     "marked": "^4.0.19",
     "minimist": "^1.2.0",
+    "mitt": "^3.0.1",
     "node-notifier": "^5.4.1",
     "pinia": "^2.3.1",
     "qrcode": "^1.5.3",

--- a/src/services/bus-event.js
+++ b/src/services/bus-event.js
@@ -1,23 +1,20 @@
-import Vue from 'vue';
+import mitt from 'mitt';
 
 class EventBuffer {
     constructor() {
-        this.buffer = new Vue();
+        this.emitter = mitt();
     }
 
     emit(name, params) {
-        const events = this.buffer._events || {};
-        const b = events[name] && events[name].length;
-        this.buffer.$emit(name, params);
-        return b;
+        this.emitter.emit(name, params);
     }
 
     on(name, callback) {
-        this.buffer.$on(name, callback);
+        this.emitter.on(name, callback);
     }
 
     off(name, callback) {
-        this.buffer.$off(name, callback);
+        this.emitter.off(name, callback);
     }
 }
 


### PR DESCRIPTION
Replaced new Vue() event bus pattern with mitt (~200B). Vue 3 removed $on/$off/$once instance methods.
No changes needed in consuming files - only bus-event.js internals.

Closes #320 