### PR TITLE
Fix buttons

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -2113,7 +2113,12 @@
       height: 56px;
       margin-top: 1em;
       padding: 1em;
+      width: fit-content;
+      max-width: 100%;
+  }
+  .user-form .btn-primary.btn-facebook {
       width: 100%;
+      max-width: 100%;
   }
   .user-form a {
       color: #ddd;
@@ -2606,6 +2611,7 @@
           color: #333;
       }
       .user-form .btn-primary {
+          width: fit-content;
           max-width: 100%;
           padding: 1em 2em;
       }

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -2606,7 +2606,7 @@
           color: #333;
       }
       .user-form .btn-primary {
-          max-width: 130px;
+          max-width: 100%;
           padding: 1em 2em;
       }
       .user-form a {

--- a/src/styles/main.apalancar.css
+++ b/src/styles/main.apalancar.css
@@ -1082,6 +1082,7 @@ textarea.has-error {
         display: none;
     }
     .reset-password .user-form .btn-primary {
+        width: fit-content;
         max-width: 100%;
     }
     .header .header_panel-right {

--- a/src/styles/main.apalancar.css
+++ b/src/styles/main.apalancar.css
@@ -1082,7 +1082,7 @@ textarea.has-error {
         display: none;
     }
     .reset-password .user-form .btn-primary {
-        max-width: 300px;
+        max-width: 100%;
     }
     .header .header_panel-right {
         height: 86px;

--- a/src/styles/main.carpoolear.css
+++ b/src/styles/main.carpoolear.css
@@ -2083,6 +2083,7 @@ textarea {
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#019be1', endColorstr='#016587', GradientType=1);
 }
 .app-container.blue.reset-password .user-form .btn-primary {
+    width: fit-content;
     max-width: 100%;
 }
 @media (max-width: 768px) {
@@ -2213,7 +2214,13 @@ textarea.has-error {
     height: 56px;
     margin-top: 1em;
     padding: 1em;
+    width: fit-content;
+    max-width: 100%;
+}
+
+.user-form .btn-primary.btn-facebook {
     width: 100%;
+    max-width: 100%;
 }
 
 .user-form a {
@@ -2773,6 +2780,7 @@ ul {
     }
 
     .user-form .btn-primary {
+        width: fit-content;
         max-width: 100%;
         padding: 1em 2em;
     }

--- a/src/styles/main.carpoolear.css
+++ b/src/styles/main.carpoolear.css
@@ -2773,7 +2773,7 @@ ul {
     }
 
     .user-form .btn-primary {
-        max-width: 130px;
+        max-width: 100%;
         padding: 1em 2em;
     }
 

--- a/src/styles/main.example.css
+++ b/src/styles/main.example.css
@@ -1868,7 +1868,12 @@ textarea.has-error {
     height: 56px;
     margin-top: 1em;
     padding: 1em;
+    width: fit-content;
+    max-width: 100%;
+}
+.user-form .btn-primary.btn-facebook {
     width: 100%;
+    max-width: 100%;
 }
 .user-form a {
     color: #ddd;
@@ -2321,6 +2326,7 @@ ul {
         color: #333;
     }
     .user-form .btn-primary {
+        width: fit-content;
         max-width: 100%;
         padding: 1em 2em;
     }

--- a/src/styles/main.example.css
+++ b/src/styles/main.example.css
@@ -2321,7 +2321,7 @@ ul {
         color: #333;
     }
     .user-form .btn-primary {
-        max-width: 130px;
+        max-width: 100%;
         padding: 1em 2em;
     }
     .user-form a {


### PR DESCRIPTION
Replace max-width caps (130px on small screens, 300px for apalancar reset-password) so labels like password recovery are not clipped.