### PR TITLE
User migration: delete or anonymize

### DIFF
--- a/src/components/views/AdminUserMigrationNew.view.test.js
+++ b/src/components/views/AdminUserMigrationNew.view.test.js
@@ -43,4 +43,14 @@ describe('AdminUserMigrationNew view', () => {
         expect(source).toContain('query.removeUserId');
         expect(source).toContain('query.keepUserId');
     });
+
+    it('renders the irreversible-delete warning above the Migrar button', () => {
+        expect(source).toContain("$t('advertenciaMigracionUsuarios')");
+        expect(source).toContain('admin-user-migration-new__warning');
+        const warningIndex = source.indexOf("$t('advertenciaMigracionUsuarios')");
+        const submitButtonIndex = source.indexOf('admin-user-migration-new__submit');
+        expect(warningIndex).toBeGreaterThan(-1);
+        expect(submitButtonIndex).toBeGreaterThan(-1);
+        expect(warningIndex).toBeLessThan(submitButtonIndex);
+    });
 });

--- a/src/components/views/AdminUserMigrationNew.vue
+++ b/src/components/views/AdminUserMigrationNew.vue
@@ -70,6 +70,12 @@
                                     </div>
                                 </div>
                             </template>
+                            <p
+                                class="alert alert-warning admin-user-migration-new__warning"
+                                role="alert"
+                            >
+                                {{ $t('advertenciaMigracionUsuarios') }}
+                            </p>
                             <button
                                 type="button"
                                 class="btn btn-primary admin-user-migration-new__submit"

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -1093,6 +1093,8 @@ const messages = {
         migrar: 'Migrar',
         confirmacionMigracionUsuarios:
             'Esta acción NO se puede deshacer, ¿revisaste que los usuarios estén en el orden correcto?',
+        advertenciaMigracionUsuarios:
+            'Advertencia: el usuario a borrar será eliminado (o anonimizado en caso de no ser posible), revise bien qué usuario eligió a mantener ya que no será reversible.',
         usuariosMigrados: 'Usuarios migrados',
         migracionId: 'ID migración',
         usuarioMantenido: 'Usuario mantenido',
@@ -2146,6 +2148,8 @@ const messages = {
         migrar: 'Migrar',
         confirmacionMigracionUsuarios:
             'Esta acción NO se puede deshacer, ¿revisaste que los usuarios estén en el orden correcto?',
+        advertenciaMigracionUsuarios:
+            'Advertencia: el usuario a borrar será eliminado (o anonimizado en caso de no ser posible), revise bien qué usuario eligió a mantener ya que no será reversible.',
         usuariosMigrados: 'Usuarios migrados',
         migracionId: 'ID migración',
         usuarioMantenido: 'Usuario mantenido',
@@ -3328,6 +3332,8 @@ const messages = {
         migrar: 'Migrate',
         confirmacionMigracionUsuarios:
             'This action CANNOT be undone. Did you verify the users are in the correct order?',
+        advertenciaMigracionUsuarios:
+            'Warning: the user to remove will be deleted (or anonymized if deletion fails); double-check the user you chose to keep — this is not reversible.',
         usuariosMigrados: 'Users migrated',
         migracionId: 'Migration ID',
         usuarioMantenido: 'Kept user',


### PR DESCRIPTION
## Summary

Adds an **i18n warning** on the user migration screen before **Migrar**, stating that the user to remove will be **deleted or anonymized** if deletion fails, and that the choice of user to **keep** is **not reversible**.

## Changes

- **`AdminUserMigrationNew.vue`** — `alert-warning` block (`admin-user-migration-new__warning`) **above** the migrate button, using `$t('advertenciaMigracionUsuarios')`
- **`i18n`** — new key `advertenciaMigracionUsuarios` in **arg / chl / en**
- **Tests** — view test asserts the warning key, CSS hook, and that it appears **before** the submit button

## Notes

- Backend now returns `removal_action` on migration success; this PR does not require UI changes for it unless you want different toasts per outcome.
- Depends on backend PR that implements delete → anonymize fallback after migration.