### PR TITLE
Reference button

### DIFF
--- a/src/components/sections/ProfileInfo.vue
+++ b/src/components/sections/ProfileInfo.vue
@@ -145,52 +145,6 @@
                         {{ $t('transacciones') }}
                     </router-link>
                 </div>
-                <div
-                    class="edit-action edit-action-reference"
-                    v-else-if="
-                        config &&
-                        config.module_references &&
-                        !userReferenceWritten
-                    "
-                >
-                    <button
-                        v-if="!sendReferenceFormVisibility"
-                        class="btn btn-primary"
-                        tag="button"
-                        @click="showReferenceForm"
-                    >
-                        {{ $t('enviarReferencia') }}
-                    </button>
-                    <div v-else class="reply-box">
-                        <label for="reply" class="label label-reply">
-                            {{ $t('escribeUnaReferenciaSobreElUsuario') }}
-                        </label>
-                        <textarea
-                            ref="reference"
-                            maxlength="260"
-                            v-model="referenceComment"
-                            id="reference"
-                        ></textarea>
-                        <div class="reply-btns">
-                            <button
-                                class="btn btn-primary"
-                                @click="sendReference"
-                                :disabled="sending"
-                            >
-                                <template v-if="sending">
-                                    <spinner class="blue"></spinner>
-                                </template>
-                                <template v-else>{{ $t('comentar') }}</template>
-                            </button>
-                            <button
-                                class="btn btn-primary"
-                                @click="sendReferenceFormVisibility = false"
-                            >
-                                {{ $t('cancelar') }}
-                            </button>
-                        </div>
-                    </div>
-                </div>
             </div>
         </div>
     </div>
@@ -201,18 +155,12 @@ import { useAuthStore } from '../../stores/auth';
 import { useProfileStore } from '../../stores/profile';
 import { useConversationsStore } from '../../stores/conversations';
 import router from '../../router';
-import Spinner from '../Spinner.vue';
 import UserNameWithBadge from '../elements/UserNameWithBadge.vue';
-import dialogs from '../../services/dialogs.js';
 import { formatId } from '../../services/utility';
 
 export default {
     data() {
-        return {
-            sendReferenceFormVisibility: false,
-            referenceComment: '',
-            sending: false
-        };
+        return {};
     },
     computed: {
         ...mapState(useAuthStore, {
@@ -223,15 +171,6 @@ export default {
             profile: 'user',
             badges: 'badges'
         }),
-        userReferenceWritten() {
-            return (
-                this.profile.references_data &&
-                    this.profile.references_data.length &&
-                    this.profile.references_data.findIndex(
-                        (item) => item.user_id_from === this.user.id
-                    ) >= 0
-            );
-        },
         identityValidationAvailable() {
             const c = this.config;
             return (
@@ -249,9 +188,6 @@ export default {
         ...mapActions(useConversationsStore, {
             lookConversation: 'createConversation'
         }),
-        ...mapActions(useProfileStore, {
-            makeReference: 'makeReference'
-        }),
         messageUser() {
             console.log('messageUser profileInfo', this.profile);
             this.lookConversation(this.profile).then((conversation) => {
@@ -259,37 +195,6 @@ export default {
                     name: 'conversation-chat',
                     params: { id: conversation.id }
                 });
-            });
-        },
-        sendReference() {
-            this.sending = true;
-            this.makeReference({
-                user_id_to: this.profile.id,
-                comment: this.referenceComment
-            })
-                .then(() => {
-                    dialogs.message(this.$t('referenciaExitosa'));
-                    this.sendReferenceFormVisibility = false;
-                })
-                .catch((error) => {
-                    let errorMessage = this.$t('referenciaError');
-                    if (this.$checkError(error, 'reference_exist')) {
-                        errorMessage = this.$t('referenciaExist');
-                    } else if (this.$checkError(error, 'reference_same_user')) {
-                        errorMessage = this.$t('referenciaSameUser');
-                    } else if (this.$checkError(error, 'user_doesnt_exist')) {
-                        errorMessage = this.$t('userDoesntExist');
-                    }
-                    dialogs.message(errorMessage, { estado: 'error' });
-                })
-                .finally(() => {
-                    this.sending = false;
-                });
-        },
-        showReferenceForm() {
-            this.sendReferenceFormVisibility = true;
-            this.$nextTick(() => {
-                this.$refs.reference.focus();
             });
         },
         badgeImageUrl(imagePath) {
@@ -302,7 +207,6 @@ export default {
         }
     },
     components: {
-        Spinner,
         UserNameWithBadge
     }
 };

--- a/src/components/sections/ProfileInfo.vue
+++ b/src/components/sections/ProfileInfo.vue
@@ -159,9 +159,6 @@ import UserNameWithBadge from '../elements/UserNameWithBadge.vue';
 import { formatId } from '../../services/utility';
 
 export default {
-    data() {
-        return {};
-    },
     computed: {
         ...mapState(useAuthStore, {
             user: 'user',

--- a/src/components/sections/ProfileRates.view.test.js
+++ b/src/components/sections/ProfileRates.view.test.js
@@ -11,6 +11,8 @@ const profileInfoSource = fs.readFileSync(profileInfoPath, 'utf8');
 const i18nSource = fs.readFileSync(i18nPath, 'utf8');
 const referenceActionSpacingRule =
     /\.edit-action-reference\s*\{[\s\S]*margin-bottom:\s*1rem/;
+const referenceLabelColorRule = /\.label-reply\s*\{[\s\S]*color:\s*#333/;
+const referenceLabelSizeRule = /\.label-reply\s*\{[\s\S]*font-size:\s*1rem/;
 const referencePersonCopy =
     'Las referencias son de la persona, y no de un viaje.';
 const referenceTripRatingCopy =
@@ -51,11 +53,7 @@ describe('ProfileRates reference action', () => {
     });
 
     it('styles the reference form label as black and larger text', () => {
-        expect(profileRatesSource).toMatch(
-            /\.label-reply\s*\{[\s\S]*color:\s*#333/
-        );
-        expect(profileRatesSource).toMatch(
-            /\.label-reply\s*\{[\s\S]*font-size:\s*1rem/
-        );
+        expect(profileRatesSource).toMatch(referenceLabelColorRule);
+        expect(profileRatesSource).toMatch(referenceLabelSizeRule);
     });
 });

--- a/src/components/sections/ProfileRates.view.test.js
+++ b/src/components/sections/ProfileRates.view.test.js
@@ -13,6 +13,8 @@ const referenceActionSpacingRule =
     /\.edit-action-reference\s*\{[\s\S]*margin-bottom:\s*1rem/;
 const referenceLabelColorRule = /\.label-reply\s*\{[\s\S]*color:\s*#333/;
 const referenceLabelSizeRule = /\.label-reply\s*\{[\s\S]*font-size:\s*1rem/;
+const referenceMessageFirstKey = 'confirmarReferenciaUsuarioMensajeReferencia';
+const referenceMessageSecondKey = 'confirmarReferenciaUsuarioMensajeCalificacion';
 const referencePersonCopy =
     'Las referencias son de la persona, y no de un viaje.';
 const referenceTripRatingCopy =
@@ -34,8 +36,8 @@ describe('ProfileRates reference action', () => {
     it('asks for confirmation in a modal before showing the reference form', () => {
         expect(profileRatesSource).toContain('<modal');
         expect(profileRatesSource).toContain("$t('confirmarReferenciaUsuarioTitulo')");
-        expect(profileRatesSource).toContain("$t('confirmarReferenciaUsuarioMensajeReferencia'");
-        expect(profileRatesSource).toContain("$t('confirmarReferenciaUsuarioMensajeCalificacion')");
+        expect(profileRatesSource).toContain(`$t('${referenceMessageFirstKey}'`);
+        expect(profileRatesSource).toContain(`$t('${referenceMessageSecondKey}')`);
         expect(profileRatesSource).toContain("$t('continuar')");
         expect(profileRatesSource).toContain("$t('cancelar')");
         expect(profileRatesSource).toMatch(/@click="showReferenceConfirmation"/);
@@ -48,8 +50,8 @@ describe('ProfileRates reference action', () => {
 
     it('keeps all new confirmation copy in i18n', () => {
         expect(i18nSource).toContain('confirmarReferenciaUsuarioTitulo');
-        expect(i18nSource).toContain('confirmarReferenciaUsuarioMensajeReferencia');
-        expect(i18nSource).toContain('confirmarReferenciaUsuarioMensajeCalificacion');
+        expect(i18nSource).toContain(referenceMessageFirstKey);
+        expect(i18nSource).toContain(referenceMessageSecondKey);
         expect(i18nSource).toContain(referencePersonCopy);
         expect(i18nSource).toContain(referenceTripRatingCopy);
         expect(i18nSource).toContain('Continuar');

--- a/src/components/sections/ProfileRates.view.test.js
+++ b/src/components/sections/ProfileRates.view.test.js
@@ -36,6 +36,12 @@ describe('ProfileRates reference action', () => {
     it('keeps all new confirmation copy in i18n', () => {
         expect(i18nSource).toContain('confirmarReferenciaUsuarioTitulo');
         expect(i18nSource).toContain('confirmarReferenciaUsuarioMensaje');
+        expect(i18nSource).toContain(
+            'Las referencias son de la persona, y no de un viaje.'
+        );
+        expect(i18nSource).toContain(
+            'Si tuviste un viaje dentro de Carpoolear y querés dejar una calificación'
+        );
         expect(i18nSource).toContain('Continuar');
         expect(i18nSource).toContain('Cancel');
     });

--- a/src/components/sections/ProfileRates.view.test.js
+++ b/src/components/sections/ProfileRates.view.test.js
@@ -9,6 +9,8 @@ const i18nPath = path.resolve(__dirname, '../../language/i18n.js');
 const profileRatesSource = fs.readFileSync(profileRatesPath, 'utf8');
 const profileInfoSource = fs.readFileSync(profileInfoPath, 'utf8');
 const i18nSource = fs.readFileSync(i18nPath, 'utf8');
+const referenceActionSpacingRule =
+    /\.edit-action-reference\s*\{[\s\S]*margin-bottom:\s*1rem/;
 
 describe('ProfileRates reference action', () => {
     it('shows the write-reference action in the references section before the list', () => {
@@ -39,8 +41,6 @@ describe('ProfileRates reference action', () => {
     });
 
     it('adds bottom spacing to the reference action before the list', () => {
-        expect(profileRatesSource).toMatch(
-            /\.edit-action-reference\s*\{[\s\S]*margin-bottom:\s*1rem/
-        );
+        expect(profileRatesSource).toMatch(referenceActionSpacingRule);
     });
 });

--- a/src/components/sections/ProfileRates.view.test.js
+++ b/src/components/sections/ProfileRates.view.test.js
@@ -37,4 +37,10 @@ describe('ProfileRates reference action', () => {
         expect(i18nSource).toContain('Continuar');
         expect(i18nSource).toContain('Cancel');
     });
+
+    it('adds bottom spacing to the reference action before the list', () => {
+        expect(profileRatesSource).toMatch(
+            /\.edit-action-reference\s*\{[\s\S]*margin-bottom:\s*1rem/
+        );
+    });
 });

--- a/src/components/sections/ProfileRates.view.test.js
+++ b/src/components/sections/ProfileRates.view.test.js
@@ -16,7 +16,9 @@ const referenceLabelSizeRule = /\.label-reply\s*\{[\s\S]*font-size:\s*1rem/;
 const referencePersonCopy =
     'Las referencias son de la persona, y no de un viaje.';
 const referenceTripRatingCopy =
-    'Si tuviste un viaje dentro de Carpoolear y querés dejar una calificación';
+    'Si tuviste un viaje dentro de Carpoolear y querés dejar una calificación, tenés que esperar a que pasen 24 horas luego de la finalización del viaje, vas a recibir una notificación cuando puedas hacerlo.';
+const referenceModalParagraphsRule =
+    /<template #body>[\s\S]*<p>[\s\S]*\$t\('confirmarReferenciaUsuarioMensajeReferencia'[\s\S]*<\/p>[\s\S]*<p>[\s\S]*\$t\('confirmarReferenciaUsuarioMensajeCalificacion'\)[\s\S]*<\/p>[\s\S]*<\/template>/;
 
 describe('ProfileRates reference action', () => {
     it('shows the write-reference action in the references section before the list', () => {
@@ -32,16 +34,22 @@ describe('ProfileRates reference action', () => {
     it('asks for confirmation in a modal before showing the reference form', () => {
         expect(profileRatesSource).toContain('<modal');
         expect(profileRatesSource).toContain("$t('confirmarReferenciaUsuarioTitulo')");
-        expect(profileRatesSource).toContain("$t('confirmarReferenciaUsuarioMensaje'");
+        expect(profileRatesSource).toContain("$t('confirmarReferenciaUsuarioMensajeReferencia'");
+        expect(profileRatesSource).toContain("$t('confirmarReferenciaUsuarioMensajeCalificacion')");
         expect(profileRatesSource).toContain("$t('continuar')");
         expect(profileRatesSource).toContain("$t('cancelar')");
         expect(profileRatesSource).toMatch(/@click="showReferenceConfirmation"/);
         expect(profileRatesSource).toMatch(/@click="confirmReferenceWriting"/);
     });
 
+    it('renders the reference explanation as two translated paragraphs', () => {
+        expect(profileRatesSource).toMatch(referenceModalParagraphsRule);
+    });
+
     it('keeps all new confirmation copy in i18n', () => {
         expect(i18nSource).toContain('confirmarReferenciaUsuarioTitulo');
-        expect(i18nSource).toContain('confirmarReferenciaUsuarioMensaje');
+        expect(i18nSource).toContain('confirmarReferenciaUsuarioMensajeReferencia');
+        expect(i18nSource).toContain('confirmarReferenciaUsuarioMensajeCalificacion');
         expect(i18nSource).toContain(referencePersonCopy);
         expect(i18nSource).toContain(referenceTripRatingCopy);
         expect(i18nSource).toContain('Continuar');

--- a/src/components/sections/ProfileRates.view.test.js
+++ b/src/components/sections/ProfileRates.view.test.js
@@ -49,4 +49,13 @@ describe('ProfileRates reference action', () => {
     it('adds bottom spacing to the reference action before the list', () => {
         expect(profileRatesSource).toMatch(referenceActionSpacingRule);
     });
+
+    it('styles the reference form label as black and larger text', () => {
+        expect(profileRatesSource).toMatch(
+            /\.label-reply\s*\{[\s\S]*color:\s*#333/
+        );
+        expect(profileRatesSource).toMatch(
+            /\.label-reply\s*\{[\s\S]*font-size:\s*1rem/
+        );
+    });
 });

--- a/src/components/sections/ProfileRates.view.test.js
+++ b/src/components/sections/ProfileRates.view.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const profileRatesPath = path.resolve(__dirname, 'ProfileRates.vue');
+const profileInfoPath = path.resolve(__dirname, 'ProfileInfo.vue');
+const i18nPath = path.resolve(__dirname, '../../language/i18n.js');
+
+const profileRatesSource = fs.readFileSync(profileRatesPath, 'utf8');
+const profileInfoSource = fs.readFileSync(profileInfoPath, 'utf8');
+const i18nSource = fs.readFileSync(i18nPath, 'utf8');
+
+describe('ProfileRates reference action', () => {
+    it('shows the write-reference action in the references section before the list', () => {
+        const referencesHeadingIndex = profileRatesSource.indexOf("$t('referencias')");
+        const actionIndex = profileRatesSource.indexOf("$t('enviarReferencia')");
+        const referencesListIndex = profileRatesSource.indexOf('<Loading :data="references">');
+
+        expect(actionIndex).toBeGreaterThan(referencesHeadingIndex);
+        expect(actionIndex).toBeLessThan(referencesListIndex);
+        expect(profileInfoSource).not.toContain("$t('enviarReferencia')");
+    });
+
+    it('asks for confirmation in a modal before showing the reference form', () => {
+        expect(profileRatesSource).toContain('<modal');
+        expect(profileRatesSource).toContain("$t('confirmarReferenciaUsuarioTitulo')");
+        expect(profileRatesSource).toContain("$t('confirmarReferenciaUsuarioMensaje'");
+        expect(profileRatesSource).toContain("$t('continuar')");
+        expect(profileRatesSource).toContain("$t('cancelar')");
+        expect(profileRatesSource).toMatch(/@click="showReferenceConfirmation"/);
+        expect(profileRatesSource).toMatch(/@click="confirmReferenceWriting"/);
+    });
+
+    it('keeps all new confirmation copy in i18n', () => {
+        expect(i18nSource).toContain('confirmarReferenciaUsuarioTitulo');
+        expect(i18nSource).toContain('confirmarReferenciaUsuarioMensaje');
+        expect(i18nSource).toContain('Continuar');
+        expect(i18nSource).toContain('Cancel');
+    });
+});

--- a/src/components/sections/ProfileRates.view.test.js
+++ b/src/components/sections/ProfileRates.view.test.js
@@ -11,6 +11,10 @@ const profileInfoSource = fs.readFileSync(profileInfoPath, 'utf8');
 const i18nSource = fs.readFileSync(i18nPath, 'utf8');
 const referenceActionSpacingRule =
     /\.edit-action-reference\s*\{[\s\S]*margin-bottom:\s*1rem/;
+const referencePersonCopy =
+    'Las referencias son de la persona, y no de un viaje.';
+const referenceTripRatingCopy =
+    'Si tuviste un viaje dentro de Carpoolear y querés dejar una calificación';
 
 describe('ProfileRates reference action', () => {
     it('shows the write-reference action in the references section before the list', () => {
@@ -36,12 +40,8 @@ describe('ProfileRates reference action', () => {
     it('keeps all new confirmation copy in i18n', () => {
         expect(i18nSource).toContain('confirmarReferenciaUsuarioTitulo');
         expect(i18nSource).toContain('confirmarReferenciaUsuarioMensaje');
-        expect(i18nSource).toContain(
-            'Las referencias son de la persona, y no de un viaje.'
-        );
-        expect(i18nSource).toContain(
-            'Si tuviste un viaje dentro de Carpoolear y querés dejar una calificación'
-        );
+        expect(i18nSource).toContain(referencePersonCopy);
+        expect(i18nSource).toContain(referenceTripRatingCopy);
         expect(i18nSource).toContain('Continuar');
         expect(i18nSource).toContain('Cancel');
     });

--- a/src/components/sections/ProfileRates.vue
+++ b/src/components/sections/ProfileRates.vue
@@ -86,9 +86,14 @@
                         <template #body>
                             <p>
                                 {{
-                                    $t('confirmarReferenciaUsuarioMensaje', {
+                                    $t('confirmarReferenciaUsuarioMensajeReferencia', {
                                         userName: referenceRecipientName
                                     })
+                                }}
+                            </p>
+                            <p>
+                                {{
+                                    $t('confirmarReferenciaUsuarioMensajeCalificacion')
                                 }}
                             </p>
                         </template>

--- a/src/components/sections/ProfileRates.vue
+++ b/src/components/sections/ProfileRates.vue
@@ -71,7 +71,6 @@
                     <button
                         v-if="!sendReferenceFormVisibility"
                         class="btn btn-primary"
-                        tag="button"
                         @click="showReferenceConfirmation"
                     >
                         {{ $t('enviarReferencia') }}
@@ -88,7 +87,7 @@
                             <p>
                                 {{
                                     $t('confirmarReferenciaUsuarioMensaje', {
-                                        userName: profile.name
+                                        userName: referenceRecipientName
                                     })
                                 }}
                             </p>
@@ -321,6 +320,9 @@ export default {
                 this.profile.id !== this.user.id &&
                 !this.userReferenceWritten
             );
+        },
+        referenceRecipientName() {
+            return this.profile ? this.profile.name : '';
         },
         userReferenceWritten() {
             return (

--- a/src/components/sections/ProfileRates.vue
+++ b/src/components/sections/ProfileRates.vue
@@ -378,4 +378,8 @@ export default {
 .profile-rates-component {
     padding-bottom: 6em;
 }
+
+.edit-action-reference {
+    margin-bottom: 1rem;
+}
 </style>

--- a/src/components/sections/ProfileRates.vue
+++ b/src/components/sections/ProfileRates.vue
@@ -382,4 +382,9 @@ export default {
 .edit-action-reference {
     margin-bottom: 1rem;
 }
+
+.label-reply {
+    color: #333;
+    font-size: 1rem;
+}
 </style>

--- a/src/components/sections/ProfileRates.vue
+++ b/src/components/sections/ProfileRates.vue
@@ -64,6 +64,80 @@
         <template v-if="config && config.module_references">
             <div class="clearfix">
                 <h2>{{ $t('referencias') }}</h2>
+                <div
+                    class="edit-action edit-action-reference"
+                    v-if="canWriteReference"
+                >
+                    <button
+                        v-if="!sendReferenceFormVisibility"
+                        class="btn btn-primary"
+                        tag="button"
+                        @click="showReferenceConfirmation"
+                    >
+                        {{ $t('enviarReferencia') }}
+                    </button>
+                    <modal
+                        v-if="referenceConfirmationVisibility"
+                        name="reference-confirmation-modal"
+                        @close="hideReferenceConfirmation"
+                    >
+                        <template #header>
+                            <h3>{{ $t('confirmarReferenciaUsuarioTitulo') }}</h3>
+                        </template>
+                        <template #body>
+                            <p>
+                                {{
+                                    $t('confirmarReferenciaUsuarioMensaje', {
+                                        userName: profile.name
+                                    })
+                                }}
+                            </p>
+                        </template>
+                        <template #footer>
+                            <button
+                                class="btn btn-secondary"
+                                @click="hideReferenceConfirmation"
+                            >
+                                {{ $t('cancelar') }}
+                            </button>
+                            <button
+                                class="btn btn-primary"
+                                @click="confirmReferenceWriting"
+                            >
+                                {{ $t('continuar') }}
+                            </button>
+                        </template>
+                    </modal>
+                    <div v-else-if="sendReferenceFormVisibility" class="reply-box">
+                        <label for="reference" class="label label-reply">
+                            {{ $t('escribeUnaReferenciaSobreElUsuario') }}
+                        </label>
+                        <textarea
+                            ref="reference"
+                            maxlength="260"
+                            v-model="referenceComment"
+                            id="reference"
+                        ></textarea>
+                        <div class="reply-btns">
+                            <button
+                                class="btn btn-primary"
+                                @click="sendReference"
+                                :disabled="sending"
+                            >
+                                <template v-if="sending">
+                                    <spinner class="blue"></spinner>
+                                </template>
+                                <template v-else>{{ $t('comentar') }}</template>
+                            </button>
+                            <button
+                                class="btn btn-primary"
+                                @click="sendReferenceFormVisibility = false"
+                            >
+                                {{ $t('cancelar') }}
+                            </button>
+                        </div>
+                    </div>
+                </div>
                 <Loading :data="references">
                     <div class="list-group">
                         <div class="column-rating">
@@ -128,12 +202,15 @@
     </div>
 </template>
 <script>
-import { mapState } from 'pinia';
+import { mapState, mapActions } from 'pinia';
 import { useAuthStore } from '../../stores/auth';
 import { useProfileStore } from '../../stores/profile';
 import { useDeviceStore } from '../../stores/device';
 import Loading from '../Loading.vue';
 import RateItem from '../RateItem';
+import Spinner from '../Spinner.vue';
+import modal from '../Modal';
+import dialogs from '../../services/dialogs.js';
 
 let emptyCols = {
     col1: [],
@@ -145,10 +222,17 @@ export default {
     data() {
         return {
             rating: {},
-            referencesCol: {}
+            referencesCol: {},
+            sendReferenceFormVisibility: false,
+            referenceConfirmationVisibility: false,
+            referenceComment: '',
+            sending: false
         };
     },
     methods: {
+        ...mapActions(useProfileStore, {
+            makeReference: 'makeReference'
+        }),
         cleanCols(array) {
             this[array] = JSON.parse(JSON.stringify(emptyCols));
         },
@@ -170,6 +254,47 @@ export default {
                     }
                 }
             }
+        },
+        showReferenceConfirmation() {
+            this.referenceConfirmationVisibility = true;
+        },
+        hideReferenceConfirmation() {
+            this.referenceConfirmationVisibility = false;
+        },
+        confirmReferenceWriting() {
+            this.referenceConfirmationVisibility = false;
+            this.showReferenceForm();
+        },
+        showReferenceForm() {
+            this.sendReferenceFormVisibility = true;
+            this.$nextTick(() => {
+                this.$refs.reference.focus();
+            });
+        },
+        sendReference() {
+            this.sending = true;
+            this.makeReference({
+                user_id_to: this.profile.id,
+                comment: this.referenceComment
+            })
+                .then(() => {
+                    dialogs.message(this.$t('referenciaExitosa'));
+                    this.sendReferenceFormVisibility = false;
+                })
+                .catch((error) => {
+                    let errorMessage = this.$t('referenciaError');
+                    if (this.$checkError(error, 'reference_exist')) {
+                        errorMessage = this.$t('referenciaExist');
+                    } else if (this.$checkError(error, 'reference_same_user')) {
+                        errorMessage = this.$t('referenciaSameUser');
+                    } else if (this.$checkError(error, 'user_doesnt_exist')) {
+                        errorMessage = this.$t('userDoesntExist');
+                    }
+                    dialogs.message(errorMessage, { estado: 'error' });
+                })
+                .finally(() => {
+                    this.sending = false;
+                });
         }
     },
     computed: {
@@ -178,6 +303,7 @@ export default {
             config: 'appConfig'
         }),
         ...mapState(useProfileStore, {
+            profile: 'user',
             rates: 'rates',
             references: 'references'
         }),
@@ -185,7 +311,26 @@ export default {
             isMobile: 'isMobile',
             isTablet: 'isTablet',
             isDesktop: 'isDesktop'
-        })
+        }),
+        canWriteReference() {
+            return (
+                this.config &&
+                this.config.module_references &&
+                this.profile &&
+                this.user &&
+                this.profile.id !== this.user.id &&
+                !this.userReferenceWritten
+            );
+        },
+        userReferenceWritten() {
+            return (
+                this.profile.references_data &&
+                    this.profile.references_data.length &&
+                    this.profile.references_data.findIndex(
+                        (item) => item.user_id_from === this.user.id
+                    ) >= 0
+            );
+        }
     },
     watch: {
         rates: {
@@ -220,7 +365,9 @@ export default {
     },
     components: {
         Loading,
-        RateItem
+        RateItem,
+        Spinner,
+        modal
     },
     props: ['id']
 };

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -332,8 +332,10 @@ const messages = {
         editarPerfil: 'Editar perfil',
         enviarReferencia: 'Escribir una referencia del usuario',
         confirmarReferenciaUsuarioTitulo: 'Escribir referencia',
-        confirmarReferenciaUsuarioMensaje:
-            'Estás por escribir una referencia para el usuario {userName}. Las referencias son de la persona, y no de un viaje.\n\nSi tuviste un viaje dentro de Carpoolear y querés dejar una calificación, tenés que esperar a que pasen 24 horas luego de la finalización del viaje, vas a recibir una notificación cuando puedas hacerlo',
+        confirmarReferenciaUsuarioMensajeReferencia:
+            'Estás por escribir una referencia para el usuario {userName}. Las referencias son de la persona, y no de un viaje.',
+        confirmarReferenciaUsuarioMensajeCalificacion:
+            'Si tuviste un viaje dentro de Carpoolear y querés dejar una calificación, tenés que esperar a que pasen 24 horas luego de la finalización del viaje, vas a recibir una notificación cuando puedas hacerlo.',
         continuar: 'Continuar',
         referenciaExitosa: 'El comentario fue enviado exitosamente',
         referenciaError: 'Ocurrió un problema al enviar el comentario.',
@@ -2655,8 +2657,10 @@ const messages = {
         editarPerfil: 'Edit profile',
         enviarReferencia: 'Write a review for the user',
         confirmarReferenciaUsuarioTitulo: 'Write a reference',
-        confirmarReferenciaUsuarioMensaje:
-            'You are about to write a reference for {userName}. References are about the person, not a trip.\n\nIf you took a trip within Carpoolear and want to leave a rating, you need to wait 24 hours after the trip ends. You will receive a notification when you can do it.',
+        confirmarReferenciaUsuarioMensajeReferencia:
+            'You are about to write a reference for {userName}. References are about the person, not a trip.',
+        confirmarReferenciaUsuarioMensajeCalificacion:
+            'If you took a trip within Carpoolear and want to leave a rating, you need to wait 24 hours after the trip ends. You will receive a notification when you can do it.',
         continuar: 'Continue',
         referenciaExitosa: 'The comment was sent successfully',
         referenciaError: 'A problem occurred while sending the comment.',

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -331,6 +331,10 @@ const messages = {
         enviarMensaje: 'Enviar mensaje',
         editarPerfil: 'Editar perfil',
         enviarReferencia: 'Escribir una referencia del usuario',
+        confirmarReferenciaUsuarioTitulo: 'Escribir referencia',
+        confirmarReferenciaUsuarioMensaje:
+            'Estás por escribir una referencia para el usuario {userName}. Si tuviste un viaje y querés dejar una calificación, tenés que esperar a que pasen 24 horas luego de la finalización del viaje, vas a recibir una notificación cuando puedas hacerlo',
+        continuar: 'Continuar',
         referenciaExitosa: 'El comentario fue enviado exitosamente',
         referenciaError: 'Ocurrió un problema al enviar el comentario.',
         referenciaExist:
@@ -2650,6 +2654,10 @@ const messages = {
         enviarMensaje: 'Send message',
         editarPerfil: 'Edit profile',
         enviarReferencia: 'Write a review for the user',
+        confirmarReferenciaUsuarioTitulo: 'Write a reference',
+        confirmarReferenciaUsuarioMensaje:
+            'You are about to write a reference for {userName}. If you took a trip and want to leave a rating, you need to wait 24 hours after the trip ends. You will receive a notification when you can do it.',
+        continuar: 'Continue',
         referenciaExitosa: 'The comment was sent successfully',
         referenciaError: 'A problem occurred while sending the comment.',
         referenciaExist:

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -333,7 +333,7 @@ const messages = {
         enviarReferencia: 'Escribir una referencia del usuario',
         confirmarReferenciaUsuarioTitulo: 'Escribir referencia',
         confirmarReferenciaUsuarioMensaje:
-            'Estás por escribir una referencia para el usuario {userName}. Si tuviste un viaje y querés dejar una calificación, tenés que esperar a que pasen 24 horas luego de la finalización del viaje, vas a recibir una notificación cuando puedas hacerlo',
+            'Estás por escribir una referencia para el usuario {userName}. Las referencias son de la persona, y no de un viaje.\n\nSi tuviste un viaje dentro de Carpoolear y querés dejar una calificación, tenés que esperar a que pasen 24 horas luego de la finalización del viaje, vas a recibir una notificación cuando puedas hacerlo',
         continuar: 'Continuar',
         referenciaExitosa: 'El comentario fue enviado exitosamente',
         referenciaError: 'Ocurrió un problema al enviar el comentario.',
@@ -2656,7 +2656,7 @@ const messages = {
         enviarReferencia: 'Write a review for the user',
         confirmarReferenciaUsuarioTitulo: 'Write a reference',
         confirmarReferenciaUsuarioMensaje:
-            'You are about to write a reference for {userName}. If you took a trip and want to leave a rating, you need to wait 24 hours after the trip ends. You will receive a notification when you can do it.',
+            'You are about to write a reference for {userName}. References are about the person, not a trip.\n\nIf you took a trip within Carpoolear and want to leave a rating, you need to wait 24 hours after the trip ends. You will receive a notification when you can do it.',
         continuar: 'Continue',
         referenciaExitosa: 'The comment was sent successfully',
         referenciaError: 'A problem occurred while sending the comment.',


### PR DESCRIPTION
## Summary
- Moved “Escribir una referencia del usuario” from profile details to the Calificaciones tab, inside Referencias before the list.
- Added an i18n confirmation modal before showing the reference form, with separate paragraphs for reference guidance and trip rating guidance.
- Improved reference form spacing and label readability.

Closes https://github.com/STS-Rosario/carpoolear/issues/124
