### PR TITLE
Prevent send button from being cropped on mobile conversation view

### DIFF
--- a/src/components/views/ConversationChat.vue
+++ b/src/components/views/ConversationChat.vue
@@ -366,9 +366,23 @@ export default {
     .message-composer {
         position: static;
         border-top: 1px solid #ddd;
+        padding-left: 4px;
+        padding-right: 4px;
     }
     .message-composer-editor-wrap {
         align-items: stretch;
+        gap: 4px;
+    }
+    .message-composer-editor {
+        overflow: hidden;
+    }
+    .message-composer-editor :deep(.toastui-editor-defaultUI-toolbar) {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+        padding: 0 8px;
+    }
+    .message-composer-editor :deep(.toastui-editor-defaultUI) {
+        border-radius: 0;
     }
     .message-composer-send {
         height: 44px;

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -2472,6 +2472,10 @@
       .trip-detail-component .driver-container {
           z-index: 0;
       }
+      .conversation-component {
+          padding-left: 0;
+          padding-right: 0;
+      }
       .conversation-component .list-group-item:first-child {
           border: 1px solid #DDDDDD;
       }

--- a/src/styles/main.carpoolear.css
+++ b/src/styles/main.carpoolear.css
@@ -2657,6 +2657,10 @@ ul {
         z-index: 0;
     }
 
+    .conversation-component {
+        padding-left: 0;
+        padding-right: 0;
+    }
     .conversation-component .list-group-item:first-child {
         border: 1px solid #DDDDDD;
     }


### PR DESCRIPTION
Reduce container padding and gap, add overflow-x auto to editor toolbar so buttons scroll instead of expanding the editor width.