### PR TITLE
Admin ticket: add sender

### DIFF
--- a/src/components/views/AdminSupportTickets.view.test.js
+++ b/src/components/views/AdminSupportTickets.view.test.js
@@ -38,6 +38,11 @@ describe('AdminSupportTickets view', () => {
         expect(priCell).toBeLessThan(catCell);
     });
 
+    it('shows ticket owner display name next to the subject for admin context', () => {
+        expect(viewSource).toContain('ticketOwnerDisplayName(ticket)');
+        expect(viewSource).toContain('support-tickets-table__owner');
+    });
+
     it('uses compact narrow columns and a wide subject column class', () => {
         expect(viewSource).toContain('support-tickets-table--compact');
         expect(viewSource).toContain('support-tickets-table__subject');

--- a/src/components/views/AdminSupportTickets.view.test.js
+++ b/src/components/views/AdminSupportTickets.view.test.js
@@ -43,6 +43,12 @@ describe('AdminSupportTickets view', () => {
         expect(viewSource).toContain('support-tickets-table__owner');
     });
 
+    it('links ticket owner display name to the public profile route when linkable', () => {
+        expect(viewSource).toContain('canLinkTicketOwnerProfile(ticket)');
+        expect(viewSource).toContain('ticketOwnerAppProfileRoute(ticket)');
+        expect(viewSource).toContain("name: 'profile'");
+    });
+
     it('uses compact narrow columns and a wide subject column class', () => {
         expect(viewSource).toContain('support-tickets-table--compact');
         expect(viewSource).toContain('support-tickets-table__subject');

--- a/src/components/views/AdminSupportTickets.vue
+++ b/src/components/views/AdminSupportTickets.vue
@@ -33,7 +33,10 @@
                             <span
                                 v-if="ticketOwnerDisplayName(ticket)"
                                 class="support-tickets-table__owner text-muted"
-                            ><span class="support-tickets-table__owner-sep" aria-hidden="true"> · </span>{{ ticketOwnerDisplayName(ticket) }}</span>
+                            ><span class="support-tickets-table__owner-sep" aria-hidden="true"> · </span><router-link
+                                v-if="canLinkTicketOwnerProfile(ticket)"
+                                :to="ticketOwnerAppProfileRoute(ticket)"
+                            >{{ ticketOwnerDisplayName(ticket) }}</router-link><span v-else>{{ ticketOwnerDisplayName(ticket) }}</span></span>
                             <span
                                 v-if="hasUserLastReply(ticket)"
                                 class="last-reply-icon text-warning"
@@ -133,6 +136,12 @@ export default {
         },
         hasUserLastReply(ticket) {
             return Number(ticket && ticket.unread_for_admin) > 0;
+        },
+        canLinkTicketOwnerProfile(ticket) {
+            return Boolean(ticket && ticket.user && ticket.user.id);
+        },
+        ticketOwnerAppProfileRoute(ticket) {
+            return { name: 'profile', params: { id: ticket.user.id } };
         },
         ticketOwnerDisplayName(ticket) {
             const u = ticket && ticket.user;

--- a/src/components/views/AdminSupportTickets.vue
+++ b/src/components/views/AdminSupportTickets.vue
@@ -31,6 +31,10 @@
                                 #{{ ticket.id }} - {{ ticket.subject }}
                             </router-link>
                             <span
+                                v-if="ticketOwnerDisplayName(ticket)"
+                                class="support-tickets-table__owner text-muted"
+                            >{{ ticketOwnerDisplayName(ticket) }}</span>
+                            <span
                                 v-if="hasUserLastReply(ticket)"
                                 class="last-reply-icon text-warning"
                                 title="Ultima respuesta del usuario"
@@ -129,6 +133,15 @@ export default {
         },
         hasUserLastReply(ticket) {
             return Number(ticket && ticket.unread_for_admin) > 0;
+        },
+        ticketOwnerDisplayName(ticket) {
+            const u = ticket && ticket.user;
+            if (!u) return '';
+            const name = u.name != null && String(u.name).trim();
+            if (name) return ` · ${name}`;
+            const username = u.username != null && String(u.username).trim();
+            if (username) return ` · ${username}`;
+            return '';
         }
     },
     mounted() {
@@ -165,6 +178,10 @@ export default {
 
 .support-tickets-table tbody tr:nth-child(odd) {
     background-color: #fafafa;
+}
+
+.support-tickets-table__owner {
+    margin-left: 4px;
 }
 
 .last-reply-icon {

--- a/src/components/views/AdminSupportTickets.vue
+++ b/src/components/views/AdminSupportTickets.vue
@@ -33,7 +33,7 @@
                             <span
                                 v-if="ticketOwnerDisplayName(ticket)"
                                 class="support-tickets-table__owner text-muted"
-                            >{{ ticketOwnerDisplayName(ticket) }}</span>
+                            ><span class="support-tickets-table__owner-sep" aria-hidden="true"> · </span>{{ ticketOwnerDisplayName(ticket) }}</span>
                             <span
                                 v-if="hasUserLastReply(ticket)"
                                 class="last-reply-icon text-warning"
@@ -138,9 +138,9 @@ export default {
             const u = ticket && ticket.user;
             if (!u) return '';
             const name = u.name != null && String(u.name).trim();
-            if (name) return ` · ${name}`;
+            if (name) return name;
             const username = u.username != null && String(u.username).trim();
-            if (username) return ` · ${username}`;
+            if (username) return username;
             return '';
         }
     },
@@ -178,10 +178,6 @@ export default {
 
 .support-tickets-table tbody tr:nth-child(odd) {
     background-color: #fafafa;
-}
-
-.support-tickets-table__owner {
-    margin-left: 4px;
 }
 
 .last-reply-icon {

--- a/src/components/views/AdminSupportTickets.vue
+++ b/src/components/views/AdminSupportTickets.vue
@@ -33,10 +33,14 @@
                             <span
                                 v-if="ticketOwnerDisplayName(ticket)"
                                 class="support-tickets-table__owner text-muted"
-                            ><span class="support-tickets-table__owner-sep" aria-hidden="true"> · </span><router-link
-                                v-if="canLinkTicketOwnerProfile(ticket)"
-                                :to="ticketOwnerAppProfileRoute(ticket)"
-                            >{{ ticketOwnerDisplayName(ticket) }}</router-link><span v-else>{{ ticketOwnerDisplayName(ticket) }}</span></span>
+                            >
+                                <span class="support-tickets-table__owner-sep" aria-hidden="true"> · </span>
+                                <router-link
+                                    v-if="canLinkTicketOwnerProfile(ticket)"
+                                    :to="ticketOwnerAppProfileRoute(ticket)"
+                                >{{ ticketOwnerDisplayName(ticket) }}</router-link>
+                                <span v-else>{{ ticketOwnerDisplayName(ticket) }}</span>
+                            </span>
                             <span
                                 v-if="hasUserLastReply(ticket)"
                                 class="last-reply-icon text-warning"
@@ -71,6 +75,10 @@ const STATUS_LABEL_KEYS = {
     Resuelto: 'estadoAprobado',
     Cerrado: 'estadoCerrado'
 };
+
+function userAppProfileLocation(userId) {
+    return { name: 'profile', params: { id: userId } };
+}
 
 export default {
     name: 'admin-support-tickets',
@@ -141,7 +149,7 @@ export default {
             return Boolean(ticket && ticket.user && ticket.user.id);
         },
         ticketOwnerAppProfileRoute(ticket) {
-            return { name: 'profile', params: { id: ticket.user.id } };
+            return userAppProfileLocation(ticket.user.id);
         },
         ticketOwnerDisplayName(ticket) {
             const u = ticket && ticket.user;

--- a/src/styles/supportTicketsTableCompact.css
+++ b/src/styles/supportTicketsTableCompact.css
@@ -19,3 +19,7 @@
     word-break: break-word;
     vertical-align: middle;
 }
+
+.support-tickets-table__owner {
+    margin-left: 4px;
+}


### PR DESCRIPTION
- **Admin support ticket list** shows the **ticket owner** (from `ticket.user`) next to the subject, with a muted ` · ` separator.
- Owner display is a **`router-link` to the public profile** (`name: 'profile'`, `id: ticket.user.id`) when `ticket.user.id` is present; otherwise the name stays plain text.
- **Styles:** `.support-tickets-table__owner` lives in shared `supportTicketsTableCompact.css`.
- **Tests:** `AdminSupportTickets.view.test.js` covers owner label, profile link helpers, and related layout strings.
- **Refactor:** `userAppProfileLocation(userId)` helper for the profile route object; cleaner template markup around the owner block.
