### PR TITLE
Migrate custom components to modelValue v-model contract

### DIFF
--- a/src/components/Autocomplete.vue
+++ b/src/components/Autocomplete.vue
@@ -46,7 +46,7 @@ import { useAuthStore } from '../stores/auth';
 export default {
     name: 'autocomplete',
     watch: {
-        value(n, o) {
+        modelValue(n) {
             if (!n) {
                 this.input = '';
             } else {
@@ -67,8 +67,7 @@ export default {
         };
     },
     mounted() {
-        console.log('mounted', this.value);
-        this.input = this.value ? this.value : '';
+        this.input = this.modelValue ? this.modelValue : '';
     },
     computed: {
         ...mapState(useAuthStore, {
@@ -218,7 +217,7 @@ export default {
         vJumpDisabled: {
             required: false
         },
-        value: {
+        modelValue: {
             required: false
         },
         classes: {

--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -91,7 +91,7 @@ export default {
         };
     },
     mounted() {
-        this.syncFromValue(this.value);
+        this.syncFromValue(this.modelValue);
     },
     methods: {
         dayjs,
@@ -154,13 +154,15 @@ export default {
                     : '';
             bus.emit('date-change', str);
             this.$emit('date_changed', str);
+            this.$emit('update:modelValue', str);
         },
         dateMobile(value) {
             const str = value && value !== '' ? value : '';
             bus.emit('date-change', str);
             this.$emit('date_changed', str);
+            this.$emit('update:modelValue', str);
         },
-        value(val) {
+        modelValue(val) {
             this.syncFromValue(val);
         }
     },
@@ -170,7 +172,7 @@ export default {
             required: false,
             default: 'DD/MM/YYYY'
         },
-        value: {
+        modelValue: {
             type: String,
             required: false
         },

--- a/src/components/Dropdown.vue
+++ b/src/components/Dropdown.vue
@@ -40,20 +40,20 @@ export default {
         size: { type: String, default: null },
         text: { type: String, default: null },
         type: { type: String, default: 'default' },
-        value: { type: Boolean, default: false }
+        modelValue: { type: Boolean, default: false }
     },
 
     data() {
         return {
-            show: this.value
+            show: this.modelValue
         };
     },
 
     watch: {
         show(val) {
-            this.$emit('input', val);
+            this.$emit('update:modelValue', val);
         },
-        value(val) {
+        modelValue(val) {
             this.show = val;
         }
     },

--- a/src/components/OsmAutocomplete.vue
+++ b/src/components/OsmAutocomplete.vue
@@ -55,7 +55,7 @@ let osmApi = new OsmApi();
 export default {
     name: 'osmautocomplete',
     watch: {
-        value(n, o) {
+        modelValue(n) {
             if (!n) {
                 this.input = '';
             } else {
@@ -76,7 +76,7 @@ export default {
         };
     },
     mounted() {
-        this.input = this.value ? this.value : '';
+        this.input = this.modelValue ? this.modelValue : '';
     },
     computed: {
         ...mapState(useAuthStore, {
@@ -584,7 +584,7 @@ export default {
         vJumpDisabled: {
             required: false
         },
-        value: {
+        modelValue: {
             required: false
         },
         classes: {

--- a/src/components/sections/AdminSearchTrips.vue
+++ b/src/components/sections/AdminSearchTrips.vue
@@ -79,7 +79,7 @@
                     :placeholder="$t('origen')"
                     name="from_town"
                     ref="from_town"
-                    :value="from_town.name"
+                    :model-value="from_town.name"
                     v-on:place_changed="(data) => getPlace(0, data)"
                     :classes="'form-control form-control-with-icon form-control-map-autocomplete'"
                     :country="allowForeignPoints ? null : 'AR'"
@@ -112,7 +112,7 @@
                     :placeholder="$t('destino')"
                     name="to_town"
                     ref="to_town"
-                    :value="to_town.name"
+                    :model-value="to_town.name"
                     v-on:place_changed="(data) => getPlace(1, data)"
                     :classes="'form-control form-control-with-icon form-control-map-autocomplete'"
                     :country="allowForeignPoints ? null : 'AR'"
@@ -130,7 +130,7 @@
             <div class="col-xs-24 col-md-4 no-padding">
                 <DatePicker
                     ref="datepicker"
-                    :value="from_date"
+                    :model-value="from_date"
                     :class="{ 'has-error': dateError.state }"
                     v-on:date_changed="(date) => (this.from_date = date)"
                 ></DatePicker>
@@ -139,7 +139,7 @@
             <div class="col-xs-24 col-md-4 no-padding">
                 <DatePicker
                     ref="datepicker"
-                    :value="to_date"
+                    :model-value="to_date"
                     :class="{ 'has-error': dateError.state }"
                     v-on:date_changed="(date) => (this.to_date = date)"
                 ></DatePicker>

--- a/src/components/sections/SearchTrip.vue
+++ b/src/components/sections/SearchTrip.vue
@@ -77,7 +77,7 @@
                     :placeholder="$t('origen')"
                     name="from_town"
                     ref="from_town"
-                    :value="from_town.name"
+                    :model-value="from_town.name"
                     v-on:place_changed="(data) => getPlace(0, data)"
                     :classes="'form-control form-control-with-icon form-control-map-autocomplete'"
                     :country="allowForeignPoints ? null : 'AR'"
@@ -110,7 +110,7 @@
                     :placeholder="$t('destino')"
                     name="to_town"
                     ref="to_town"
-                    :value="to_town.name"
+                    :model-value="to_town.name"
                     v-on:place_changed="(data) => getPlace(1, data)"
                     :classes="'form-control form-control-with-icon form-control-map-autocomplete'"
                     :country="allowForeignPoints ? null : 'AR'"
@@ -127,7 +127,7 @@
             <div class="col-xs-24 col-md-4 no-padding">
                 <DatePicker
                     ref="datepicker"
-                    :value="date"
+                    :model-value="date"
                     :minDate="minDate"
                     :class="{ 'has-error': dateError.state }"
                 ></DatePicker>

--- a/src/components/sections/UpdateProfile.vue
+++ b/src/components/sections/UpdateProfile.vue
@@ -113,7 +113,7 @@
                     </div>
                     <!--<div class="form-group">
                     <label for="">Fecha de nacimiento <span class="required-field-flag" title="Campo requerido">(*)</span></label>
-                    <DatePicker :value="dayjs(birthday).format('YYYY-MM-DD') " ref="ipt_calendar" name="ipt_calendar" :maxDate="maxDate" :minDate="minDate" :class="{'has-error': birthdayError.state}" ></DatePicker>
+                    <DatePicker :model-value="dayjs(birthday).format('YYYY-MM-DD') " ref="ipt_calendar" name="ipt_calendar" :maxDate="maxDate" :minDate="minDate" :class="{'has-error': birthdayError.state}" ></DatePicker>
                     <span class="error" v-if="birthdayError.state"> {{birthdayError.message}} </span>
                 </div>-->
                     <div class="form-group">

--- a/src/components/views/AdminPage.vue
+++ b/src/components/views/AdminPage.vue
@@ -10,7 +10,7 @@
                         <div class="col-md-9 col-md-offset-1">
                             <datePicker
                                 class="picker"
-                                :value="dateLimits.start"
+                                :model-value="dateLimits.start"
                                 :class="{
                                     'has-error': dateLimits.dateError.state
                                 }"
@@ -25,7 +25,7 @@
                         <div class="col-md-9 col-md-offset-4">
                             <datePicker
                                 class="picker"
-                                :value="dateLimits.end"
+                                :model-value="dateLimits.end"
                                 :class="{
                                     'has-error': dateLimits.dateError.state
                                 }"

--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -135,7 +135,7 @@
                                 :placeholder="getPlaceholder(index)"
                                 name="'input-' + index"
                                 ref="'input-' + index"
-                                :value="m.name"
+                                :model-value="m.name"
                                 v-on:place_changed="
                                     (data) => getPlace(index, data)
                                 "
@@ -245,7 +245,7 @@
                                         :placeholder="getPlaceholder(index)"
                                         name="'input-' + index"
                                         ref="'input-' + index"
-                                        :value="m.name"
+                                        :model-value="m.name"
                                         v-on:place_changed="
                                             (data) => getPlace(index, data)
                                         "
@@ -344,7 +344,7 @@
                                         $t('dia')
                                     }}</label>
                                     <DatePicker
-                                        :value="date"
+                                        :model-value="date"
                                         :minDate="minDate"
                                         :class="{
                                             'has-error': dateError.state
@@ -932,7 +932,7 @@
                                 :placeholder="getPlaceholder(index)"
                                 name="'input-return-trip' + index"
                                 ref="'input-return-trip' + index"
-                                :value="m.name"
+                                :model-value="m.name"
                                 v-on:place_changed="
                                     (data) =>
                                         getPlace(
@@ -988,7 +988,7 @@
                                         :placeholder="getPlaceholder(index)"
                                         name="'input-return-trip' + index"
                                         ref="'input-return-trip' + index"
-                                        :value="m.name"
+                                        :model-value="m.name"
                                         v-on:place_changed="
                                             (data) =>
                                                 getPlace(
@@ -1101,7 +1101,7 @@
                                         $t('dia')
                                     }}</label>
                                     <DatePicker
-                                        :value="otherTrip.date"
+                                        :model-value="otherTrip.date"
                                         :minDate="otherTrip.minDate"
                                         :class="{
                                             'has-error':

--- a/src/components/views/Register.vue
+++ b/src/components/views/Register.vue
@@ -153,7 +153,7 @@
                 </span>
 
                 <!--<label for="">Fecha de nacimiento <span aria-label="Campo obligatorio" class="campo-obligatorio">*</span></label>
-        <DatePicker :value="birthday" ref="ipt_calendar" name="ipt_calendar" :maxDate="maxDate" :minDate="minDate" :class="{'has-error': birthdayError.state}" ></DatePicker>-->
+        <DatePicker :model-value="birthday" ref="ipt_calendar" name="ipt_calendar" :maxDate="maxDate" :minDate="minDate" :class="{'has-error': birthdayError.state}" ></DatePicker>-->
                 <span class="error" v-if="birthdayError.state">
                     {{ birthdayError.message }}
                 </span>


### PR DESCRIPTION
Rename value prop to modelValue on Autocomplete, OsmAutocomplete, DatePicker, and Dropdown. Emit update:modelValue from Dropdown and DatePicker (alongside existing date_changed and date-change bus).

Update parent templates to use :model-value instead of :value.

Closes #333 