### PR TITLE
Remove unused vue-analytics (Google Analytics)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "pinia": "^2.3.1",
         "qrcode": "^1.5.3",
         "vue": "^3.2",
-        "vue-analytics": "^3.2.0",
         "vue-chartjs": "^4.1.2",
         "vue-eslint-parser": "^1.0.0",
         "vue-i18n": "^9",
@@ -15334,12 +15333,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/load-script": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-      "integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==",
-      "license": "MIT"
-    },
     "node_modules/loader-utils": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
@@ -22967,16 +22960,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vue-analytics": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/vue-analytics/-/vue-analytics-3.2.1.tgz",
-      "integrity": "sha512-TRR8KsgIZPK+4OzcnykggP3hG+Np4B/lJmvU+8W/GytRKCecDwxQvzETAesSN8nrv468NMFk54rK2u6rBEWkjg==",
-      "deprecated": "Sorry but vue-analytics is no longer maintained. I would suggest you switch to vue-gtag, with love, the guy who made the package.",
-      "license": "ISC",
-      "dependencies": {
-        "load-script": "^1.0.0"
       }
     },
     "node_modules/vue-chartjs": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "pinia": "^2.3.1",
     "qrcode": "^1.5.3",
     "vue": "^3.2",
-    "vue-analytics": "^3.2.0",
     "vue-chartjs": "^4.1.2",
     "vue-eslint-parser": "^1.0.0",
     "vue-i18n": "^9",

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,6 @@ import 'core-js/stable';
 import Vue, { createApp } from 'vue';
 import App from './App';
 
-import VueAnalytics from 'vue-analytics';
 import dayjs from './dayjs';
 
 import router from './router';


### PR DESCRIPTION
The plugin was only imported in main.js and never registered with Vue.use/app.use, so no tracking ran. Drop the dependency per #332.

Closes #332 