### PR TITLE
Fix review error

### DIFF
--- a/src/components/RatePending.view.test.js
+++ b/src/components/RatePending.view.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
+import nodeVm from 'node:vm';
 import { parse } from '@vue/compiler-sfc';
 
 const componentPath = path.resolve(__dirname, 'RatePending.vue');
@@ -11,27 +12,18 @@ function loadComponent(dialogs) {
     const script = descriptor.script.content
         .replace(/^import .*;\n/gm, '')
         .replace('export default', 'component =');
-
-    return new Function(
-        'mapState',
-        'mapActions',
-        'useRatesStore',
-        'useAuthStore',
-        'dialogs',
-        'dayjs',
-        `
-            let component;
-            ${script}
-            return component;
-        `
-    )(
-        () => ({}),
-        () => ({}),
-        () => ({}),
-        () => ({}),
+    const context = {
+        component: null,
+        mapState: () => ({}),
+        mapActions: () => ({}),
+        useRatesStore: () => ({}),
+        useAuthStore: () => ({}),
         dialogs,
-        () => {}
-    );
+        dayjs: () => {}
+    };
+
+    nodeVm.runInNewContext(script, context);
+    return context.component;
 }
 
 function makeRate() {
@@ -56,13 +48,13 @@ function makeRate() {
 
 describe('RatePending blank comments', () => {
     it('shows an error instead of submitting a positive rating without a comment', () => {
+        const emitted = [];
+        const submitted = [];
         const dialogs = {
             message: vi.fn()
         };
         const component = loadComponent(dialogs);
-        const emitted = [];
-        const submitted = [];
-        const vm = {
+        const componentVm = {
             ...component.data(),
             rate: makeRate(),
             trip: makeRate().trip,
@@ -77,7 +69,7 @@ describe('RatePending blank comments', () => {
             }
         };
 
-        component.methods.makeVote.call(vm);
+        component.methods.makeVote.call(componentVm);
 
         expect(dialogs.message).toHaveBeenCalledWith(
             'ratePendingComentarioNoPuedeEstarVacio',
@@ -85,6 +77,6 @@ describe('RatePending blank comments', () => {
         );
         expect(emitted).toEqual([]);
         expect(submitted).toEqual([]);
-        expect(vm.sending).toBe(false);
+        expect(componentVm.sending).toBe(false);
     });
 });

--- a/src/components/RatePending.view.test.js
+++ b/src/components/RatePending.view.test.js
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { parse } from '@vue/compiler-sfc';
+
+const componentPath = path.resolve(__dirname, 'RatePending.vue');
+
+function loadComponent(dialogs) {
+    const source = fs.readFileSync(componentPath, 'utf8');
+    const { descriptor } = parse(source);
+    const script = descriptor.script.content
+        .replace(/^import .*;\n/gm, '')
+        .replace('export default', 'component =');
+
+    return new Function(
+        'mapState',
+        'mapActions',
+        'useRatesStore',
+        'useAuthStore',
+        'dialogs',
+        'dayjs',
+        `
+            let component;
+            ${script}
+            return component;
+        `
+    )(
+        () => ({}),
+        () => ({}),
+        () => ({}),
+        () => ({}),
+        dialogs,
+        () => {}
+    );
+}
+
+function makeRate() {
+    return {
+        id: 23,
+        to: {
+            id: 42,
+            name: 'Ada'
+        },
+        trip: {
+            id: 99,
+            points: [
+                {
+                    json_address: {
+                        ciudad: 'Rosario'
+                    }
+                }
+            ]
+        }
+    };
+}
+
+describe('RatePending blank comments', () => {
+    it('shows an error instead of submitting a positive rating without a comment', () => {
+        const dialogs = {
+            message: vi.fn()
+        };
+        const component = loadComponent(dialogs);
+        const emitted = [];
+        const submitted = [];
+        const vm = {
+            ...component.data(),
+            rate: makeRate(),
+            trip: makeRate().trip,
+            to: makeRate().to,
+            vote: 1,
+            comment: '',
+            $t: (key) => key,
+            $emit: (...args) => emitted.push(args),
+            emit: (data) => {
+                submitted.push(data);
+                return Promise.resolve();
+            }
+        };
+
+        component.methods.makeVote.call(vm);
+
+        expect(dialogs.message).toHaveBeenCalledWith(
+            'ratePendingComentarioNoPuedeEstarVacio',
+            { duration: 10, estado: 'error' }
+        );
+        expect(emitted).toEqual([]);
+        expect(submitted).toEqual([]);
+        expect(vm.sending).toBe(false);
+    });
+});

--- a/src/components/RatePending.vue
+++ b/src/components/RatePending.vue
@@ -109,25 +109,21 @@ export default {
 
         makeVote() {
             this.sending = true;
+            const comment = this.comment.trim();
             let data = {
                 id: this.rate.id,
                 trip_id: this.trip.id,
                 user_id: this.to.id,
                 trip: this.rate.trip,
-                comment: this.comment,
+                comment,
                 rating: this.vote
             };
             let ok = false;
-            if (!this.vote) {
-                if (!this.comment) {
-                    // Voto negativo y comentario vacio
-                    dialogs.message(
-                        this.$t('ratePendingComentarioNoPuedeEstarVacio'),
-                        { duration: 10, estado: 'error' }
-                    );
-                } else {
-                    ok = true;
-                }
+            if (!comment) {
+                dialogs.message(
+                    this.$t('ratePendingComentarioNoPuedeEstarVacio'),
+                    { duration: 10, estado: 'error' }
+                );
             } else {
                 ok = true;
             }

--- a/src/components/RatePending.vue
+++ b/src/components/RatePending.vue
@@ -118,29 +118,24 @@ export default {
                 comment,
                 rating: this.vote
             };
-            let ok = false;
             if (!comment) {
                 dialogs.message(
                     this.$t('ratePendingComentarioNoPuedeEstarVacio'),
                     { duration: 10, estado: 'error' }
                 );
-            } else {
-                ok = true;
-            }
-            if (ok) {
-                console.log('emit rated');
-                this.$emit('rated', data);
-                this.emit(data)
-                    .then(() => {
-                        this.comment = '';
-                        this.sending = false;
-                    })
-                    .catch(() => {
-                        this.sending = false;
-                    });
-            } else {
                 this.sending = false;
+                return;
             }
+            console.log('emit rated');
+            this.$emit('rated', data);
+            this.emit(data)
+                .then(() => {
+                    this.comment = '';
+                    this.sending = false;
+                })
+                .catch(() => {
+                    this.sending = false;
+                });
         }
     },
 

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -1153,7 +1153,7 @@ const messages = {
         ratePendingIncluyaUnComentario: 'Incluya un comentario...',
         ratePendingCalificar: 'Calificar',
         ratePendingComentarioNoPuedeEstarVacio:
-            'El comentario no puede estar vacío para los votos negativos.',
+            'El comentario no puede estar vacío.',
         rateItemPositiva: 'Positiva',
         rateItemNegativa: 'Negativa',
         rateItemViajoAComo: 'Viajó a',
@@ -2241,7 +2241,7 @@ const messages = {
         ratePendingIncluyaUnComentario: 'Incluya un comentario...',
         ratePendingCalificar: 'Calificar',
         ratePendingComentarioNoPuedeEstarVacio:
-            'El comentario no puede estar vacío para los votos negativos.',
+            'El comentario no puede estar vacío.',
         rateItemPositiva: 'Positiva',
         rateItemNegativa: 'Negativa',
         rateItemViajoAComo: 'Viajó a',
@@ -3463,7 +3463,7 @@ const messages = {
         ratePendingIncluyaUnComentario: 'Include a comment...',
         ratePendingCalificar: 'Rate',
         ratePendingComentarioNoPuedeEstarVacio:
-            'Comment cannot be empty for negative votes.',
+            'Comment cannot be empty.',
         rateItemPositiva: 'Positive',
         rateItemNegativa: 'Negative',
         rateItemViajoAComo: 'Traveled to',


### PR DESCRIPTION
### Frontend
- Added validation when submitting a trip rating so blank descriptions are rejected before sending.
- Shows the existing error message for empty rating comments and updated the copy to apply to all ratings.
- Added regression coverage for blank positive-rating comments.
