### PR TITLE
Update errorHandler signature for Vue 3

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -195,7 +195,7 @@ bus.on('system-ready', () => {
         return original$n.call(this, value, ...args);
     };
 
-    app.config.errorHandler = function (err, vm, info) {
+    app.config.errorHandler = function (err, instance, info) {
         const data = {};
         data.log = err.stack;
         debugApi.log(data);


### PR DESCRIPTION
Changed vm to instance in app.config.errorHandler callback. Vue 3 passes component instance as second argument.

Closes #323 