### PR TITLE
Seat price tweaks

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -146,7 +146,7 @@ export default {
             const appVersionInfo = useRootStore().appVersionInfo;
             const version = (appVersionInfo && appVersionInfo.version) || (typeof window !== 'undefined' && window.appVersion) || '0';
             const base = 'Version ' + version;
-            return Capacitor.isNativePlatform() ? base : base + ' - build 107';
+            return Capacitor.isNativePlatform() ? base : base + ' - build 108';
         },
         ...mapState(useCordovaStore, {
             deviceReady: 'deviceReady'

--- a/src/components/elements/CoordinateTrip.vue
+++ b/src/components/elements/CoordinateTrip.vue
@@ -76,7 +76,14 @@
                 <span v-else-if="expiredTrip">{{ $t('viajeCarpooleado') }}</span>
                 <span v-else>
                     <template v-if="config && config.module_trip_seats_payment">
-                        {{ $t('reservar') }} {{ $n(conversation.trip.seat_price_cents / 100, 'currency') }}
+                        {{ $t('reservar') }}
+                        <template
+                            v-if="isVoluntaryContributionSeatPrice(conversation.trip.seat_price_cents)"
+                            >{{ $t('loQueSePuedaAportar') }}</template
+                        >
+                        <template v-else>{{
+                            $n(conversation.trip.seat_price_cents / 100, 'currency')
+                        }}</template>
                         <template v-if="conversation.return_trip"
                             >{{ $t('deIda') }}</template
                         >
@@ -126,7 +133,15 @@
                 <span v-else-if="expiredReturnTrip">{{ $t('viajeCarpooleado') }}</span>
                 <span v-else>
                     <template v-if="config && config.module_trip_seats_payment">
-                        {{ $t('reservar') }} {{ $n(conversation.return_trip.seat_price_cents / 100, 'currency') }} {{ $t('deVuelta') }}
+                        {{ $t('reservar') }}
+                        <template
+                            v-if="isVoluntaryContributionSeatPrice(conversation.return_trip.seat_price_cents)"
+                            >{{ $t('loQueSePuedaAportar') }}</template
+                        >
+                        <template v-else>{{
+                            $n(conversation.return_trip.seat_price_cents / 100, 'currency')
+                        }}</template>
+                        {{ $t('deVuelta') }}
                     </template>
                     <template v-else>{{ $t('solicitarAsientoDeVuelta') }}</template>
                 </span>
@@ -157,6 +172,7 @@ import dialogs from '../../services/dialogs.js';
 import spinner from '../Spinner.vue';
 import dayjs from '../../dayjs';
 import { getConversationContributionWarningData } from '../../utils/conversationContributionWarning.js';
+import { isVoluntaryContributionSeatPrice } from '../../utils/tripSeatPrice.js';
 
 export default {
     name: 'conversation-chat',
@@ -223,6 +239,7 @@ export default {
         }
     },
     methods: {
+        isVoluntaryContributionSeatPrice,
         dayjs,
         ...mapActions(usePassengerStore, {
             make: 'makeRequest',

--- a/src/components/elements/TripButtons.vue
+++ b/src/components/elements/TripButtons.vue
@@ -64,7 +64,14 @@
                                         config.module_trip_seats_payment
                                     "
                                 >
-                                    {{ $t('reservar') }} {{ $n(trip.seat_price_cents / 100, 'currency') }}
+                                    {{ $t('reservar') }}
+                                    <template
+                                        v-if="isVoluntaryContributionSeatPrice(trip.seat_price_cents)"
+                                        >{{ $t('loQueSePuedaAportar') }}</template
+                                    >
+                                    <template v-else>{{
+                                        $n(trip.seat_price_cents / 100, 'currency')
+                                    }}</template>
                                 </template>
                                 <template v-else>{{ $t('reservar') }}</template>
                             </template>
@@ -150,6 +157,7 @@ import { useDeviceStore } from '../../stores/device';
 import dayjs from '../../dayjs';
 import spinner from '../Spinner.vue';
 import Transactions from '../views/transactions.vue';
+import { isVoluntaryContributionSeatPrice } from '../../utils/tripSeatPrice.js';
 
 export default {
     name: 'TripButtons',
@@ -199,6 +207,7 @@ export default {
         Transactions
     },
     methods: {
+        isVoluntaryContributionSeatPrice,
         onShareLinkClick(event) {
             if (
                 window.device &&

--- a/src/components/elements/TripPrice.view.test.js
+++ b/src/components/elements/TripPrice.view.test.js
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const viewPath = path.resolve(__dirname, 'TripPrice.vue');
+const viewSource = fs.readFileSync(viewPath, 'utf8');
+
+describe('TripPrice.vue voluntary contribution display', () => {
+    it('uses seat price helpers so unset prices hide the block and -1 shows i18n phrase', () => {
+        expect(viewSource).toContain('shouldShowTripSeatPriceSection');
+        expect(viewSource).toContain('isVoluntaryContributionSeatPrice');
+        expect(viewSource).toMatch(/tripSeatPrice\.js/);
+    });
+});

--- a/src/components/elements/TripPrice.vue
+++ b/src/components/elements/TripPrice.vue
@@ -2,12 +2,16 @@
     
     <div
         class="trip-seats"
-        v-if="this.config.module_seat_price_enabled && (tripCardTheme === 'light' || !trip.is_passenger)"
+        v-if="
+            this.config.module_seat_price_enabled &&
+            (tripCardTheme === 'light' || !trip.is_passenger) &&
+            showSeatPriceSection
+        "
     >
         <div v-if="tripCardTheme !== 'light'" class="price-container">
             <div class="price-item">
                 <span class="trip_seat-price_value trip_seat-price_value-main">
-                    <template v-if="isZeroTripContribution">{{
+                    <template v-if="isVoluntaryContribution">{{
                         $t('loQueSePuedaAportar')
                     }}</template>
                     <template v-else>{{
@@ -54,7 +58,7 @@
             <div class="trip_seats-available" v-if="!trip.is_passenger">
                 <template v-for="n in trip.total_seats">
                     {{ $t('contribucionPorPersona') }}:
-                    <span v-if="isZeroTripContribution">{{
+                    <span v-if="isVoluntaryContribution">{{
                         $t('loQueSePuedaAportar')
                     }}</span>
                     <span v-else>{{
@@ -69,6 +73,10 @@
 import { mapState } from 'pinia';
 import { useTripsStore } from '../../stores/trips';
 import { useAuthStore } from '../../stores/auth';
+import {
+    isVoluntaryContributionSeatPrice,
+    shouldShowTripSeatPriceSection
+} from '../../utils/tripSeatPrice.js';
 import SvgItem from '../SvgItem';
 export default {
     name: 'TripSeats',
@@ -87,14 +95,19 @@ export default {
             config: 'appConfig'
         }),
         owner() {
-            console.log('this.trip', this.trip);
-            console.log('this.user', this.user);
-            console.log('this.trip.user.id', this.trip.user.id);
-            console.log('this.user.id', this.user.id);
             return this.trip && this.user && this.user.id === this.trip.user.id;
         },
-        isZeroTripContribution() {
-            return this.trip && this.trip.seat_price_cents === 0;
+        showSeatPriceSection() {
+            return (
+                this.trip &&
+                shouldShowTripSeatPriceSection(this.trip.seat_price_cents)
+            );
+        },
+        isVoluntaryContribution() {
+            return (
+                this.trip &&
+                isVoluntaryContributionSeatPrice(this.trip.seat_price_cents)
+            );
         },
         calculadoEnBaseNaftaDescription() {
             const base = this.$t('calculadoEnBaseNaftaBase');

--- a/src/components/views/NewTrip.view.test.js
+++ b/src/components/views/NewTrip.view.test.js
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const viewPath = path.resolve(__dirname, 'NewTrip.vue');
+const viewSource = fs.readFileSync(viewPath, 'utf8');
+
+describe('NewTrip.vue seat price API mapping', () => {
+    it('imports seat price helpers for voluntary -1 sentinel', () => {
+        expect(viewSource).toMatch(/from '\.\.\/\.\.\/utils\/tripSeatPrice\.js'/);
+        expect(viewSource).toContain('seatPriceCentsForApi');
+        expect(viewSource).toContain('priceInputNumberFromStoredSeatPriceCents');
+    });
+});

--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -1820,6 +1820,11 @@ import WeeklySchedule from '../elements/WeeklySchedule';
 import bus from '../../services/bus-event.js';
 import { getMaxContributionExceededMessage } from '../../utils/maxContributionExceededMessage.js';
 import { rememberMaxContributionWarning } from '../../utils/maxContributionWarningState.js';
+import {
+    parseSeatPriceInput,
+    priceInputNumberFromStoredSeatPriceCents,
+    seatPriceCentsForApi
+} from '../../utils/tripSeatPrice.js';
 
 let tripApi = new TripApi();
 let userApi = new UserApi();
@@ -1913,6 +1918,7 @@ export default {
                 allow_animals: false,
                 car_id: null,
                 enc_path: '123',
+                seat_price_cents: null,
                 points: [] /* address json_address lat lng */
             },
             updatingTrip: null,
@@ -1967,7 +1973,7 @@ export default {
                     allow_kids: false,
                     allow_smoking: false,
                     allow_animals: false,
-                    seat_price_cents: 0,
+                    seat_price_cents: null,
                     points: [] /* address json_address lat lng */
                 }
             },
@@ -2276,9 +2282,11 @@ export default {
         this.trip.allow_animals = Number(trip.allow_animals) > 0;
         this.trip.allow_smoking = Number(trip.allow_smoking) > 0;
         
-        if (trip.seat_price_cents != null) {
-            this.price = trip.seat_price_cents / 100;
-            this.trip.seat_price_cents = trip.seat_price_cents;
+        this.trip.seat_price_cents = trip.seat_price_cents;
+        const restoredPrice =
+            priceInputNumberFromStoredSeatPriceCents(trip.seat_price_cents);
+        if (restoredPrice !== null) {
+            this.price = restoredPrice;
         }
         
         this.calcRoute();
@@ -2306,28 +2314,9 @@ export default {
                 });
         },
 
-        parseSeatPriceInput(value) {
-            if (value === '' || value === null || value === undefined) {
-                return null;
-            }
-            if (typeof value === 'string' && value.trim() === '') {
-                return null;
-            }
-            const n = Number(value);
-            return Number.isFinite(n) ? n : null;
-        },
-
-        seatPriceCentsForApi(raw) {
-            const p = this.parseSeatPriceInput(raw);
-            if (p === null) {
-                return 0;
-            }
-            return Math.round(p * 100);
-        },
-
         onOutboundPriceFieldInput() {
             this.validatePrice();
-            const p = this.parseSeatPriceInput(this.price);
+            const p = parseSeatPriceInput(this.price);
             if (
                 p !== null &&
                 this.priceError.message ===
@@ -2339,7 +2328,7 @@ export default {
 
         onReturnPriceFieldInput() {
             this.validateReturnPrice();
-            const p = this.parseSeatPriceInput(this.returnPrice);
+            const p = parseSeatPriceInput(this.returnPrice);
             if (
                 p !== null &&
                 this.returnPriceError.message ===
@@ -2509,7 +2498,7 @@ export default {
             }
 
             if (this.trip.is_passenger == 0 && this.config.module_seat_price_enabled) {
-                const seatP = this.parseSeatPriceInput(this.price);
+                const seatP = parseSeatPriceInput(this.price);
                 if (seatP === null) {
                     globalError = true;
                     this.priceError.state = true;
@@ -2654,7 +2643,7 @@ export default {
                     (!this.config.module_max_price_enabled ||
                         this.config.module_trip_creation_payment_enabled)
                 ) {
-                    const returnSeatP = this.parseSeatPriceInput(
+                    const returnSeatP = parseSeatPriceInput(
                         this.returnPrice
                     );
                     if (returnSeatP === null) {
@@ -2743,7 +2732,7 @@ export default {
                 trip.is_passenger = trip.is_passenger ? 1 : 0;
                 this.normalizeAllowFlagsForApi(trip);
 
-                trip.seat_price_cents = this.seatPriceCentsForApi(this.price);
+                trip.seat_price_cents = seatPriceCentsForApi(this.price);
                 
                 if (trip.is_passenger === 1) {
                     trip.no_lucrar = 1;
@@ -2766,7 +2755,7 @@ export default {
                                 );
                                 this.normalizeAllowFlagsForApi(otherTrip);
                                 otherTrip.seat_price_cents =
-                                    this.seatPriceCentsForApi(this.returnPrice);
+                                    seatPriceCentsForApi(this.returnPrice);
                                 this.createTrip(otherTrip).then((ot) => {
                                     return resolve(ot);
                                 });
@@ -2816,7 +2805,7 @@ export default {
                 this.trip.id = this.updatingTrip.id;
                 let trip = JSON.parse(JSON.stringify(this.trip));
                 this.normalizeAllowFlagsForApi(trip);
-                trip.seat_price_cents = this.seatPriceCentsForApi(this.price);
+                trip.seat_price_cents = seatPriceCentsForApi(this.price);
                 this.updateTrip(trip)
                     .then(() => {
                         this.saving = false;
@@ -3023,7 +3012,7 @@ export default {
             }
         },
         validatePrice() {
-            const p = this.parseSeatPriceInput(this.price);
+            const p = parseSeatPriceInput(this.price);
             if (
                 p !== null &&
                 this.config.module_max_price_enabled &&
@@ -3062,7 +3051,7 @@ export default {
             this.validateReturnPrice();
         },
         validateReturnPrice() {
-            const p = this.parseSeatPriceInput(this.returnPrice);
+            const p = parseSeatPriceInput(this.returnPrice);
             if (
                 p !== null &&
                 p > this.maximum_return_seat_price_cents / 100

--- a/src/utils/conversationContributionWarning.js
+++ b/src/utils/conversationContributionWarning.js
@@ -5,7 +5,9 @@ export function getConversationContributionWarningData({ conversation, user }) {
     }
 
     const isDriver = user.id === trip.user.id;
-    const maxContributionCents = trip.seat_price_cents || 0;
+    const cents = trip.seat_price_cents;
+    const maxContributionCents =
+        typeof cents === 'number' && cents > 0 ? cents : 0;
 
     return {
         role: isDriver ? 'driver' : 'passenger',

--- a/src/utils/conversationContributionWarning.js
+++ b/src/utils/conversationContributionWarning.js
@@ -1,3 +1,5 @@
+import { maxContributionCapFromSeatPriceCents } from './tripSeatPrice.js';
+
 export function getConversationContributionWarningData({ conversation, user }) {
     const trip = conversation && conversation.trip;
     if (!trip || !trip.user || !user) {
@@ -5,9 +7,9 @@ export function getConversationContributionWarningData({ conversation, user }) {
     }
 
     const isDriver = user.id === trip.user.id;
-    const cents = trip.seat_price_cents;
-    const maxContributionCents =
-        typeof cents === 'number' && cents > 0 ? cents : 0;
+    const maxContributionCents = maxContributionCapFromSeatPriceCents(
+        trip.seat_price_cents
+    );
 
     return {
         role: isDriver ? 'driver' : 'passenger',

--- a/src/utils/conversationContributionWarning.test.js
+++ b/src/utils/conversationContributionWarning.test.js
@@ -37,4 +37,22 @@ describe('getConversationContributionWarningData', () => {
             maxContributionCents: 5000
         });
     });
+
+    it('treats voluntary contribution sentinel (-1 cents) as zero max amount', () => {
+        const data = getConversationContributionWarningData({
+            conversation: {
+                trip: {
+                    id: 7,
+                    seat_price_cents: -1,
+                    user: { id: 2 }
+                }
+            },
+            user: { id: 2 }
+        });
+
+        expect(data).toEqual({
+            role: 'driver',
+            maxContributionCents: 0
+        });
+    });
 });

--- a/src/utils/tripSeatPrice.js
+++ b/src/utils/tripSeatPrice.js
@@ -37,6 +37,13 @@ export function isVoluntaryContributionSeatPrice(seatPriceCents) {
     return seatPriceCents === VOLUNTARY_CONTRIBUTION_SEAT_PRICE_CENTS;
 }
 
+/** Caps used in warnings; voluntary (-1) and unset/non-positive amounts yield 0. */
+export function maxContributionCapFromSeatPriceCents(seatPriceCents) {
+    return typeof seatPriceCents === 'number' && seatPriceCents > 0
+        ? seatPriceCents
+        : 0;
+}
+
 export function shouldShowTripSeatPriceSection(seatPriceCents) {
     return (
         isVoluntaryContributionSeatPrice(seatPriceCents) ||

--- a/src/utils/tripSeatPrice.js
+++ b/src/utils/tripSeatPrice.js
@@ -33,13 +33,13 @@ export function priceInputNumberFromStoredSeatPriceCents(seatPriceCents) {
     return seatPriceCents / 100;
 }
 
-export function shouldShowTripSeatPriceSection(seatPriceCents) {
-    return (
-        seatPriceCents === VOLUNTARY_CONTRIBUTION_SEAT_PRICE_CENTS ||
-        (typeof seatPriceCents === 'number' && seatPriceCents > 0)
-    );
-}
-
 export function isVoluntaryContributionSeatPrice(seatPriceCents) {
     return seatPriceCents === VOLUNTARY_CONTRIBUTION_SEAT_PRICE_CENTS;
+}
+
+export function shouldShowTripSeatPriceSection(seatPriceCents) {
+    return (
+        isVoluntaryContributionSeatPrice(seatPriceCents) ||
+        (typeof seatPriceCents === 'number' && seatPriceCents > 0)
+    );
 }

--- a/src/utils/tripSeatPrice.js
+++ b/src/utils/tripSeatPrice.js
@@ -1,0 +1,45 @@
+/** Sentinel stored in seat_price_cents when the driver chose “lo que se pueda aportar” (explicit zero in the form). */
+export const VOLUNTARY_CONTRIBUTION_SEAT_PRICE_CENTS = -1;
+
+export function parseSeatPriceInput(value) {
+    if (value === '' || value === null || value === undefined) {
+        return null;
+    }
+    if (typeof value === 'string' && value.trim() === '') {
+        return null;
+    }
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+}
+
+export function seatPriceCentsForApi(raw) {
+    const p = parseSeatPriceInput(raw);
+    if (p === null) {
+        return null;
+    }
+    if (p === 0) {
+        return VOLUNTARY_CONTRIBUTION_SEAT_PRICE_CENTS;
+    }
+    return Math.round(p * 100);
+}
+
+export function priceInputNumberFromStoredSeatPriceCents(seatPriceCents) {
+    if (seatPriceCents == null) {
+        return null;
+    }
+    if (seatPriceCents === VOLUNTARY_CONTRIBUTION_SEAT_PRICE_CENTS) {
+        return 0;
+    }
+    return seatPriceCents / 100;
+}
+
+export function shouldShowTripSeatPriceSection(seatPriceCents) {
+    return (
+        seatPriceCents === VOLUNTARY_CONTRIBUTION_SEAT_PRICE_CENTS ||
+        (typeof seatPriceCents === 'number' && seatPriceCents > 0)
+    );
+}
+
+export function isVoluntaryContributionSeatPrice(seatPriceCents) {
+    return seatPriceCents === VOLUNTARY_CONTRIBUTION_SEAT_PRICE_CENTS;
+}

--- a/src/utils/tripSeatPrice.test.js
+++ b/src/utils/tripSeatPrice.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
     VOLUNTARY_CONTRIBUTION_SEAT_PRICE_CENTS,
     isVoluntaryContributionSeatPrice,
+    maxContributionCapFromSeatPriceCents,
     parseSeatPriceInput,
     priceInputNumberFromStoredSeatPriceCents,
     seatPriceCentsForApi,
@@ -81,6 +82,15 @@ describe('tripSeatPrice', () => {
             expect(isVoluntaryContributionSeatPrice(0)).toBe(false);
             expect(isVoluntaryContributionSeatPrice(null)).toBe(false);
             expect(isVoluntaryContributionSeatPrice(100)).toBe(false);
+        });
+    });
+
+    describe('maxContributionCapFromSeatPriceCents', () => {
+        it('returns positive cents only', () => {
+            expect(maxContributionCapFromSeatPriceCents(500)).toBe(500);
+            expect(maxContributionCapFromSeatPriceCents(-1)).toBe(0);
+            expect(maxContributionCapFromSeatPriceCents(0)).toBe(0);
+            expect(maxContributionCapFromSeatPriceCents(null)).toBe(0);
         });
     });
 });

--- a/src/utils/tripSeatPrice.test.js
+++ b/src/utils/tripSeatPrice.test.js
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+    VOLUNTARY_CONTRIBUTION_SEAT_PRICE_CENTS,
+    isVoluntaryContributionSeatPrice,
+    parseSeatPriceInput,
+    priceInputNumberFromStoredSeatPriceCents,
+    seatPriceCentsForApi,
+    shouldShowTripSeatPriceSection
+} from './tripSeatPrice.js';
+
+describe('tripSeatPrice', () => {
+    describe('VOLUNTARY_CONTRIBUTION_SEAT_PRICE_CENTS', () => {
+        it('is -1 cents sentinel for “lo que se pueda aportar”', () => {
+            expect(VOLUNTARY_CONTRIBUTION_SEAT_PRICE_CENTS).toBe(-1);
+        });
+    });
+
+    describe('parseSeatPriceInput', () => {
+        it('returns null for empty / unset', () => {
+            expect(parseSeatPriceInput('')).toBeNull();
+            expect(parseSeatPriceInput('   ')).toBeNull();
+            expect(parseSeatPriceInput(null)).toBeNull();
+            expect(parseSeatPriceInput(undefined)).toBeNull();
+        });
+
+        it('parses finite numbers including zero', () => {
+            expect(parseSeatPriceInput(0)).toBe(0);
+            expect(parseSeatPriceInput('0')).toBe(0);
+            expect(parseSeatPriceInput('12.5')).toBe(12.5);
+        });
+    });
+
+    describe('seatPriceCentsForApi', () => {
+        it('maps explicit zero to voluntary sentinel -1', () => {
+            expect(seatPriceCentsForApi(0)).toBe(-1);
+            expect(seatPriceCentsForApi('0')).toBe(-1);
+        });
+
+        it('maps positive amounts to cents', () => {
+            expect(seatPriceCentsForApi(10)).toBe(1000);
+            expect(seatPriceCentsForApi(12.345)).toBe(1235);
+        });
+
+        it('returns null when unset (empty input)', () => {
+            expect(seatPriceCentsForApi('')).toBeNull();
+            expect(seatPriceCentsForApi(null)).toBeNull();
+        });
+    });
+
+    describe('priceInputNumberFromStoredSeatPriceCents', () => {
+        it('maps voluntary sentinel to 0 for the form field', () => {
+            expect(priceInputNumberFromStoredSeatPriceCents(-1)).toBe(0);
+        });
+
+        it('maps stored cents to currency units for the form field', () => {
+            expect(priceInputNumberFromStoredSeatPriceCents(1500)).toBe(15);
+        });
+
+        it('returns null when no stored price', () => {
+            expect(priceInputNumberFromStoredSeatPriceCents(null)).toBeNull();
+            expect(priceInputNumberFromStoredSeatPriceCents(undefined)).toBeNull();
+        });
+    });
+
+    describe('shouldShowTripSeatPriceSection', () => {
+        it('is false when price is unset or legacy default zero', () => {
+            expect(shouldShowTripSeatPriceSection(null)).toBe(false);
+            expect(shouldShowTripSeatPriceSection(undefined)).toBe(false);
+            expect(shouldShowTripSeatPriceSection(0)).toBe(false);
+        });
+
+        it('is true for voluntary sentinel -1 or positive cents', () => {
+            expect(shouldShowTripSeatPriceSection(-1)).toBe(true);
+            expect(shouldShowTripSeatPriceSection(500)).toBe(true);
+        });
+    });
+
+    describe('isVoluntaryContributionSeatPrice', () => {
+        it('is true only for voluntary sentinel', () => {
+            expect(isVoluntaryContributionSeatPrice(-1)).toBe(true);
+            expect(isVoluntaryContributionSeatPrice(0)).toBe(false);
+            expect(isVoluntaryContributionSeatPrice(null)).toBe(false);
+            expect(isVoluntaryContributionSeatPrice(100)).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
Voluntary contribution: When the driver sets contribution to 0 on create/edit, the client sends seat_price_cents: -1. The UI shows “Lo que se pueda aportar” for that value.
No fixed price: seat_price_cents null/undefined or legacy 0 is treated as “not set”; the trip detail price block is hidden (no misleading zero or phrase).
Shared logic: New helpers in tripSeatPrice.js (parse, API cents, restore form value, visibility, voluntary check); NewTrip uses them; conversation contribution caps use positive cents only (so -1 does not become a negative cap).
Booking buttons: CoordinateTrip and TripButtons show the same phrase for -1 instead of formatting cents as currency.
Tests: Vitest for helpers, conversation warning, and light source checks on TripPrice/NewTrip; lint + unit tests green.