### PR TITLE
Trip description messaging

### DIFF
--- a/src/components/elements/CoordinateTrip.view.test.js
+++ b/src/components/elements/CoordinateTrip.view.test.js
@@ -5,7 +5,7 @@ import path from 'node:path';
 const viewPath = path.resolve(__dirname, 'CoordinateTrip.vue');
 const viewSource = fs.readFileSync(viewPath, 'utf8');
 
-describe('CoordinateTrip.vue contribution warning', () => {
+describe('CoordinateTrip.vue', () => {
     it('renders a collapsed trip description toggle after the trip summary', () => {
         expect(viewSource).toContain("$t('coordinateTripMostrarDescripcionViaje')");
         expect(viewSource).toContain('showTripDescription');

--- a/src/components/elements/CoordinateTrip.view.test.js
+++ b/src/components/elements/CoordinateTrip.view.test.js
@@ -6,6 +6,20 @@ const viewPath = path.resolve(__dirname, 'CoordinateTrip.vue');
 const viewSource = fs.readFileSync(viewPath, 'utf8');
 
 describe('CoordinateTrip.vue contribution warning', () => {
+    it('renders a collapsed trip description toggle after the trip summary', () => {
+        expect(viewSource).toContain("$t('coordinateTripMostrarDescripcionViaje')");
+        expect(viewSource).toContain('showTripDescription');
+        expect(viewSource).toMatch(
+            /<div class="trip_actions-detail">[\s\S]*?<\/div>\s*<div[\s\S]*?class="trip_actions-description"/s
+        );
+        expect(viewSource).toMatch(
+            /v-if="conversation\.trip\.description"/
+        );
+        expect(viewSource).toMatch(
+            /v-show="showTripDescription"[\s\S]*conversation\.trip\.description/s
+        );
+    });
+
     it('uses optional amountPart so zero-price trips omit currency in driver and passenger copy', () => {
         expect(viewSource).toContain('getContributionWarningAmountPart');
         expect(viewSource).toMatch(

--- a/src/components/elements/CoordinateTrip.vue
+++ b/src/components/elements/CoordinateTrip.vue
@@ -27,6 +27,23 @@
                 </template>
             </span>
         </div>
+        <div class="trip_actions-description" v-if="conversation.trip.description">
+            <button
+                type="button"
+                class="trip_actions-description-toggle"
+                :aria-expanded="showTripDescription ? 'true' : 'false'"
+                @click="showTripDescription = !showTripDescription"
+            >
+                {{ $t('coordinateTripMostrarDescripcionViaje') }}
+                <span aria-hidden="true">{{ showTripDescription ? '-' : '+' }}</span>
+            </button>
+            <div
+                v-show="showTripDescription"
+                class="trip_actions-description-content"
+            >
+                {{ conversation.trip.description }}
+            </div>
+        </div>
         <p v-if="contributionWarningData" class="trip_actions-contribution-warning">
             <template v-if="contributionWarningData.role === 'driver'">
                 {{
@@ -185,7 +202,8 @@ export default {
             sending: {
                 trip: false,
                 returnTrip: false
-            }
+            },
+            showTripDescription: false
         };
     },
     computed: {

--- a/src/components/elements/CoordinateTrip.vue
+++ b/src/components/elements/CoordinateTrip.vue
@@ -380,6 +380,33 @@ export default {
     text-decoration: underline;
     font-weight: bold;
 }
+
+.trip_actions-description {
+    margin: 0.4em 0 0.6em;
+}
+
+.trip_actions-description-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: 0.35em 0.5em;
+    font-size: 12px;
+    color: #337ab7;
+    background: transparent;
+    border: 1px solid #d6e6f3;
+    border-radius: 4px;
+}
+
+.trip_actions-description-content {
+    margin-top: 0.35em;
+    padding: 0.55em 0.65em;
+    font-size: 12px;
+    line-height: 1.35;
+    background-color: #fff;
+    border: 1px solid #ececec;
+    border-radius: 4px;
+}
 @media only screen and (max-width: 768px) {
     .trip_actions {
         padding: 0.4em 0.8em;

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -1229,6 +1229,7 @@ const messages = {
         coordinateTripALas: 'a las',
         coordinateTripYVueltaElDia: 'y vuelta el día',
         coordinateTripALas2: 'a las',
+        coordinateTripMostrarDescripcionViaje: 'Mostrar descripción de viaje',
         coordinateTripContributionWarningDriver:
             'Recuerde no superar la contribución del viaje{amountPart} ya que el seguro automotor no lo cubrirá en caso de accidentes y está contra las reglas de uso de Carpoolear, por lo que podrá ser suspendido',
         coordinateTripContributionWarningPassengerPrefix:
@@ -2304,6 +2305,7 @@ const messages = {
         coordinateTripALas: 'a las',
         coordinateTripYVueltaElDia: 'y vuelta el día',
         coordinateTripALas2: 'a las',
+        coordinateTripMostrarDescripcionViaje: 'Mostrar descripción de viaje',
         solicitudFueEnviada: 'La solicitud fue enviada.',
         teHasSubidoAlViaje: 'Te has subido al viaje.',
         yaSubidoMismoViaje:
@@ -3535,6 +3537,7 @@ const messages = {
         coordinateTripALas: 'at',
         coordinateTripYVueltaElDia: 'and return on',
         coordinateTripALas2: 'at',
+        coordinateTripMostrarDescripcionViaje: 'Show trip description',
         coordinateTripContributionWarningDriver:
             'Remember not to exceed the trip contribution{amountPart}, since auto insurance will not cover it in case of accidents and it is against Carpoolear usage rules, so you may be suspended',
         coordinateTripContributionWarningPassengerPrefix:


### PR DESCRIPTION
## Summary
Adds a collapsible trip description section in trip-related user conversations, shown right after the trip summary line (e.g. “Te envía una consulta por tu viaje desde …”).

### Frontend (`carpoolear`)
- **`CoordinateTrip.vue`**: After the trip summary, shows a toggle button labeled “Mostrar descripción de viaje” when the conversation’s trip has a `description`. Clicking expands/collapses the description text (hidden by default).
- **`i18n.js`**: New key `coordinateTripMostrarDescripcionViaje` (Spanish + English).
- **`CoordinateTrip.view.test.js`**: Source-based tests for the new toggle markup and placement.

## Test plan
- [ ] Open a trip-related conversation where the trip has a description.
- [ ] Confirm the toggle appears below the trip summary and shows “Mostrar descripción de viaje”.
- [ ] Click the toggle and verify the description expands/collapses.
- [ ] Open a trip-related conversation without a description and confirm the block is not shown.
- [ ] Run: `npm run test:unit -- src/components/elements/CoordinateTrip.view.test.js --run`

Closes https://github.com/STS-Rosario/carpoolear/issues/163