### PR TITLE
Persist trip search

### DIFF
--- a/src/components/views/Trips.view.test.js
+++ b/src/components/views/Trips.view.test.js
@@ -28,7 +28,7 @@ describe('Trips.vue persisted search state', () => {
     it('restores scroll from query only after trips have loaded', () => {
         expect(viewSource).toContain('pendingScrollRestore: null');
         expect(viewSource).toContain('maybeRestoreScroll()');
-        expect(viewSource).toContain('this.pendingScrollRestore = Number.parseInt(this.$route.query.scroll, 10);');
+        expect(viewSource).toContain('this.pendingScrollRestore = Number.parseInt(this.getRouteQuery().scroll, 10);');
         expect(viewSource).toContain('window.scrollTo(0, this.pendingScrollRestore);');
         expect(viewSource).toContain('this.pendingScrollRestore = null;');
     });

--- a/src/components/views/Trips.view.test.js
+++ b/src/components/views/Trips.view.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const viewPath = path.resolve(__dirname, 'Trips.vue');
+const viewSource = fs.readFileSync(viewPath, 'utf8');
+
+describe('Trips.vue persisted search state', () => {
+    it('stores search filters in the route query when searching', () => {
+        expect(viewSource).toContain('updateTripsQuery(params = {}, scroll)');
+        expect(viewSource).toContain('this.$router.replace({');
+        expect(viewSource).toContain('name: \'trips\'');
+        expect(viewSource).toContain('query: nextQuery');
+    });
+
+    it('hydrates search params from the route query on mount', () => {
+        expect(viewSource).toContain('getSearchParamsFromQuery()');
+        expect(viewSource).toContain('const queryParams = this.getSearchParamsFromQuery();');
+        expect(viewSource).toContain('this.$refs.searchBox.loadParams(queryParams);');
+        expect(viewSource).toContain('this.search(queryParams);');
+    });
+
+    it('restores scroll from query only after trips have loaded', () => {
+        expect(viewSource).toContain('pendingScrollRestore: null');
+        expect(viewSource).toContain('maybeRestoreScroll()');
+        expect(viewSource).toContain('this.pendingScrollRestore = Number.parseInt(this.$route.query.scroll, 10);');
+        expect(viewSource).toContain('window.scrollTo(0, this.pendingScrollRestore);');
+        expect(viewSource).toContain('this.pendingScrollRestore = null;');
+    });
+});

--- a/src/components/views/Trips.view.test.js
+++ b/src/components/views/Trips.view.test.js
@@ -6,6 +6,11 @@ const viewPath = path.resolve(__dirname, 'Trips.vue');
 const viewSource = fs.readFileSync(viewPath, 'utf8');
 
 describe('Trips.vue persisted search state', () => {
+    it('does not run default search when URL already has search params', () => {
+        expect(viewSource).toContain('hasRouteSearchParams()');
+        expect(viewSource).toContain('if (!this.clearSearch && !this.keepSearch && !this.hasRouteSearchParams()) {');
+    });
+
     it('stores search filters in the route query when searching', () => {
         expect(viewSource).toContain('updateTripsQuery(params = {}, scroll)');
         expect(viewSource).toContain('this.$router.replace({');

--- a/src/components/views/Trips.vue
+++ b/src/components/views/Trips.vue
@@ -324,7 +324,7 @@ export default {
         // SearchTrip mounts after this hook and runs loadParams(searchParams). If the store still
         // holds a previous narrow search, trips_auto_search watchers emit() and overwrite the
         // default trip list with a 0-result search. Reset the store before the child reads it.
-        if (!this.clearSearch && !this.keepSearch) {
+        if (!this.clearSearch && !this.keepSearch && !this.hasRouteSearchParams()) {
             this.search({ is_passenger: false });
         }
     },
@@ -448,6 +448,10 @@ export default {
             let scrolloffset = window.scrollY;
             this.setScrollOffset(scrolloffset);
             this.updateTripsQuery(this.searchParams.data, scrolloffset);
+        },
+        hasRouteSearchParams() {
+            const query = this.$route && this.$route.query ? this.$route.query : {};
+            return Object.keys(query).some((key) => key !== 'scroll' && key !== 'clearSearch' && key !== 'keepSearch');
         },
         getSearchParamsFromQuery() {
             const query = this.$route && this.$route.query ? this.$route.query : {};

--- a/src/components/views/Trips.vue
+++ b/src/components/views/Trips.vue
@@ -450,11 +450,14 @@ export default {
             this.updateTripsQuery(this.searchParams.data, scrolloffset);
         },
         hasRouteSearchParams() {
-            const query = this.$route && this.$route.query ? this.$route.query : {};
+            const query = this.getRouteQuery();
             return Object.keys(query).some((key) => key !== 'scroll' && key !== 'clearSearch' && key !== 'keepSearch');
         },
+        getRouteQuery() {
+            return this.$route && this.$route.query ? this.$route.query : {};
+        },
         getSearchParamsFromQuery() {
-            const query = this.$route && this.$route.query ? this.$route.query : {};
+            const query = this.getRouteQuery();
             const params = {};
             const textFields = ['origin_name', 'destination_name', 'date'];
             textFields.forEach((field) => {
@@ -772,7 +775,7 @@ export default {
             }
             this.search(queryParams);
         }
-        this.pendingScrollRestore = Number.parseInt(this.$route.query.scroll, 10);
+        this.pendingScrollRestore = Number.parseInt(this.getRouteQuery().scroll, 10);
         if (Number.isNaN(this.pendingScrollRestore)) {
             this.pendingScrollRestore = null;
         }

--- a/src/components/views/Trips.vue
+++ b/src/components/views/Trips.vue
@@ -469,18 +469,25 @@ export default {
                 'destination_id'
             ];
             numericFields.forEach((field) => {
-                if (query[field] === undefined || query[field] === null || query[field] === '') {
-                    return;
-                }
-                const parsed = Number.parseFloat(query[field]);
-                if (!Number.isNaN(parsed)) {
+                const parsed = this.parseNumericQueryValue(query[field]);
+                if (parsed !== null) {
                     params[field] = parsed;
                 }
             });
-            if (query.is_passenger === 'true' || query.is_passenger === '1' || query.is_passenger === true) {
+            if (this.parseBooleanQueryValue(query.is_passenger)) {
                 params.is_passenger = true;
             }
             return params;
+        },
+        parseNumericQueryValue(value) {
+            if (value === undefined || value === null || value === '') {
+                return null;
+            }
+            const parsed = Number.parseFloat(value);
+            return Number.isNaN(parsed) ? null : parsed;
+        },
+        parseBooleanQueryValue(value) {
+            return value === 'true' || value === '1' || value === true;
         },
         updateTripsQuery(params = {}, scroll) {
             const nextQuery = {};

--- a/src/components/views/Trips.vue
+++ b/src/components/views/Trips.vue
@@ -310,6 +310,7 @@ export default {
             runningSearch: false,
             alreadySubscribe: false,
             resultaOfSearch: false,
+            pendingScrollRestore: null,
             showModal: false,
             showModalInstallApp: false,
             installAppEvent: null,
@@ -437,6 +438,7 @@ export default {
             this.alreadySubscribe = false;
             this.search(params);
             this.findSubscriptions();
+            this.updateTripsQuery(params);
             // this.setActionButton(['clear']);
         },
         nextPage() {
@@ -445,6 +447,67 @@ export default {
         onTripClick() {
             let scrolloffset = window.scrollY;
             this.setScrollOffset(scrolloffset);
+            this.updateTripsQuery(this.searchParams.data, scrolloffset);
+        },
+        getSearchParamsFromQuery() {
+            const query = this.$route && this.$route.query ? this.$route.query : {};
+            const params = {};
+            const textFields = ['origin_name', 'destination_name', 'date'];
+            textFields.forEach((field) => {
+                if (typeof query[field] === 'string' && query[field].trim()) {
+                    params[field] = query[field];
+                }
+            });
+            const numericFields = [
+                'origin_lat',
+                'origin_lng',
+                'origin_radio',
+                'origin_id',
+                'destination_lat',
+                'destination_lng',
+                'destination_radio',
+                'destination_id'
+            ];
+            numericFields.forEach((field) => {
+                if (query[field] === undefined || query[field] === null || query[field] === '') {
+                    return;
+                }
+                const parsed = Number.parseFloat(query[field]);
+                if (!Number.isNaN(parsed)) {
+                    params[field] = parsed;
+                }
+            });
+            if (query.is_passenger === 'true' || query.is_passenger === '1' || query.is_passenger === true) {
+                params.is_passenger = true;
+            }
+            return params;
+        },
+        updateTripsQuery(params = {}, scroll) {
+            const nextQuery = {};
+            const source = params || {};
+            Object.keys(source).forEach((key) => {
+                if (source[key] !== undefined && source[key] !== null && source[key] !== '') {
+                    nextQuery[key] = source[key];
+                }
+            });
+            if (scroll !== undefined && scroll !== null) {
+                nextQuery.scroll = Math.max(0, Math.floor(scroll));
+            }
+            this.$router.replace({
+                name: 'trips',
+                query: nextQuery
+            });
+        },
+        maybeRestoreScroll() {
+            if (this.pendingScrollRestore === null || this.pendingScrollRestore === undefined) {
+                return;
+            }
+            this.$nextTick(() => {
+                this.$nextTick(() => {
+                    window.scrollTo(0, this.pendingScrollRestore);
+                    this.pendingScrollRestore = null;
+                });
+            });
         },
         isComplementary(trip, searchParams, index) {
             let isComplementary = false;
@@ -689,12 +752,18 @@ export default {
             }
         }
 
-        if (this.scrollPosition) {
-            this.$nextTick(() => {
-                setTimeout(() => {
-                    window.scrollTo(0, this.scrollPosition);
-                }, 2);
-            });
+        const queryParams = this.getSearchParamsFromQuery();
+        if (Object.keys(queryParams).length) {
+            this.resultaOfSearch = true;
+            this.filtered = true;
+            if (this.$refs.searchBox) {
+                this.$refs.searchBox.loadParams(queryParams);
+            }
+            this.search(queryParams);
+        }
+        this.pendingScrollRestore = Number.parseInt(this.$route.query.scroll, 10);
+        if (Number.isNaN(this.pendingScrollRestore)) {
+            this.pendingScrollRestore = null;
         }
 
         window.addEventListener('beforeinstallprompt', (e) => {
@@ -750,6 +819,7 @@ export default {
         trips: {
             deep: true,
             handler() {
+                this.maybeRestoreScroll();
                 if (this.refreshList) {
                     this.refreshTrips(false);
                     this.lookSearch = false;


### PR DESCRIPTION
## Summary

- Persisted `/trips` search filters (`origin`, `destination`, `date`, related query params) in the URL so returning from trip detail keeps the same search context.
- Added URL-based scroll restoration on `/trips`, applied after list data is loaded.
- Fixed duplicate initial fetch on back navigation by skipping the default search when URL already contains search params (prevents filtered + unfiltered race condition).
- Added/updated unit coverage in `Trips.view.test.js` for URL persistence, scroll restore timing, and default-search suppression with query params.