### PR TITLE
Leaflet migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ www/*
 test-results/
 playwright-report/
 playwright/.cache/
+
+# Cursor (local debug session NDJSON logs)
+.cursor/debug-*.log

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "dompurify": "^3.3.2",
         "firebase": "^9.19.1",
         "font-awesome": "^4.7.0",
+        "leaflet": "^1.9.4",
         "leaflet-routing-machine": "^3.2.12",
         "lodash": "^4.18.1",
         "marked": "^4.0.19",
@@ -52,7 +53,6 @@
         "vue-eslint-parser": "^1.0.0",
         "vue-i18n": "^9",
         "vue-router": "4.3.3",
-        "vue2-leaflet": "^1.0.2",
         "vuejs-datepicker": "^0.9.7"
       },
       "devDependencies": {
@@ -6664,12 +6664,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/geojson": {
-      "version": "7946.0.16",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
-      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
-      "license": "MIT"
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -6683,15 +6677,6 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/leaflet": {
-      "version": "1.9.17",
-      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.17.tgz",
-      "integrity": "sha512-IJ4K6t7I3Fh5qXbQ1uwL3CFVbCi6haW9+53oLWgdKlLP7EaS21byWFJxxqOx9y8I0AP0actXSJLVMbyvxhkUTA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "*"
-      }
     },
     "node_modules/@types/long": {
       "version": "4.0.2",
@@ -14772,9 +14757,9 @@
       }
     },
     "node_modules/leaflet": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.3.1.tgz",
-      "integrity": "sha512-adQOIzh+bfdridLM1xIgJ9VnJbAUY3wqs/ueF+ITla+PLQ1z47USdBKUf+iD9FuUA8RtlT6j6hZBfZoA6mW+XQ==",
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause"
     },
     "node_modules/leaflet-routing-machine": {
@@ -22996,19 +22981,6 @@
       "dependencies": {
         "hash-sum": "^1.0.2",
         "loader-utils": "^1.0.2"
-      }
-    },
-    "node_modules/vue2-leaflet": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/vue2-leaflet/-/vue2-leaflet-1.2.3.tgz",
-      "integrity": "sha512-dsmhswT6Xu2Nm59T64edvG0lpycSgIWQL3pUU7h6foP8QL+mSuT5gnhJGLO2mt+39w+HBTr4Rgz8bQvyELKVPA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/leaflet": "^1.2.11",
-        "leaflet": "1.3.1"
-      },
-      "peerDependencies": {
-        "vue": "^2.5.3"
       }
     },
     "node_modules/vuejs-datepicker": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "dompurify": "^3.3.2",
     "firebase": "^9.19.1",
     "font-awesome": "^4.7.0",
+    "leaflet": "^1.9.4",
     "leaflet-routing-machine": "^3.2.12",
     "lodash": "^4.18.1",
     "marked": "^4.0.19",
@@ -75,7 +76,6 @@
     "vue-eslint-parser": "^1.0.0",
     "vue-i18n": "^9",
     "vue-router": "4.3.3",
-    "vue2-leaflet": "^1.0.2",
     "vuejs-datepicker": "^0.9.7"
   },
   "devDependencies": {

--- a/src/components/views/Trip.vue
+++ b/src/components/views/Trip.vue
@@ -331,9 +331,9 @@
                                 </div>
                             </div>
                         </div>
-                        <l-map
-                            :zoom="zoom"
-                            :center="center"
+                        <div
+                            ref="tripMapEl"
+                            class="trip-route-map"
                             style="
                                 width: calc(100% + 20px);
                                 height: 461px;
@@ -341,13 +341,7 @@
                                 margin-left: -10px;
                                 z-index: 0;
                             "
-                            ref="map"
-                        >
-                            <l-tile-layer
-                                :url="url"
-                                :attribution="attribution"
-                            ></l-tile-layer>
-                        </l-map>
+                        ></div>
                     </div>
                 </div>
             </div>
@@ -386,12 +380,17 @@ import TripPassengers from '../elements/TripPassengers';
 import TripButtons from '../elements/TripButtons';
 
 import { useHead } from '@unhead/vue';
-import { LMap, LTileLayer } from 'vue2-leaflet';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
 import { appLocaleToRoutingLanguage } from '../../main';
 import 'leaflet-routing-machine';
 
 export default {
     name: 'trip',
+    beforeCreate() {
+        this._tripLeafletMap = null;
+        this._tripRoutingControl = null;
+    },
     data() {
         return {
             sending: {
@@ -505,9 +504,11 @@ export default {
                     var self = this;
                     this.calculateHeight();
                     this.$nextTick(function () { self.enablePayment(); });
-                    setTimeout(() => {
-                        self.renderMap();
-                    }, 500);
+                    self.$nextTick(() => {
+                        self.$nextTick(() => {
+                            self.syncTripRouteMap();
+                        });
+                    });
                     if (this.owner) {
                         this.searchMatchers({ trip: this.trip }).then(
                             (users) => {
@@ -693,19 +694,48 @@ export default {
             router.back();
         },
 
-        renderMap() {
-            if (this.$refs.map) {
-                let map = this.$refs.map.mapObject;
-                /* eslint-disable no-undef */
-                let points = this.trip.points.map((point) =>
-                    L.latLng(point.lat, point.lng)
-                );
-                let control = L.Routing.control({
-                    waypoints: points,
-                    language: appLocaleToRoutingLanguage[this.$i18n.locale] || 'es'
-                });
-                control.addTo(map);
+        destroyTripRouteMap() {
+            if (this._tripRoutingControl && this._tripLeafletMap) {
+                try {
+                    this._tripLeafletMap.removeControl(this._tripRoutingControl);
+                } catch (_) {
+                    /* noop */
+                }
+                this._tripRoutingControl = null;
             }
+            if (this._tripLeafletMap) {
+                try {
+                    this._tripLeafletMap.remove();
+                } catch (_) {
+                    /* noop */
+                }
+                this._tripLeafletMap = null;
+            }
+        },
+
+        syncTripRouteMap() {
+            const el = this.$refs.tripMapEl;
+            if (this.isPassengersView) {
+                this.destroyTripRouteMap();
+                return;
+            }
+            if (!el || !this.trip || !this.trip.points || !this.trip.points.length) {
+                return;
+            }
+            this.destroyTripRouteMap();
+            const c = this.center;
+            const map = L.map(el).setView([c.lat, c.lng], this.zoom);
+            L.tileLayer(this.url, { attribution: this.attribution }).addTo(map);
+            this._tripLeafletMap = map;
+            const points = this.trip.points.map((point) =>
+                L.latLng(point.lat, point.lng)
+            );
+            this._tripRoutingControl = L.Routing.control({
+                waypoints: points,
+                language: appLocaleToRoutingLanguage[this.$i18n.locale] || 'es'
+            });
+            this._tripRoutingControl.addTo(map);
+            map.invalidateSize();
         },
 
         restoreData(trip) {
@@ -847,6 +877,7 @@ export default {
     },
 
     beforeUnmount() {
+        this.destroyTripRouteMap();
         bus.off('back-click', this.onBackClick);
         bus.off('calculate-height', this.calculateHeight);
     },
@@ -971,8 +1002,6 @@ export default {
 
     components: {
         svgItem,
-        LMap,
-        LTileLayer,
         modal,
         TripLocation,
         TripDriver,
@@ -999,6 +1028,10 @@ export default {
     min-height: 418px;
     /* overflow: hidden; */
     top: 0;
+}
+.trip-route-map :deep(.leaflet-container) {
+    height: 100%;
+    width: 100%;
 }
 .trip-detail-component .driver-container {
     margin-top: 0;

--- a/src/main.js
+++ b/src/main.js
@@ -42,8 +42,6 @@ import { StatusBar, Style } from '@capacitor/status-bar';
 import { SplashScreen } from '@capacitor/splash-screen';
 import { App as CapacitorApp } from '@capacitor/app';
 
-import Vue2Leaflet from 'vue2-leaflet';
-
 // Re-export locale maps so existing imports from '../../main' still work
 export { appLocaleToBCP47, appLocaleToRoutingLanguage };
 


### PR DESCRIPTION
Imperative Leaflet map; drop @vue-leaflet (incompatible with @vue/compat)

Replace vue-leaflet LMap with L.map on a div: Vite still resolved vue-leaflet against @vue/compat, breaking LMap render and hiding the route map.

- Trip.vue: syncTripRouteMap/destroyTripRouteMap, tile layer + routing machine
- Remove @vue-leaflet/vue-leaflet dependency
- main.js: remove unused vue2-leaflet import (already gone)
- Ignore .cursor/debug-*.log

Closes #329