### PR TITLE
App fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@
 
 # API
 VITE_API_URL="http://carpoolear_backend.test"
+# Optional: when building iOS/Android with Capacitor server.hostname matching VITE_API_URL, set a
+# different API origin (e.g. www vs apex) so requests are not intercepted by the local bridge.
+# VITE_API_URL_NATIVE="https://www.example.com"
 VITE_WEB_URL="https://carpoolear.com.ar/app"
 
 # App

--- a/.env.production
+++ b/.env.production
@@ -1,7 +1,10 @@
 # Production env vars
 
-# API
+# API (browser + default)
 VITE_API_URL="https://carpoolear.com.ar"
+# Capacitor WebView uses hostname carpoolear.com.ar (password managers); same-host API calls would
+# load index.html from the bridge. Native builds use this host for axios instead:
+VITE_API_URL_NATIVE="https://www.carpoolear.com.ar"
 VITE_WEB_URL="https://carpoolear.com.ar/app"
 
 # App

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.sts.carpoolear"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 301080
-        versionName "3.1.8"
+        versionCode 3010100
+        versionName "3.1.10"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -357,7 +357,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 310;
-				DEVELOPMENT_TEAM = L3E36EM8LM;
+				DEVELOPMENT_TEAM = UMLY3ZBABJ;
 				INFOPLIST_FILE = App/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Carpoolear;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.travel";
@@ -365,7 +365,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 3.1.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
-				PRODUCT_BUNDLE_IDENTIFIER = com.sts.carpoolear;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.sts.carpoolear-test";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;

--- a/ios/App/App/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/App/App/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,92 +1,107 @@
 {
-	"images": [
-		{
-			"idiom": "ipad",
-			"size": "20x20",
-			"scale": "1x",
-			"filename": "Icon-20x20@1x.png"
-		},
-		{
-			"idiom": "iphone",
-			"size": "20x20",
-			"scale": "2x",
-			"filename": "Icon-20x20@2x.png"
-		},
-		{
-			"idiom": "iphone",
-			"size": "20x20",
-			"scale": "3x",
-			"filename": "Icon-20x20@3x.png"
-		},
-		{
-			"idiom": "iphone",
-			"size": "29x29",
-			"scale": "1x",
-			"filename": "Icon-29x29@1x.png"
-		},
-		{
-			"idiom": "iphone",
-			"size": "29x29",
-			"scale": "2x",
-			"filename": "Icon-29x29@2x.png"
-		},
-		{
-			"idiom": "iphone",
-			"size": "29x29",
-			"scale": "3x",
-			"filename": "Icon-29x29@3x.png"
-		},
-		{
-			"idiom": "iphone",
-			"size": "40x40",
-			"scale": "2x",
-			"filename": "Icon-40x40@2x.png"
-		},
-		{
-			"idiom": "iphone",
-			"size": "40x40",
-			"scale": "3x",
-			"filename": "Icon-40x40@3x.png"
-		},
-		{
-			"idiom": "iphone",
-			"size": "60x60",
-			"scale": "2x",
-			"filename": "Icon-60x60@2x.png"
-		},
-		{
-			"idiom": "iphone",
-			"size": "60x60",
-			"scale": "3x",
-			"filename": "Icon-60x60@3x.png"
-		},
-		{
-			"idiom": "ipad",
-			"size": "76x76",
-			"scale": "1x",
-			"filename": "Icon-76x76@1x.png"
-		},
-		{
-			"idiom": "ipad",
-			"size": "76x76",
-			"scale": "2x",
-			"filename": "Icon-76x76@2x.png"
-		},
-		{
-			"idiom": "ipad",
-			"size": "83.5x83.5",
-			"scale": "2x",
-			"filename": "Icon-83.5@2x.png"
-		},
-		{
-			"idiom": "ios-marketing",
-			"size": "1024x1024",
-			"scale": "1x",
-			"filename": "Icon-marketing-1024x1024.png"
-		}
-	],
-	"info": {
-		"version": 1,
-		"author": "apetools.webprofusion.com"
-	}
+  "images" : [
+    {
+      "filename" : "Icon-20x20@2x.png",
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "filename" : "Icon-20x20@3x.png",
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "filename" : "Icon-29x29@1x.png",
+      "idiom" : "iphone",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "filename" : "Icon-29x29@2x.png",
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "filename" : "Icon-29x29@3x.png",
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "filename" : "Icon-40x40@2x.png",
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "filename" : "Icon-40x40@3x.png",
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "filename" : "Icon-60x60@2x.png",
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "filename" : "Icon-60x60@3x.png",
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "filename" : "Icon-20x20@1x.png",
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "filename" : "Icon-76x76@1x.png",
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "filename" : "Icon-76x76@2x.png",
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "filename" : "Icon-83.5@2x.png",
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "filename" : "Icon-marketing-1024x1024.png",
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -146,7 +146,7 @@ export default {
             const appVersionInfo = useRootStore().appVersionInfo;
             const version = (appVersionInfo && appVersionInfo.version) || (typeof window !== 'undefined' && window.appVersion) || '0';
             const base = 'Version ' + version;
-            return Capacitor.isNativePlatform() ? base : base + ' - build 104';
+            return Capacitor.isNativePlatform() ? base : base + ' - build 106';
         },
         ...mapState(useCordovaStore, {
             deviceReady: 'deviceReady'

--- a/src/components/views/Login.vue
+++ b/src/components/views/Login.vue
@@ -483,7 +483,8 @@ export default {
             }
         },
         onClearClick() {
-            router.back();
+            // After failed retoken, login can be the first route — history.back() does nothing.
+            router.replace({ name: 'trips' });
         }
     },
 

--- a/src/cordova/index.js
+++ b/src/cordova/index.js
@@ -11,7 +11,7 @@ import { useCordovaStore } from '../stores/cordova';
 import { useRootStore } from '../stores/root';
 
 window.facebook = facebook;
-window.appVersion = '3.1.8';
+window.appVersion = '3.1.10';
 
 function getCordovaStore () {
     return useCordovaStore();

--- a/src/services/cache/NativeStorage.js
+++ b/src/services/cache/NativeStorage.js
@@ -18,7 +18,7 @@ class NativeStorage {
         return (async () => {
             const result = await Preferences.get({ key });
             if (result.value === null) {
-                throw new Error('Item not found');
+                return null;
             }
 
             try {

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -182,9 +182,12 @@ export const useAuthStore = defineStore('auth', {
                         resolve();
                     })
                     .catch(async () => {
+                        // Stale or invalid token: clear session and open the app as a guest (same as logout).
+                        // Do not send to login — /trips and other routes work without auth; pushing login traps
+                        // users when history is empty (clear / back does nothing).
                         this.doLogout();
                         const router = await getLazyRouter();
-                        router.push({ name: 'login' });
+                        router.replace({ name: 'trips' });
                         resolve();
                     });
             });
@@ -282,6 +285,16 @@ export const useAuthStore = defineStore('auth', {
             localConfig.__isLocal = true;
             this.setAppConfig(localConfig);
             return authApi.config().then((response) => {
+                const isConfigObject =
+                    response &&
+                    typeof response === 'object' &&
+                    !Array.isArray(response);
+                if (!isConfigObject) {
+                    console.error(
+                        'getConfig: expected JSON object from /api/config; keeping local config only.'
+                    );
+                    return localConfig;
+                }
                 response.__isLocal = false;
                 console.log('Loading config from server: ', response);
                 const config = { ...localConfig, ...response };

--- a/src/stores/device.js
+++ b/src/stores/device.js
@@ -55,6 +55,10 @@ export const useDeviceStore = defineStore('device', {
             return deviceApi
                 .create(data)
                 .then((response) => {
+                    if (!response || !response.data) {
+                        console.warn('Device register: missing response data');
+                        return;
+                    }
                     response.data.notifications = true;
                     this.setCurrentDevice(response.data);
                 })

--- a/vite.config.js
+++ b/vite.config.js
@@ -66,10 +66,23 @@ export default defineConfig(({ mode }) => {
         ? (env.VITE_HISTORY_MODE || env.HISTORY_MODE || 'history')
         : (env.VITE_MOBILE_HISTORY_MODE || 'hash');
     // Must read VITE_API_URL — .env files use that name; env.API_URL was always undefined.
-    const apiUrl =
+    let apiUrl =
         env.VITE_API_URL !== undefined && env.VITE_API_URL !== null
             ? String(env.VITE_API_URL)
             : env.API_URL || 'http://carpoolear_backend.test';
+
+    // Capacitor + server.hostname: the WebView is served as https://<hostname>. Requests to the
+    // same host hit the local asset server (HTML for unknown paths). Use VITE_API_URL_NATIVE for
+    // iOS/Android so axios targets a different host (e.g. www) while LastPass still matches apex.
+    if (!isWebBuild) {
+        const nativeApi =
+            env.VITE_API_URL_NATIVE !== undefined && env.VITE_API_URL_NATIVE !== null
+                ? String(env.VITE_API_URL_NATIVE).trim()
+                : '';
+        if (nativeApi !== '') {
+            apiUrl = nativeApi;
+        }
+    }
 
     return {
         base: routeBase === '/' ? '/' : routeBase,


### PR DESCRIPTION
fix(mobile): native API host, guest flow after auth errors, storage guards

Use VITE_API_URL_NATIVE for Capacitor builds so axios hits the real backend while server.hostname stays carpoolear.com.ar for password manager autofill.

On retoken failure, clear the session and replace the route with trips instead of pushing login, which left users stuck when history had no back target. Login header close now uses the same trips destination.

NativeStorage returns null for missing keys. Harden getConfig and device registration when API payloads are not objects.

Bump native app metadata to 3.1.10 (Android Gradle, Cordova window.appVersion, web splash build label, iOS project and app icon set).