### PR TITLE
Add module_conversation_average_delay 

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -20,6 +20,7 @@
     "disable_user_hints": false,
     "login_custom_header": false,
     "module_trip_seats_payment": false,
+    "module_conversation_average_delay": false,
     "module_validated_drivers": false,
     "trip_stars": false,
     "api_price": false,


### PR DESCRIPTION
Aligns with backend MODULE_CONVERSATION_AVERAGE_DELAY; TripDriver reads appConfig after merge.