### PR TITLE
Admin: create support ticket from user detail

### DIFF
--- a/src/components/views/AdminUserDetail.view.test.js
+++ b/src/components/views/AdminUserDetail.view.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const viewPath = path.resolve(__dirname, 'AdminUserDetail.vue');
+const source = fs.readFileSync(viewPath, 'utf8');
+
+describe('AdminUserDetail view', () => {
+    it('includes a support ticket button prefilled with user detail context', () => {
+        expect(source).toContain("name: 'admin-support-ticket-new'");
+        expect(source).toContain('query: {');
+        expect(source).toContain('userId: user.id');
+        expect(source).toContain('userName: user.name');
+        expect(source).toContain("type: 'account_verification'");
+        expect(source).toContain("subject: $t('ticketTypeAccountVerification')");
+        expect(source).toContain("$t('crearTicketSoporte')");
+    });
+});

--- a/src/components/views/AdminUserDetail.view.test.js
+++ b/src/components/views/AdminUserDetail.view.test.js
@@ -8,11 +8,13 @@ const source = fs.readFileSync(viewPath, 'utf8');
 describe('AdminUserDetail view', () => {
     it('includes a support ticket button prefilled with user detail context', () => {
         expect(source).toContain("name: 'admin-support-ticket-new'");
+        expect(source).toContain(':to="supportTicketRoute(user)"');
+        expect(source).toContain('supportTicketRoute(user)');
         expect(source).toContain('query: {');
         expect(source).toContain('userId: user.id');
         expect(source).toContain('userName: user.name');
         expect(source).toContain("type: 'account_verification'");
-        expect(source).toContain("subject: $t('ticketTypeAccountVerification')");
+        expect(source).toContain("subject: this.$t('ticketTypeAccountVerification')");
         expect(source).toContain("$t('crearTicketSoporte')");
     });
 });

--- a/src/components/views/AdminUserDetail.vue
+++ b/src/components/views/AdminUserDetail.vue
@@ -53,6 +53,20 @@
                             >
                                 {{ $t('adminUsuariosEditar') }}
                             </router-link>
+                            <router-link
+                                :to="{
+                                    name: 'admin-support-ticket-new',
+                                    query: {
+                                        userId: user.id,
+                                        userName: user.name,
+                                        type: 'account_verification',
+                                        subject: $t('ticketTypeAccountVerification')
+                                    }
+                                }"
+                                class="btn btn-default"
+                            >
+                                {{ $t('crearTicketSoporte') }}
+                            </router-link>
                             <button
                                 type="button"
                                 class="btn btn-success btn-circle"

--- a/src/components/views/AdminUserDetail.vue
+++ b/src/components/views/AdminUserDetail.vue
@@ -54,15 +54,7 @@
                                 {{ $t('adminUsuariosEditar') }}
                             </router-link>
                             <router-link
-                                :to="{
-                                    name: 'admin-support-ticket-new',
-                                    query: {
-                                        userId: user.id,
-                                        userName: user.name,
-                                        type: 'account_verification',
-                                        subject: $t('ticketTypeAccountVerification')
-                                    }
-                                }"
+                                :to="supportTicketRoute(user)"
                                 class="btn btn-default"
                             >
                                 {{ $t('crearTicketSoporte') }}
@@ -144,6 +136,17 @@ export default {
                     });
                 }
             );
+        },
+        supportTicketRoute(user) {
+            return {
+                name: 'admin-support-ticket-new',
+                query: {
+                    userId: user.id,
+                    userName: user.name,
+                    type: 'account_verification',
+                    subject: this.$t('ticketTypeAccountVerification')
+                }
+            };
         }
     },
     watch: {


### PR DESCRIPTION
- Added a **“Crear ticket de soporte”** button in the admin user detail view (`AdminUserDetail.vue`), aligned with the existing admin flows (e.g. Mercado Pago rejection detail).
- The button routes to `admin-support-ticket-new` with prefilled context (`userId`, `userName`, `type: account_verification`, and account verification subject).
- Added/updated view tests to cover the new CTA and prefill wiring.