### PR TITLE
Trip length overflow fix

### DIFF
--- a/src/components/sections/Trip.vue
+++ b/src/components/sections/Trip.vue
@@ -187,115 +187,172 @@
                     >
                     <div class="trip_location">
                         <template v-if="trip.points && trip.points.length >= 2">
-                            <div class="row trip_location_from">
-                                <div
-                                    class="col-xs-4"
-                                    v-if="tripCardTheme === 'light'"
-                                >
-                                    <span class="trip_from_time">
-                                        {{ dayjs(trip.trip_date).format('HH:mm') }}
-                                    </span>
-                                </div>
-                                <div
-                                    class="text-right"
-                                    :class="
-                                        tripCardTheme === 'light'
-                                            ? 'col-xs-2'
-                                            : 'col-xs-3'
-                                    "
-                                >
-                                    <i
-                                        class="fa fa-map-marker"
-                                        aria-hidden="true"
-                                        v-if="tripCardTheme !== 'light'"
-                                    ></i>
-                                    <i
-                                        class="fa fa-circle"
-                                        aria-hidden="true"
-                                        v-else
-                                    ></i>
-                                </div>
-                                <div
-                                    :class="
-                                        config &&
-                                        config.trip_card_design === 'light'
-                                            ? 'col-xs-14'
-                                            : 'col-xs-20'
-                                    "
-                                >
-                                    <span
-                                        class="trip_location_from_city"
-                                    >
-                                        {{ getLocationName(trip.points[0]) }}
-                                    </span>
-                                    <span
-                                        class="trip_location_from_state-country"
-                                    >
-                                        {{
-                                            googleInfoClean(getStateName(trip.points[0]))
-                                        }}
-                                    </span>
-                                </div>
-                            </div>
-                            <div class="row trip_location_to">
-                                <div
-                                    class="col-xs-4"
-                                    v-if="tripCardTheme === 'light'"
-                                >
-                                    <span class="trip_to_time">
-                                        {{ dayjs(tripArrivingTime).format('HH:mm') }}
-                                    </span>
-                                </div>
-                                <div
-                                    class="text-right"
-                                    :class="
-                                        tripCardTheme === 'light'
-                                            ? 'col-xs-2'
-                                            : 'col-xs-3'
-                                    "
-                                >
-                                    <i
-                                        class="fa fa-map-marker"
-                                        aria-hidden="true"
-                                    ></i>
-                                </div>
-                                <div
-                                    :class="
-                                        config &&
-                                        config.trip_card_design === 'light'
-                                            ? 'col-xs-14'
-                                            : 'col-xs-20'
-                                    "
-                                >
-                                    <span
-                                        class="trip_location_to_city"
-                                    >
-                                        {{
-                                            getLocationName(
-                                                trip.points[
-                                                    trip.points.length - 1
-                                                ]
-                                            )
-                                        }}
-                                    </span>
-                                    <span
-                                        class="trip_location_to_state-country"
-                                    >
-                                        {{
-                                            googleInfoClean(getStateName(
-                                                trip.points[
-                                                    trip.points.length - 1
-                                                ]
-                                            ))
-                                        }}
-                                    </span>
-                                </div>
-                            </div>
                             <div
-                                class="col-xs-3 trip_location-dot-line trip_location-dot-line-small"
+                                v-if="tripCardTheme !== 'light'"
+                                class="trip_location-routed"
                             >
-                                <div></div>
+                                <div class="trip_location-routed__row">
+                                    <div
+                                        class="trip_location-routed__pin-col text-right"
+                                    >
+                                        <i
+                                            class="fa fa-map-marker trip_location-routed__pin trip_location-routed__pin--from"
+                                            aria-hidden="true"
+                                        ></i>
+                                    </div>
+                                    <div
+                                        class="trip_location-routed__text-col trip_location_from"
+                                    >
+                                        <span class="trip_location_from_city">
+                                            {{
+                                                getLocationName(trip.points[0])
+                                            }}
+                                        </span>
+                                        <span
+                                            class="trip_location_from_state-country"
+                                        >
+                                            {{
+                                                googleInfoClean(
+                                                    getStateName(trip.points[0])
+                                                )
+                                            }}
+                                        </span>
+                                    </div>
+                                </div>
+                                <div
+                                    class="trip_location-routed__row trip_location-routed__row--connector"
+                                >
+                                    <div class="trip_location-routed__pin-col">
+                                        <span
+                                            class="trip_location-routed__connector"
+                                            aria-hidden="true"
+                                        ></span>
+                                    </div>
+                                    <div
+                                        class="trip_location-routed__text-col"
+                                        aria-hidden="true"
+                                    ></div>
+                                </div>
+                                <div class="trip_location-routed__row">
+                                    <div
+                                        class="trip_location-routed__pin-col text-right"
+                                    >
+                                        <i
+                                            class="fa fa-map-marker trip_location-routed__pin trip_location-routed__pin--to"
+                                            aria-hidden="true"
+                                        ></i>
+                                    </div>
+                                    <div
+                                        class="trip_location-routed__text-col trip_location_to"
+                                    >
+                                        <span class="trip_location_to_city">
+                                            {{
+                                                getLocationName(
+                                                    trip.points[
+                                                        trip.points.length - 1
+                                                    ]
+                                                )
+                                            }}
+                                        </span>
+                                        <span
+                                            class="trip_location_to_state-country"
+                                        >
+                                            {{
+                                                googleInfoClean(
+                                                    getStateName(
+                                                        trip.points[
+                                                            trip.points.length -
+                                                                1
+                                                        ]
+                                                    )
+                                                )
+                                            }}
+                                        </span>
+                                    </div>
+                                </div>
                             </div>
+                            <template v-else>
+                                <div class="row trip_location_from">
+                                    <div class="col-xs-4">
+                                        <span class="trip_from_time">
+                                            {{
+                                                dayjs(trip.trip_date).format(
+                                                    'HH:mm'
+                                                )
+                                            }}
+                                        </span>
+                                    </div>
+                                    <div class="text-right col-xs-2">
+                                        <i
+                                            class="fa fa-circle"
+                                            aria-hidden="true"
+                                        ></i>
+                                    </div>
+                                    <div class="col-xs-14">
+                                        <span class="trip_location_from_city">
+                                            {{
+                                                getLocationName(trip.points[0])
+                                            }}
+                                        </span>
+                                        <span
+                                            class="trip_location_from_state-country"
+                                        >
+                                            {{
+                                                googleInfoClean(
+                                                    getStateName(trip.points[0])
+                                                )
+                                            }}
+                                        </span>
+                                    </div>
+                                </div>
+                                <div class="row trip_location_to">
+                                    <div class="col-xs-4">
+                                        <span class="trip_to_time">
+                                            {{
+                                                dayjs(tripArrivingTime).format(
+                                                    'HH:mm'
+                                                )
+                                            }}
+                                        </span>
+                                    </div>
+                                    <div class="text-right col-xs-2">
+                                        <i
+                                            class="fa fa-map-marker"
+                                            aria-hidden="true"
+                                        ></i>
+                                    </div>
+                                    <div class="col-xs-14">
+                                        <span class="trip_location_to_city">
+                                            {{
+                                                getLocationName(
+                                                    trip.points[
+                                                        trip.points.length - 1
+                                                    ]
+                                                )
+                                            }}
+                                        </span>
+                                        <span
+                                            class="trip_location_to_state-country"
+                                        >
+                                            {{
+                                                googleInfoClean(
+                                                    getStateName(
+                                                        trip.points[
+                                                            trip.points
+                                                                .length - 1
+                                                        ]
+                                                    )
+                                                )
+                                            }}
+                                        </span>
+                                    </div>
+                                </div>
+                                <div
+                                    class="col-xs-2 trip_location-dot-line trip_location-dot-line-small"
+                                >
+                                    <div></div>
+                                </div>
+                            </template>
                         </template>
                         <template v-else>
                             <div class="row trip_location_from">

--- a/src/components/sections/Trip.vue
+++ b/src/components/sections/Trip.vue
@@ -182,6 +182,9 @@
                     >
                         {{ $t('faltaPagarSellado') }}
                     </div>
+                    <div
+                        class="trip-card-section trip-card-section--route"
+                    >
                     <div class="trip_location">
                         <template v-if="trip.points && trip.points.length >= 2">
                             <div class="row trip_location_from">
@@ -198,7 +201,7 @@
                                     :class="
                                         tripCardTheme === 'light'
                                             ? 'col-xs-2'
-                                            : 'col-xs-4'
+                                            : 'col-xs-3'
                                     "
                                 >
                                     <i
@@ -217,16 +220,11 @@
                                         config &&
                                         config.trip_card_design === 'light'
                                             ? 'col-xs-14'
-                                            : 'col-xs-18'
+                                            : 'col-xs-20'
                                     "
                                 >
                                     <span
                                         class="trip_location_from_city"
-                                        :style="
-                                            originLongName
-                                                ? LONG_NAME_STYLE
-                                                : {}
-                                        "
                                     >
                                         {{ getLocationName(trip.points[0]) }}
                                     </span>
@@ -253,7 +251,7 @@
                                     :class="
                                         tripCardTheme === 'light'
                                             ? 'col-xs-2'
-                                            : 'col-xs-4'
+                                            : 'col-xs-3'
                                     "
                                 >
                                     <i
@@ -266,16 +264,11 @@
                                         config &&
                                         config.trip_card_design === 'light'
                                             ? 'col-xs-14'
-                                            : 'col-xs-18'
+                                            : 'col-xs-20'
                                     "
                                 >
                                     <span
                                         class="trip_location_to_city"
-                                        :style="
-                                            destinyLongName
-                                                ? LONG_NAME_STYLE
-                                                : {}
-                                        "
                                     >
                                         {{
                                             getLocationName(
@@ -299,7 +292,7 @@
                                 </div>
                             </div>
                             <div
-                                class="col-xs-4 trip_location-dot-line trip_location-dot-line-small"
+                                class="col-xs-3 trip_location-dot-line trip_location-dot-line-small"
                             >
                                 <div></div>
                             </div>
@@ -344,6 +337,11 @@
                             </div>
                         </template>
                     </div>
+                    </div>
+                    <div
+                        v-if="tripCardTheme !== 'light'"
+                        class="trip-card-section trip-card-section--schedule"
+                    >
                     <div class="row">
                         <time
                             class="trip_datetime col-xs-24"
@@ -384,7 +382,11 @@
                             />
                         </div>
                     </div>
-                    <template v-if="tripCardTheme !== 'light'">
+                    </div>
+                    <div
+                        v-if="tripCardTheme !== 'light'"
+                        class="trip-card-section trip-card-section--footer"
+                    >
                         <template v-if="!enableChangeSeats">
                             <div v-if="trip.seats_available !== 0" class="row">
                                 <div
@@ -541,7 +543,7 @@
                                 </div>
                             </div>
                         </template>
-                    </template>
+                    </div>
                 </div>
             </div>
         </div>
@@ -724,10 +726,6 @@ export default {
         return {
             sending: false,
             seats_available: 0,
-            CITY_NAME_LONG_LENGTH: 16,
-            LONG_NAME_STYLE: {
-                'font-size': '17px'
-            },
             showTrip: false
         };
     },
@@ -753,24 +751,6 @@ export default {
         },
         tripCardTheme() {
             return this.config ? this.config.trip_card_design : '';
-        },
-        originLongName() {
-            if (this.trip.points) {
-                let name = this.getLocationName(this.trip.points[0]);
-                return name.length > this.CITY_NAME_LONG_LENGTH;
-            } else {
-                return false;
-            }
-        },
-        destinyLongName() {
-            if (this.trip.points) {
-                let name = this.getLocationName(
-                    this.trip.points[this.trip.points.length - 1]
-                );
-                return name.length > this.CITY_NAME_LONG_LENGTH;
-            } else {
-                return false;
-            }
         },
         getUserImage() {
             if (!this.trip || !this.trip.user) {
@@ -892,6 +872,7 @@ export default {
         height: 500px;
     }
 }
+
 .trip-needs-sellado {
     opacity: 0.6;
 }

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1026,7 +1026,7 @@
       float: right;
       width: 1px;
       margin-right: 13px;
-      height: 50px;
+      min-height: 50px;
       content: '\A0';
       border: 0;
       border-left: solid 1px #777;

--- a/src/styles/main.carpoolear.css
+++ b/src/styles/main.carpoolear.css
@@ -951,11 +951,50 @@ textarea {
 
 .card-trip {
     height: 432px;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
     box-shadow: 0 0 4px 1px #CCC;
     border-radius: .4em;
 }
 
+.card-trip .card_body {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    padding-bottom: 1rem;
+}
+
+.card-trip .trip-card-section--route {
+    flex: 1 1 0;
+    min-height: 0;
+    overflow: hidden;
+    padding-bottom: 0.75rem;
+}
+
+.card-trip .trip-card-section--schedule {
+    flex: 0 0 auto;
+    padding: 0.75rem 0;
+}
+
+.card-trip .trip-card-section--schedule .row {
+    margin-left: 0;
+    margin-right: 0;
+}
+
+.card-trip .trip-card-section--footer {
+    flex: 0 0 auto;
+    margin-top: auto;
+}
+
+.card-trip .trip-card-section--footer > .row {
+    margin-bottom: 0;
+}
+
 .card-trip .card_heading {
+    flex: 0 0 auto;
     color: white;
     background: var(--trip-half-free-color);
 
@@ -1111,6 +1150,66 @@ textarea {
 
 .trip_location_to {
     color: var(--trip-mostly-free-color);
+}
+
+.card-trip .trip_location {
+    height: 100%;
+    min-height: 0;
+}
+
+.card-trip .trip_location_from {
+    margin-bottom: 0.65rem;
+}
+
+.card-trip .trip_location_to {
+    margin-top: 0;
+}
+
+.card-trip .trip_location_from,
+.card-trip .trip_location_to {
+    font-size: 1.35rem;
+    line-height: 1.25;
+}
+
+.card-trip .trip_location_from_city,
+.card-trip .trip_location_to_city {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    overflow: hidden;
+    line-height: 1.25;
+    overflow-wrap: anywhere;
+}
+
+.card-trip .trip_location_from_state-country,
+.card-trip .trip_location_to_state-country {
+    display: block;
+    min-height: 0;
+    margin-top: 0.15em;
+    line-height: 1.3;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.card-trip .trip_location-dot-line {
+    top: 1rem;
+    bottom: 1.5rem;
+    height: auto;
+}
+
+.card-trip .trip_location-dot-line > div {
+    height: 100%;
+    min-height: 2.5rem;
+}
+
+.card-trip .trip_datetime {
+    margin-top: 0;
+    margin-bottom: 0;
+    min-height: 0;
+    padding-top: 0;
+    padding-bottom: 0;
 }
 
 .trip_location_from_state-country,

--- a/src/styles/main.carpoolear.css
+++ b/src/styles/main.carpoolear.css
@@ -1157,6 +1157,65 @@ textarea {
     min-height: 0;
 }
 
+.card-trip .trip_location-routed {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+}
+
+.card-trip .trip_location-routed__row {
+    display: flex;
+    align-items: flex-start;
+    flex: 0 0 auto;
+}
+
+.card-trip .trip_location-routed__row--connector {
+    flex: 1 1 auto;
+    min-height: 0.35rem;
+    align-items: stretch;
+}
+
+.card-trip .trip_location-routed__pin-col {
+    flex: 0 0 12.5%;
+    padding-right: 0.35rem;
+}
+
+.card-trip .trip_location-routed__row--connector .trip_location-routed__pin-col {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.card-trip .trip_location-routed__text-col {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.card-trip .trip_location-routed__connector {
+    display: block;
+    width: 0;
+    height: 100%;
+    margin-right: 6px;
+    border-left: 1px dashed #777;
+}
+
+.card-trip .trip_location-routed__pin {
+    line-height: 1;
+}
+
+.card-trip .trip_location-routed__pin--from {
+    color: var(--trip-half-free-color);
+}
+
+.card-trip .trip_location-routed__pin--to {
+    color: var(--trip-mostly-free-color);
+}
+
+.card-trip .trip_location-routed .trip_location_from,
+.card-trip .trip_location-routed .trip_location_to {
+    margin: 0;
+}
+
 .card-trip .trip_location_from {
     margin-bottom: 0.65rem;
 }
@@ -1191,17 +1250,6 @@ textarea {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-}
-
-.card-trip .trip_location-dot-line {
-    top: 1rem;
-    bottom: 1.5rem;
-    height: auto;
-}
-
-.card-trip .trip_location-dot-line > div {
-    height: 100%;
-    min-height: 2.5rem;
 }
 
 .card-trip .trip_datetime {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -105,6 +105,65 @@
     min-height: 0;
 }
 
+.card-trip .trip_location-routed {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+}
+
+.card-trip .trip_location-routed__row {
+    display: flex;
+    align-items: flex-start;
+    flex: 0 0 auto;
+}
+
+.card-trip .trip_location-routed__row--connector {
+    flex: 1 1 auto;
+    min-height: 0.35rem;
+    align-items: stretch;
+}
+
+.card-trip .trip_location-routed__pin-col {
+    flex: 0 0 12.5%;
+    padding-right: 0.35rem;
+}
+
+.card-trip .trip_location-routed__row--connector .trip_location-routed__pin-col {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.card-trip .trip_location-routed__text-col {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.card-trip .trip_location-routed__connector {
+    display: block;
+    width: 0;
+    height: 100%;
+    margin-right: 6px;
+    border-left: 1px dashed #777;
+}
+
+.card-trip .trip_location-routed__pin {
+    line-height: 1;
+}
+
+.card-trip .trip_location-routed__pin--from {
+    color: var(--trip-half-free-color);
+}
+
+.card-trip .trip_location-routed__pin--to {
+    color: var(--trip-mostly-free-color);
+}
+
+.card-trip .trip_location-routed .trip_location_from,
+.card-trip .trip_location-routed .trip_location_to {
+    margin: 0;
+}
+
 .card-trip .trip_location_from {
     margin-bottom: 0.65rem;
 }
@@ -139,17 +198,6 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-}
-
-.card-trip .trip_location-dot-line {
-    top: 1rem;
-    bottom: 1.5rem;
-    height: auto;
-}
-
-.card-trip .trip_location-dot-line > div {
-    height: 100%;
-    min-height: 2.5rem;
 }
 
 .card-trip .trip_datetime {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -20,10 +20,50 @@
 }
 .card-trip {
     height: 432px;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
     box-shadow: 0 0 4px 1px #CCC;
     border-radius: .4em;
 }
+
+.card-trip .card_body {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    padding-bottom: 1rem;
+}
+
+.card-trip .trip-card-section--route {
+    flex: 1 1 0;
+    min-height: 0;
+    overflow: hidden;
+    padding-bottom: 0.75rem;
+}
+
+.card-trip .trip-card-section--schedule {
+    flex: 0 0 auto;
+    padding: 0.75rem 0;
+}
+
+.card-trip .trip-card-section--schedule .row {
+    margin-left: 0;
+    margin-right: 0;
+}
+
+.card-trip .trip-card-section--footer {
+    flex: 0 0 auto;
+    margin-top: auto;
+}
+
+.card-trip .trip-card-section--footer > .row {
+    margin-bottom: 0;
+}
+
 .card-trip .card_heading {
+    flex: 0 0 auto;
     color: white;
     background: var(--trip-half-free-color);
 
@@ -59,6 +99,65 @@
 }
 .trip_location_to.has_points {
     margin-top: 1.6rem;
+}
+.card-trip .trip_location {
+    height: 100%;
+    min-height: 0;
+}
+
+.card-trip .trip_location_from {
+    margin-bottom: 0.65rem;
+}
+
+.card-trip .trip_location_to {
+    margin-top: 0;
+}
+
+.card-trip .trip_location_from,
+.card-trip .trip_location_to {
+    font-size: 1.35rem;
+    line-height: 1.25;
+}
+
+.card-trip .trip_location_from_city,
+.card-trip .trip_location_to_city {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    overflow: hidden;
+    line-height: 1.25;
+    overflow-wrap: anywhere;
+}
+
+.card-trip .trip_location_from_state-country,
+.card-trip .trip_location_to_state-country {
+    display: block;
+    min-height: 0;
+    margin-top: 0.15em;
+    line-height: 1.3;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.card-trip .trip_location-dot-line {
+    top: 1rem;
+    bottom: 1.5rem;
+    height: auto;
+}
+
+.card-trip .trip_location-dot-line > div {
+    height: 100%;
+    min-height: 2.5rem;
+}
+
+.card-trip .trip_datetime {
+    margin-top: 0;
+    margin-bottom: 0;
+    min-height: 0;
+    padding-top: 0.15rem;
+    padding-bottom: 0.15rem;
 }
 .trip_location_from_state-country,
 .trip_location_to_state-country {


### PR DESCRIPTION
- **Equal-height cards:** Restored fixed card height (`432px`) with an internal flex layout so route, date, and footer (seats + VER) stay aligned across cards in the same row.
- **Long city names:** City names clamp to 2 lines with ellipsis; provinces use a single line with ellipsis so content stays inside the card.
- **Section spacing:** Card body split into route, schedule, and footer sections with clearer vertical spacing.
- **Route layout:** Replaced the absolute-positioned dotted connector with a row-based layout so the dashed line sits between origin and destination and stops at the destination pin (no overlap).
- **Wider text column:** Route icons use a narrower column so city names have more horizontal space.


Closes https://github.com/STS-Rosario/carpoolear/issues/206