### PR TITLE
Handle offline errors globally

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,6 +3,7 @@
         class="app-container"
         :class="[backgroundStyle, viewName, deviceClass]"
     >
+        <OfflineStatusBar />
         <ForceUpgradeModal v-if="showForceUpgrade" />
         <MaintenanceFullscreen v-else-if="passengerMaintenanceWall" />
         <template v-else>
@@ -53,6 +54,7 @@ import ForceUpgradeModal from './components/ForceUpgradeModal.vue';
 import IdentityValidationPromptModal from './components/IdentityValidationPromptModal.vue';
 import MaintenanceFullscreen from './components/MaintenanceFullscreen.vue';
 import MaintenanceAdminBanner from './components/MaintenanceAdminBanner.vue';
+import OfflineStatusBar from './components/OfflineStatusBar.vue';
 
 export default {
     name: 'app',
@@ -251,7 +253,8 @@ export default {
         ForceUpgradeModal,
         IdentityValidationPromptModal,
         MaintenanceFullscreen,
-        MaintenanceAdminBanner
+        MaintenanceAdminBanner,
+        OfflineStatusBar
     }
 };
 </script>

--- a/src/components/OfflineStatusBar.view.test.js
+++ b/src/components/OfflineStatusBar.view.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('OfflineStatusBar component', () => {
+    it('renders a fixed bottom status bar from initialized network state', () => {
+        const componentPath = path.resolve(__dirname, 'OfflineStatusBar.vue');
+        const source = fs.readFileSync(componentPath, 'utf8');
+
+        expect(source).toContain("name: 'offline-status-bar'");
+        expect(source).toContain('networkReady');
+        expect(source).toContain('networkState');
+        expect(source).toContain('role="status"');
+        expect(source).toContain('position: fixed');
+        expect(source).toContain('bottom: 0');
+        expect(source).toContain('offlineStatusBarMessage');
+    });
+
+    it('is mounted once at the app root', () => {
+        const appPath = path.resolve(__dirname, '../App.vue');
+        const source = fs.readFileSync(appPath, 'utf8');
+
+        expect(source).toContain('<OfflineStatusBar />');
+        expect(source).toContain("import OfflineStatusBar from './components/OfflineStatusBar.vue'");
+    });
+});

--- a/src/components/OfflineStatusBar.vue
+++ b/src/components/OfflineStatusBar.vue
@@ -1,0 +1,42 @@
+<template>
+    <div
+        v-if="networkReady && !networkState"
+        class="offline-status-bar"
+        role="status"
+        aria-live="polite"
+    >
+        {{ $t('offlineStatusBarMessage') }}
+    </div>
+</template>
+
+<script>
+import { mapState } from 'pinia';
+import { useCordovaStore } from '../stores/cordova';
+
+export default {
+    name: 'offline-status-bar',
+    computed: {
+        ...mapState(useCordovaStore, {
+            networkReady: 'networkReady',
+            networkState: 'networkState'
+        })
+    }
+};
+</script>
+
+<style scoped>
+.offline-status-bar {
+    position: fixed;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 10000;
+    padding: 12px 16px;
+    background: #d9534f;
+    color: #fff;
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1.3;
+    text-align: center;
+}
+</style>

--- a/src/components/views/AuthOfflineHandling.view.test.js
+++ b/src/components/views/AuthOfflineHandling.view.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const loginSource = fs.readFileSync(path.resolve(__dirname, 'Login.vue'), 'utf8');
+const registerSource = fs.readFileSync(path.resolve(__dirname, 'Register.vue'), 'utf8');
+
+describe('auth views offline error handling', () => {
+    it('does not show incorrect credentials for offline login failures', () => {
+        expect(loginSource).toContain('isOfflineApiError');
+        expect(loginSource).toContain('this.$t(\'emailOContra\')');
+    });
+
+    it('lets the global offline bar handle offline registration failures', () => {
+        expect(registerSource).toContain('isOfflineApiError');
+        expect(registerSource).toContain('return;');
+    });
+});

--- a/src/components/views/Login.vue
+++ b/src/components/views/Login.vue
@@ -298,6 +298,7 @@ import router from '../../router';
 import bus from '../../services/bus-event';
 import Spinner from '../Spinner.vue';
 import cache from '../../services/cache';
+import { isOfflineApiError } from '../../utils/apiErrors.js';
 
 export default {
     name: 'login',
@@ -416,6 +417,10 @@ export default {
                         // router.rememberBack();
                     },
                     (error) => {
+                        if (isOfflineApiError(error)) {
+                            this.loading = false;
+                            return;
+                        }
                         const userNotActive =
                             error && error.message === 'user_not_active';
                         const userBanned =

--- a/src/components/views/Register.vue
+++ b/src/components/views/Register.vue
@@ -387,6 +387,7 @@ import router from '../../router';
 import modal from '../Modal';
 import dayjs from '../../dayjs';
 import Spinner from '../Spinner.vue';
+import { isOfflineApiError } from '../../utils/apiErrors.js';
 let emailRegex =
     /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/;
 class Error {
@@ -697,6 +698,10 @@ export default {
                             })
                             .catch((err) => {
                                 console.log('catch', err);
+                                if (isOfflineApiError(err)) {
+                                    that.progress = false;
+                                    return;
+                                }
                                 if (err) {
                                     console.log('err register', err);
                                     if (err.status === 422) {
@@ -748,8 +753,11 @@ export default {
                                 that.progress = false;
                             });
                     })
-                    .catch(function () {
+                    .catch(function (err) {
                         that.progress = false;
+                        if (isOfflineApiError(err)) {
+                            return;
+                        }
                         dialogs.message(that.$t('errorRegistro'), {
                             duration: 10,
                             estado: 'error'

--- a/src/cordova/index.js
+++ b/src/cordova/index.js
@@ -13,6 +13,10 @@ import { useRootStore } from '../stores/root';
 window.facebook = facebook;
 window.appVersion = '3.2.2';
 
+const NETWORK_POLL_INTERVAL_MS = 5000;
+let networkMonitoringStarted = false;
+let networkPollInterval = null;
+
 function getCordovaStore() {
     return useCordovaStore();
 }
@@ -91,26 +95,20 @@ const initDeviceInfo = async () => {
 };
 
 const initNetworkMonitoring = async () => {
-    const cordovaStore = getCordovaStore();
+    if (networkMonitoringStarted) {
+        return;
+    }
+    networkMonitoringStarted = true;
 
     if (Capacitor.isNativePlatform()) {
         try {
             // Get initial network status
             const status = await Network.getStatus();
-
-            if (status.connected) {
-                cordovaStore.deviceOnline();
-            } else {
-                cordovaStore.deviceOffline();
-            }
+            handleNetworkStatus(status.connected);
 
             // Listen for network changes
             Network.addListener('networkStatusChange', (status) => {
-                if (status.connected) {
-                    cordovaStore.deviceOnline();
-                } else {
-                    cordovaStore.deviceOffline();
-                }
+                handleNetworkStatus(status.connected);
             });
         } catch (error) {
             // Fallback to browser events
@@ -122,16 +120,59 @@ const initNetworkMonitoring = async () => {
 };
 
 const initBrowserNetworkEvents = () => {
-    document.addEventListener('online', onOnline, false);
-    document.addEventListener('offline', onOffline, false);
+    handleNetworkStatus(navigator.onLine !== false);
+    window.addEventListener('online', onOnline, false);
+    window.addEventListener('offline', onOffline, false);
 };
 
 const onOnline = () => {
-    getCordovaStore().deviceOnline();
+    handleNetworkStatus(true);
 };
 
 const onOffline = () => {
-    getCordovaStore().deviceOffline();
+    handleNetworkStatus(false);
+};
+
+const handleNetworkStatus = (connected) => {
+    getCordovaStore().setNetworkState(connected);
+    if (connected) {
+        stopOfflinePolling();
+    } else {
+        startOfflinePolling();
+    }
+};
+
+const getCurrentNetworkStatus = async () => {
+    if (Capacitor.isNativePlatform()) {
+        try {
+            const status = await Network.getStatus();
+            return status.connected;
+        } catch (error) {
+            return navigator.onLine !== false;
+        }
+    }
+
+    return navigator.onLine !== false;
+};
+
+const startOfflinePolling = () => {
+    if (networkPollInterval) {
+        return;
+    }
+
+    networkPollInterval = setInterval(async () => {
+        const connected = await getCurrentNetworkStatus();
+        handleNetworkStatus(connected);
+    }, NETWORK_POLL_INTERVAL_MS);
+};
+
+const stopOfflinePolling = () => {
+    if (!networkPollInterval) {
+        return;
+    }
+
+    clearInterval(networkPollInterval);
+    networkPollInterval = null;
 };
 
 //  cordova.fireDocumentEvent('backbutton'); for testing in console
@@ -162,6 +203,7 @@ if (Capacitor.isNativePlatform()) {
         onDeviceReady();
     }, 1000);
 } else {
+    initNetworkMonitoring();
     if (
         config.web_push_notification &&
         window.Notification.permission === 'granted'

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -254,6 +254,8 @@ const messages = {
             'Ya existe un usuario con este número de documento o número de teléfono. Si es tuyo y querés recuperar tu cuenta, escribinos desde la ',
         errorRegistro:
             'Ocurrió un error al procesar el registro, por favor vuelva a intentar.',
+        offlineStatusBarMessage:
+            'Sin conexión a internet. Revisá tu conexión.',
         valorDonacion: 'Tienes que seleccionar un valor de donación.',
         correctamenteSubscripto:
             'Te subscribiste correctamente. Te avisaremos cuando hayan viajes similares',
@@ -1525,6 +1527,8 @@ const messages = {
             'Ya existe un usuario con este número de documento o número de teléfono. Si es tuyo y querés recuperar tu cuenta, escribinos desde la ',
         errorRegistro:
             'Ocurrió un error al procesar el registro, por favor vuelva a intentar.',
+        offlineStatusBarMessage:
+            'Sin conexión a internet. Revisá tu conexión.',
         buscoConductor: 'Conductor',
         buscoPasajero: 'Pasajero',
         iniciarSesion: 'Comparte auto para llegar al lugar donde quierés ir',
@@ -2570,6 +2574,8 @@ const messages = {
             "A user with this document number or phone number already exists. If it's yours and you want to recover your account, reach out through the ",
         errorRegistro:
             'An error occurred while processing the registration, please try again.',
+        offlineStatusBarMessage:
+            'No internet connection. Check your connection.',
         valorDonacion: 'You must select a donation amount.',
         correctamenteSubscripto:
             'You subscribed successfully. We will notify you when there are similar trips.',

--- a/src/services/network.js
+++ b/src/services/network.js
@@ -4,6 +4,11 @@ import axios from 'axios';
 import { Capacitor } from '@capacitor/core';
 
 const API_URL = import.meta.env.VITE_API_URL;
+const OFFLINE_ERROR = {
+    data: { message: 'network_offline' },
+    status: 0,
+    offline: true
+};
 
 class MyPromise {
     constructor(resolve, reject, promise = null) {
@@ -88,13 +93,30 @@ export default {
         return CancelToken.source();
     },
 
+    createOfflineError() {
+        return {
+            data: { ...OFFLINE_ERROR.data },
+            status: OFFLINE_ERROR.status,
+            offline: OFFLINE_ERROR.offline
+        };
+    },
+
+    async markOffline() {
+        try {
+            const { useCordovaStore } = await import('../stores/cordova');
+            useCordovaStore().setNetworkState(false);
+        } catch (e) {
+            console.warn('markOffline:', e);
+        }
+    },
+
     processResponse(response, source) {
         const promise = new MyPromise((resolve, reject) => {
             response
                 .then((response) => {
                     resolve(response.data);
                 })
-                .catch((resp) => {
+                .catch(async (resp) => {
                     // Revisar el tipo de error!
                     if (resp.response) {
                         const data = resp.response.data;
@@ -120,8 +142,11 @@ export default {
                             );
                         }
                         reject({ data, status });
-                    } else {
+                    } else if (axios.isCancel && axios.isCancel(resp)) {
                         reject(resp);
+                    } else {
+                        await this.markOffline();
+                        reject(this.createOfflineError());
                     }
                 });
         });

--- a/src/services/network.test.js
+++ b/src/services/network.test.js
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+
+vi.mock('axios', () => ({
+    default: {
+        CancelToken: {
+            source: vi.fn(() => ({ token: 'token', cancel: vi.fn() }))
+        },
+        isCancel: vi.fn(() => false)
+    }
+}));
+
+vi.mock('@capacitor/core', () => ({
+    Capacitor: {
+        getPlatform: vi.fn(() => 'web')
+    }
+}));
+
+vi.mock('../cordova/facebook.js', () => ({
+    default: {}
+}));
+
+vi.mock('../cordova/apple.js', () => ({
+    default: {}
+}));
+
+vi.mock('../services/api', () => ({
+    AuthApi: class AuthApiMock {}
+}));
+
+vi.mock('../services/bus-event.js', () => ({
+    default: { emit: vi.fn() }
+}));
+
+vi.mock('../cordova/toast.js', () => ({
+    default: { toast: vi.fn() }
+}));
+
+vi.mock('../utils/routerLazy.js', () => ({
+    fireLazyRouterPush: vi.fn(),
+    getLazyRouter: vi.fn()
+}));
+
+describe('network transport errors', () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+    });
+
+    it('normalizes axios transport failures and marks the app offline', async () => {
+        const network = await import('./network');
+        const { useCordovaStore } = await import('../stores/cordova');
+        const store = useCordovaStore();
+        store.setNetworkState(true);
+
+        const source = { cancel: vi.fn() };
+        const request = network.default.processResponse(
+            Promise.reject(
+                Object.assign(new Error('Network Error'), {
+                    code: 'ERR_NETWORK'
+                })
+            ),
+            source
+        );
+
+        await expect(request).rejects.toEqual({
+            data: { message: 'network_offline' },
+            status: 0,
+            offline: true
+        });
+        expect(store.networkReady).toBe(true);
+        expect(store.networkState).toBe(false);
+    });
+});

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -150,8 +150,11 @@ export const useAuthStore = defineStore('auth', {
                     this.onLoggin(response.token);
                     return Promise.resolve();
                 },
-                ({ data, status }) => {
-                    return Promise.reject(data);
+                (error) => {
+                    if (error && error.offline) {
+                        return Promise.reject(error);
+                    }
+                    return Promise.reject(error ? error.data : error);
                 }
             );
         },

--- a/src/stores/auth.offline.test.js
+++ b/src/stores/auth.offline.test.js
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+
+const apiMock = {
+    login: vi.fn()
+};
+
+vi.mock('../services/api', () => ({
+    AuthApi: class AuthApiMock {
+        constructor() {
+            return apiMock;
+        }
+    },
+    UserApi: class UserApiMock {}
+}));
+
+vi.mock('../services/cache', () => ({
+    default: {
+        setItem: vi.fn(),
+        clear: vi.fn()
+    },
+    keys: {
+        TOKEN_KEY: 'token',
+        USER_KEY: 'user'
+    }
+}));
+
+vi.mock('../../config/conf', () => ({
+    default: {}
+}));
+
+vi.mock('../utils/registrationAutoLogin', () => ({
+    completeSessionIfRegistrationReturnsToken: vi.fn()
+}));
+
+vi.mock('../utils/routerLazy.js', () => ({
+    getLazyRouter: vi.fn()
+}));
+
+describe('auth store offline errors', () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        apiMock.login.mockReset();
+    });
+
+    it('preserves normalized offline errors from login', async () => {
+        const offlineError = {
+            data: { message: 'network_offline' },
+            status: 0,
+            offline: true
+        };
+        apiMock.login.mockRejectedValue(offlineError);
+
+        const { useAuthStore } = await import('./auth');
+        const store = useAuthStore();
+
+        await expect(
+            store.login({ email: 'user@example.com', password: 'secret' })
+        ).rejects.toEqual(offlineError);
+    });
+});

--- a/src/stores/cordova.js
+++ b/src/stores/cordova.js
@@ -11,6 +11,7 @@ const authApi = new AuthApi();
 export const useCordovaStore = defineStore('cordova', {
     state: () => ({
         deviceReady: false,
+        networkReady: false,
         _deviceOnline: false,
         device: null,
         deviceId: null
@@ -37,12 +38,17 @@ export const useCordovaStore = defineStore('cordova', {
             this.deviceReady = true;
         },
 
+        setNetworkState(connected) {
+            this.networkReady = true;
+            this._deviceOnline = Boolean(connected);
+        },
+
         setOnline() {
-            this._deviceOnline = true;
+            this.setNetworkState(true);
         },
 
         setOffline() {
-            this._deviceOnline = false;
+            this.setNetworkState(false);
         },
 
         setDevice(device) {
@@ -115,11 +121,11 @@ export const useCordovaStore = defineStore('cordova', {
         },
 
         deviceOnline() {
-            this._deviceOnline = true;
+            this.setNetworkState(true);
         },
 
         deviceOffline() {
-            this._deviceOnline = false;
+            this.setNetworkState(false);
         },
 
         onPausa() {

--- a/src/stores/cordova.networkState.test.js
+++ b/src/stores/cordova.networkState.test.js
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+
+vi.mock('../cordova/facebook.js', () => ({
+    default: {}
+}));
+
+vi.mock('../cordova/apple.js', () => ({
+    default: {}
+}));
+
+vi.mock('../services/api', () => ({
+    AuthApi: class AuthApiMock {}
+}));
+
+vi.mock('../services/bus-event.js', () => ({
+    default: { emit: vi.fn() }
+}));
+
+vi.mock('../cordova/toast.js', () => ({
+    default: { toast: vi.fn() }
+}));
+
+vi.mock('../utils/routerLazy.js', () => ({
+    fireLazyRouterPush: vi.fn(),
+    getLazyRouter: vi.fn()
+}));
+
+describe('cordova store network state', () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+    });
+
+    it('marks network state as ready when the first status is received', async () => {
+        const { useCordovaStore } = await import('./cordova');
+        const store = useCordovaStore();
+
+        expect(store.networkReady).toBe(false);
+
+        store.setNetworkState(true);
+
+        expect(store.networkReady).toBe(true);
+        expect(store.networkState).toBe(true);
+    });
+
+    it('keeps legacy deviceOnline and deviceOffline actions in sync with the initialized state', async () => {
+        const { useCordovaStore } = await import('./cordova');
+        const store = useCordovaStore();
+
+        store.deviceOnline();
+        expect(store.networkReady).toBe(true);
+        expect(store.networkState).toBe(true);
+
+        store.deviceOffline();
+        expect(store.networkReady).toBe(true);
+        expect(store.networkState).toBe(false);
+    });
+});

--- a/src/utils/apiErrors.js
+++ b/src/utils/apiErrors.js
@@ -1,0 +1,9 @@
+export function isOfflineApiError(error) {
+    return Boolean(
+        error &&
+            (error.offline === true ||
+                error.status === 0 ||
+                (error.data && error.data.message === 'network_offline') ||
+                error.message === 'network_offline')
+    );
+}

--- a/src/utils/apiErrors.test.js
+++ b/src/utils/apiErrors.test.js
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { isOfflineApiError } from './apiErrors.js';
+
+describe('api error helpers', () => {
+    it('detects normalized offline API errors', () => {
+        expect(
+            isOfflineApiError({
+                data: { message: 'network_offline' },
+                status: 0,
+                offline: true
+            })
+        ).toBe(true);
+    });
+
+    it('does not treat validation responses as offline errors', () => {
+        expect(
+            isOfflineApiError({
+                data: { errors: { email: ['The email has already been taken.'] } },
+                status: 422
+            })
+        ).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

- Added global offline detection and a bottom status bar that appears while the app is offline and clears when connectivity returns.
- Normalized transport/network API failures so offline errors are handled consistently across the app.
- Updated login and registration flows to avoid showing incorrect credentials or generic registration errors when the user is offline.
- Added focused tests for offline state handling, API error normalization, auth behavior, and the offline status bar.

## Test Plan

- `npm run lint`
- `npm run test:unit -- --run`
- Manual browser check with offline/online network emulation

- Closes https://github.com/STS-Rosario/carpoolear/issues/116