### PR TITLE
Fix frontend tests

### DIFF
--- a/e2e-frontend/click-outside.spec.js
+++ b/e2e-frontend/click-outside.spec.js
@@ -1,4 +1,9 @@
 const { test, expect } = require('@playwright/test');
+const {
+  setupCatchAllMock,
+  setupCommonMocks,
+  waitForPageReady,
+} = require('./shared/mocks');
 
 /**
  * Test to reproduce the clickOutside directive error in Vue 3 compat mode.
@@ -12,40 +17,8 @@ const { test, expect } = require('@playwright/test');
  */
 test.describe('clickOutside directive', () => {
   test.beforeEach(async ({ page }) => {
-    // Mock the API calls so we don't need a backend
-    await page.route('**/api/app/config', route =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          module_trip_creation_payment_enabled: false,
-          onboarding: [],
-        }),
-      })
-    );
-
-    await page.route('**/api/trips/search*', route =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          data: [],
-          total: 0,
-          per_page: 20,
-          current_page: 1,
-          last_page: 1,
-        }),
-      })
-    );
-
-    // Catch-all for other API calls
-    await page.route('**/api/**', route =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({}),
-      })
-    );
+    await setupCatchAllMock(page);
+    await setupCommonMocks(page);
   });
 
   test('clicking outside autocomplete should not throw TypeError', async ({ page }) => {
@@ -56,7 +29,7 @@ test.describe('clickOutside directive', () => {
 
     // Go to trips page which has the search Autocomplete component
     await page.goto('/trips');
-    await page.waitForLoadState('networkidle');
+    await waitForPageReady(page);
 
     // Remove webpack dev server overlay that intercepts pointer events
     await page.evaluate(() => {

--- a/e2e-frontend/register.spec.js
+++ b/e2e-frontend/register.spec.js
@@ -7,6 +7,10 @@ const {
 
 test.describe('Register', () => {
   test.beforeEach(async ({ page }) => {
+    // Keep init-script mock: Register.vue injects Google's script which would replace it.
+    await page.route('https://www.google.com/recaptcha/**', route => route.abort());
+    await page.route('https://www.gstatic.com/recaptcha/**', route => route.abort());
+
     await setupCatchAllMock(page);
     await setupCommonMocks(page);
 

--- a/src/components/views/Register.vue
+++ b/src/components/views/Register.vue
@@ -407,7 +407,6 @@ class Error {
         this.message = '';
     }
 }
-console.log('RECAPTCHA_SECRET_KEY', process.env.RECAPTCHA_SITE_KEY);
 export default {
     name: 'register',
     data() {
@@ -429,7 +428,7 @@ export default {
                 'img/' +
                 process.env.TARGET_APP +
                 '_logo.png',
-            RECAPTCHA_SITE_KEY: process.env.RECAPTCHA_SITE_KEY,
+            RECAPTCHA_SITE_KEY: import.meta.env.VITE_RECAPTCHA_SITE_KEY || '',
             progress: false,
             success: false,
             emailError: new Error(),
@@ -644,9 +643,10 @@ export default {
         },
         register(event) {
             const that = this;
+            const siteKey = that.RECAPTCHA_SITE_KEY;
             grecaptcha.ready(function () {
                 grecaptcha
-                    .execute(process.env.RECAPTCHA_SITE_KEY, {
+                    .execute(siteKey, {
                         action: 'submit'
                     })
                     .then(function (token) {
@@ -759,6 +759,13 @@ export default {
                                 }
                                 that.progress = false;
                             });
+                    })
+                    .catch(function () {
+                        that.progress = false;
+                        dialogs.message(that.$t('errorRegistro'), {
+                            duration: 10,
+                            estado: 'error'
+                        });
                     });
             });
         },
@@ -778,12 +785,15 @@ export default {
             this.accountTypes = data.cc;
         });
 
-        let recaptchaScript = document.createElement('script');
-        recaptchaScript.setAttribute(
-            'src',
-            `https://www.google.com/recaptcha/api.js?render=${process.env.RECAPTCHA_SITE_KEY}`
-        );
-        document.head.appendChild(recaptchaScript);
+        const siteKey = import.meta.env.VITE_RECAPTCHA_SITE_KEY;
+        if (siteKey) {
+            const recaptchaScript = document.createElement('script');
+            recaptchaScript.setAttribute(
+                'src',
+                `https://www.google.com/recaptcha/api.js?render=${siteKey}`
+            );
+            document.head.appendChild(recaptchaScript);
+        }
     },
 
     beforeUnmount() {


### PR DESCRIPTION
- click-outside: use shared API mocks and waitForPageReady so /trips search UI is ready before interacting.
- register: abort Google reCAPTCHA scripts so the init-script mock is not replaced during tests.
- Register.vue: read VITE_RECAPTCHA_SITE_KEY via import.meta.env, load api.js only when a key is set, and handle execute() failures.