### PR TITLE
Enforce required profile fields

### DIFF
--- a/src/components/sections/UpdateProfile.view.test.js
+++ b/src/components/sections/UpdateProfile.view.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const viewPath = path.resolve(__dirname, 'UpdateProfile.vue');
+const viewSource = fs.readFileSync(viewPath, 'utf8');
+
+describe('UpdateProfile missing field routing', () => {
+    it('exposes the patente input as a scroll target', () => {
+        expect(viewSource).toContain('for="input-patente"');
+        expect(viewSource).toContain('id="input-patente"');
+        expect(viewSource).toContain('ref="patenteInput"');
+    });
+
+    it('scrolls to patente when route query requests the missing patente field', () => {
+        expect(viewSource).toContain("this.$route.query.missing !== 'patente'");
+        expect(viewSource).toContain('this.$refs.patenteInput');
+        expect(viewSource).toContain(
+            'this.$scrollToElement(this.$refs.patenteInput, -270)'
+        );
+    });
+
+    it('highlights the patente field when route query requests it', () => {
+        expect(viewSource).toContain('missing-field-highlight');
+        expect(viewSource).toContain('shouldHighlightPatente');
+        expect(viewSource).toContain("this.$route.query.missing === 'patente'");
+    });
+});

--- a/src/components/sections/UpdateProfile.vue
+++ b/src/components/sections/UpdateProfile.vue
@@ -200,8 +200,13 @@
                         </span>
                     </div>
 
-                    <div class="form-group">
-                        <label for="input-telefono">
+                    <div
+                        class="form-group"
+                        :class="{
+                            'missing-field-highlight': shouldHighlightPatente
+                        }"
+                    >
+                        <label for="input-patente">
                             {{ $t('patente') }}
                             <span class="description">
                                 ({{ $t('soloConductores') }}).
@@ -213,7 +218,8 @@
                             v-model="patente"
                             type="text"
                             class="form-control"
-                            id="input-phone"
+                            id="input-patente"
+                            ref="patenteInput"
                             :class="{ 'has-error': patentError.state }"
                         />
                         <span class="error" v-if="patentError.state">
@@ -730,6 +736,13 @@ export default {
             if (this.user) {
                 return this.user.mobile_phone;
             }
+        },
+        shouldHighlightPatente() {
+            return !!(
+                this.$route &&
+                this.$route.query &&
+                this.$route.query.missing === 'patente'
+            );
         }
     },
     methods: {
@@ -752,6 +765,20 @@ export default {
                 let element = hasError[0];
                 this.$scrollToElement(element, -270);
             }
+        },
+        scrollToMissingRouteField() {
+            if (
+                !this.$route ||
+                !this.$route.query ||
+                this.$route.query.missing !== 'patente'
+            ) {
+                return;
+            }
+            this.$nextTick(() => {
+                if (this.$refs.patenteInput) {
+                    this.$scrollToElement(this.$refs.patenteInput, -270);
+                }
+            });
         },
         changeShowPassword() {
             this.showChangePassword = !this.showChangePassword;
@@ -1190,6 +1217,7 @@ export default {
         } catch (ex) {
             console.log('exception', ex);
         }
+        this.scrollToMissingRouteField();
     },
     beforeUnmount() {
         bus.off('date-change', this.dateChange);
@@ -1247,6 +1275,11 @@ span.error.textarea {
     vertical-align: -2px;
     margin-right: 5px;
     color: var(--trip-mostly-free-color);
+}
+.missing-field-highlight {
+    background: #fff4cc;
+    border-radius: 4px;
+    padding: 0.75em;
 }
 
 hr {

--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -1825,6 +1825,11 @@ import {
     priceInputNumberFromStoredSeatPriceCents,
     seatPriceCentsForApi
 } from '../../utils/tripSeatPrice.js';
+import {
+    firstCarWithPlate,
+    hasDriverPlate,
+    requiresDriverPlate
+} from '../../utils/profileRequirements';
 
 let tripApi = new TripApi();
 let userApi = new UserApi();
@@ -2189,6 +2194,9 @@ export default {
             createTrip: 'create',
             updateTrip: 'update',
             getPrice: 'price'
+        }),
+        ...mapActions(useCarsStore, {
+            carIndex: 'index'
         }),
         ...mapActions(useRootStore, {
             getTrip: 'getTrip'
@@ -2689,13 +2697,14 @@ export default {
                     node_id: p.place.id
                 };
             });
+            const car = firstCarWithPlate(this.cars);
 
             const tripInfo = {
                 points,
                 from_town: points[0].address,
                 to_town: last(points).address,
                 estimated_time: estimatedTime,
-                car_id: this.cars.length > 0 ? this.cars[0].id : undefined
+                car_id: car ? car.id : undefined
             };
 
             if (!useWeeklySchedule) {
@@ -2712,7 +2721,26 @@ export default {
             return result;
         },
 
-        save() {
+        async save() {
+            if (
+                requiresDriverPlate(this.trip) &&
+                !Array.isArray(this.cars)
+            ) {
+                await this.carIndex();
+            }
+            if (
+                requiresDriverPlate(this.trip) &&
+                !hasDriverPlate(this.cars)
+            ) {
+                dialogs.message(this.$t('olvidastePatente'), {
+                    estado: 'error'
+                });
+                this.$router.replace({
+                    name: 'profile_update',
+                    query: { incompleteProfile: 'true', missing: 'patente' }
+                });
+                return;
+            }
             const validationResult = this.validate();
             if (validationResult) {
                 // Jump To Error

--- a/src/router/middleware.js
+++ b/src/router/middleware.js
@@ -1,6 +1,7 @@
 /* jshint esversion: 6 */
 import router from '../router';
 import { useAuthStore } from '../stores/auth';
+import { hasRequiredProfileFields } from '../utils/profileRequirements';
 
 function getAuthStore () {
     return useAuthStore();
@@ -84,12 +85,7 @@ export function requireIdentityValidation(to, from, next) {
 
 export function profileComplete(to, from, next) {
     const user = getAuthStore().user;
-    if (
-        !user.image ||
-        user.image.length === 0 ||
-        !user.description ||
-        user.description.length === 0
-    ) {
+    if (!hasRequiredProfileFields(user)) {
         router.rememberRoute = {
             name: to.name,
             params: to.params

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -4,6 +4,7 @@ import cache, { keys } from '../services/cache';
 import localConfig from '../../config/conf';
 import { completeSessionIfRegistrationReturnsToken } from '../utils/registrationAutoLogin';
 import { getLazyRouter } from '../utils/routerLazy.js';
+import { hasRequiredProfileFields } from '../utils/profileRequirements';
 
 const authApi = new AuthApi();
 const userApi = new UserApi();
@@ -88,7 +89,7 @@ export const useAuthStore = defineStore('auth', {
         // Business logic actions
         async onLoggin(token) {
             this.setToken(token);
-            this.fetchUser();
+            await this.fetchUser();
 
             const [
                 { useCordovaStore },
@@ -133,7 +134,7 @@ export const useAuthStore = defineStore('auth', {
             passengerStore.getPendingRequest();
             rootStore.startThread();
             const router = await getLazyRouter();
-            if (this.firstTime) {
+            if (this.firstTime || !hasRequiredProfileFields(this.user)) {
                 router.replace({ name: 'profile_update' });
             } else {
                 router.rememberBack();

--- a/src/utils/profileRequirements.js
+++ b/src/utils/profileRequirements.js
@@ -1,0 +1,40 @@
+function hasValue(value) {
+    return value !== null && value !== undefined && String(value).trim().length > 0;
+}
+
+export function hasRequiredProfileFields(user) {
+    if (!user) {
+        return false;
+    }
+
+    return (
+        hasValue(user.image) &&
+        hasValue(user.description) &&
+        hasValue(user.nro_doc) &&
+        hasValue(user.mobile_phone)
+    );
+}
+
+export function firstCarWithPlate(cars) {
+    if (!Array.isArray(cars)) {
+        return null;
+    }
+
+    return cars.find((car) => car && hasValue(car.patente)) || null;
+}
+
+export function hasDriverPlate(cars) {
+    return !!firstCarWithPlate(cars);
+}
+
+export function requiresDriverPlate(trip) {
+    if (!trip) {
+        return false;
+    }
+
+    return !(
+        trip.is_passenger === 1 ||
+        trip.is_passenger === '1' ||
+        trip.is_passenger === true
+    );
+}

--- a/src/utils/profileRequirements.test.js
+++ b/src/utils/profileRequirements.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import {
+    hasRequiredProfileFields,
+    hasDriverPlate,
+    firstCarWithPlate,
+    requiresDriverPlate
+} from './profileRequirements';
+
+describe('profile required fields', () => {
+    const completeUser = {
+        image: 'profile.jpg',
+        description: 'Viajo seguido entre ciudades.',
+        nro_doc: '30111222',
+        mobile_phone: '+5493415551234'
+    };
+
+    it('requires image, description, document, and phone for restricted actions', () => {
+        expect(hasRequiredProfileFields(completeUser)).toBe(true);
+
+        expect(hasRequiredProfileFields({ ...completeUser, image: '' })).toBe(false);
+        expect(hasRequiredProfileFields({ ...completeUser, description: '' })).toBe(false);
+        expect(hasRequiredProfileFields({ ...completeUser, nro_doc: '' })).toBe(false);
+        expect(hasRequiredProfileFields({ ...completeUser, mobile_phone: '' })).toBe(false);
+    });
+
+    it('requires a saved plate only when creating a driver trip', () => {
+        expect(requiresDriverPlate({ is_passenger: 0 })).toBe(true);
+        expect(requiresDriverPlate({ is_passenger: '0' })).toBe(true);
+        expect(requiresDriverPlate({ is_passenger: 1 })).toBe(false);
+        expect(requiresDriverPlate({ is_passenger: '1' })).toBe(false);
+    });
+
+    it('treats a non-empty car plate as present', () => {
+        expect(hasDriverPlate([{ patente: 'ABC123' }])).toBe(true);
+        expect(hasDriverPlate([{ patente: '   ' }])).toBe(false);
+        expect(hasDriverPlate([])).toBe(false);
+        expect(hasDriverPlate(null)).toBe(false);
+    });
+
+    it('returns the first car that has a plate', () => {
+        const first = { id: 1, patente: '' };
+        const second = { id: 2, patente: 'ABC123' };
+
+        expect(firstCarWithPlate([first, second])).toBe(second);
+        expect(firstCarWithPlate([first])).toBe(null);
+    });
+});


### PR DESCRIPTION
### Frontend
- Require users to complete profile fields before accessing restricted trip flows: profile image, description, DNI, and phone.
- Block driver trip creation when the user has no saved car plate, showing the existing plate-required message and redirecting to profile edit.
- Use the first saved car with a plate when creating driver trips.
