### PR TITLE
Trip request warning

### DIFF
--- a/e2e-frontend/trip-detail.spec.js
+++ b/e2e-frontend/trip-detail.spec.js
@@ -110,6 +110,56 @@ test.describe('Trip detail page', () => {
     await expect(page.getByText('Carpooleado')).toBeVisible({ timeout: 15000 });
   });
 
+  test('shows seat requests warning link for driver with pending requests', async ({
+    page,
+  }) => {
+    await freezeClock(page);
+    await setupCatchAllMock(page);
+    await setupCommonMocks(page);
+    await setupAuthState(page);
+
+    const ownTripWithRequests = makeMockTrip(TRIP_ID, {
+      user: { ...MOCK_USER, positive_ratings: 5, negative_ratings: 0 },
+      passengerPending_count: 2,
+      seats_available: 3,
+    });
+    await setupTripRoute(page, ownTripWithRequests);
+
+    await page.goto(`/trips/${TRIP_ID}`);
+    await waitForPageReady(page);
+
+    const warningLink = page.getByRole('link', {
+      name: 'Tenés pedidos de asiento de pasajeros para este viaje, revisalos en Tus Viajes',
+    });
+    await expect(warningLink).toBeVisible({ timeout: 15000 });
+    await expect(warningLink).toHaveAttribute('href', '/my-trips');
+  });
+
+  test('does not show seat requests warning when driver has no pending requests', async ({
+    page,
+  }) => {
+    await freezeClock(page);
+    await setupCatchAllMock(page);
+    await setupCommonMocks(page);
+    await setupAuthState(page);
+
+    const ownTripWithoutRequests = makeMockTrip(TRIP_ID, {
+      user: { ...MOCK_USER, positive_ratings: 5, negative_ratings: 0 },
+      passengerPending_count: 0,
+      seats_available: 3,
+    });
+    await setupTripRoute(page, ownTripWithoutRequests);
+
+    await page.goto(`/trips/${TRIP_ID}`);
+    await waitForPageReady(page);
+
+    await expect(
+      page.getByRole('link', {
+        name: 'Tenés pedidos de asiento de pasajeros para este viaje, revisalos en Tus Viajes',
+      })
+    ).toHaveCount(0);
+  });
+
   test('renders passenger list with multiple passengers', async ({ page }) => {
     await freezeClock(page);
     await setupCatchAllMock(page);

--- a/src/components/views/Trip.view.test.js
+++ b/src/components/views/Trip.view.test.js
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const viewPath = path.resolve(__dirname, 'Trip.vue');
+const viewSource = fs.readFileSync(viewPath, 'utf8');
+
+describe('Trip.vue driver seat requests warning', () => {
+    it('shows a warning link to my-trips when the driver has pending seat requests', () => {
+        expect(viewSource).toContain('shouldShowTripSeatRequestsWarning');
+        expect(viewSource).toContain("$t('tripSeatRequestsDriverWarning')");
+        expect(viewSource).toMatch(
+            /class="alert alert-warning trip-seat-requests-warning"[\s\S]*?name: 'my-trips'/s
+        );
+        expect(viewSource).toContain('passengerPending_count');
+    });
+});

--- a/src/components/views/Trip.view.test.js
+++ b/src/components/views/Trip.view.test.js
@@ -13,5 +13,6 @@ describe('Trip.vue driver seat requests warning', () => {
             /class="alert alert-warning trip-seat-requests-warning"[\s\S]*?name: 'my-trips'/s
         );
         expect(viewSource).toContain('passengerPending_count');
+        expect(viewSource).toContain('.trip-seat-requests-warning a');
     });
 });

--- a/src/components/views/Trip.view.test.js
+++ b/src/components/views/Trip.view.test.js
@@ -13,6 +13,8 @@ describe('Trip.vue driver seat requests warning', () => {
             /class="alert alert-warning trip-seat-requests-warning"[\s\S]*?name: 'my-trips'/s
         );
         expect(viewSource).toContain('passengerPending_count');
+        expect(viewSource).toContain('fa-exclamation-triangle');
+        expect(viewSource).toContain('trip-seat-requests-warning__icon');
         expect(viewSource).toContain('.trip-seat-requests-warning a');
     });
 });

--- a/src/components/views/Trip.vue
+++ b/src/components/views/Trip.vue
@@ -17,6 +17,15 @@
                     <p>{{ $t('pagarSelladoViaje', { amount: $n(this.config.module_trip_creation_payment_amount_cents / 100, 'currency') }) }}</p>
                     <div id="walletBrick_container"></div>
                 </div>
+                <div
+                    class="alert alert-warning trip-seat-requests-warning"
+                    role="alert"
+                    v-if="showSeatRequestsWarning"
+                >
+                    <router-link :to="{ name: 'my-trips' }">
+                        {{ $t('tripSeatRequestsDriverWarning') }}
+                    </router-link>
+                </div>
                 <div class="row form">
                     <div
                         ref="rightPanel"
@@ -367,6 +376,7 @@ import svgItem from '../SvgItem';
 import modal from '../Modal';
 import dayjs from '../../dayjs';
 import dialogs from '../../services/dialogs.js';
+import { shouldShowTripSeatRequestsWarning } from '../../utils/tripSeatRequestsWarning.js';
 import TripLocation from '../elements/TripLocation';
 import TripDriver from '../elements/TripDriver';
 import TripDate from '../elements/TripDate';
@@ -1013,6 +1023,12 @@ export default {
         },
         owner() {
             return this.trip && this.user && this.user.id === this.trip.user.id;
+        },
+        showSeatRequestsWarning() {
+            return shouldShowTripSeatRequestsWarning(
+                this.owner,
+                this.trip?.passengerPending_count
+            );
         },
         isPassengersView() {
             if (this.location) {

--- a/src/components/views/Trip.vue
+++ b/src/components/views/Trip.vue
@@ -1068,6 +1068,14 @@ export default {
 </script>
 
 <style scoped>
+.trip-seat-requests-warning {
+    margin: 1rem 0;
+}
+.trip-seat-requests-warning a {
+    color: inherit;
+    font-weight: 500;
+    text-decoration: underline;
+}
 .trip-detail-component .structure-div {
     margin-top: 1rem;
     z-index: 0;

--- a/src/components/views/Trip.vue
+++ b/src/components/views/Trip.vue
@@ -22,6 +22,10 @@
                     role="alert"
                     v-if="showSeatRequestsWarning"
                 >
+                    <i
+                        class="fa fa-exclamation-triangle trip-seat-requests-warning__icon"
+                        aria-hidden="true"
+                    ></i>
                     <router-link :to="{ name: 'my-trips' }">
                         {{ $t('tripSeatRequestsDriverWarning') }}
                     </router-link>
@@ -1069,7 +1073,15 @@ export default {
 
 <style scoped>
 .trip-seat-requests-warning {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.6rem;
     margin: 1rem 0;
+}
+.trip-seat-requests-warning__icon {
+    flex-shrink: 0;
+    margin-top: 0.15rem;
+    font-size: 1.15em;
 }
 .trip-seat-requests-warning a {
     color: inherit;

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -886,6 +886,8 @@ const messages = {
         bajarmeViaje: 'Bajarme del viaje',
         finalizado: 'Finalizado',
         viajeCarpooleado: 'Viaje Carpooleado',
+        tripSeatRequestsDriverWarning:
+            'Tenés pedidos de asiento de pasajeros para este viaje, revisalos en Tus Viajes',
         atencionViajeSolicitado:
             'Atención! Este viaje está siendo muy solicitado: {count} personas lo están solicitando',
         bajarPasajeroViaje: 'Bajar pasajero del viaje',
@@ -1958,6 +1960,8 @@ const messages = {
         bajarmeViaje: 'Bajarme del viaje',
         finalizado: 'Finalizado',
         viajeCarpooleado: 'Viaje Carpooleado',
+        tripSeatRequestsDriverWarning:
+            'Tenés pedidos de asiento de pasajeros para este viaje, revisalos en Tus Viajes',
         atencionViajeSolicitado:
             'Atención! Este viaje está siendo muy solicitado: {count} personas lo están solicitando',
         bajarPasajeroViaje: 'Bajar pasajero del viaje',
@@ -3208,6 +3212,8 @@ const messages = {
         bajarmeViaje: 'Leave the trip',
         finalizado: 'Completed',
         viajeCarpooleado: 'Carpooled Trip',
+        tripSeatRequestsDriverWarning:
+            'You have passenger seat requests for this trip, review them in My Trips',
         atencionViajeSolicitado:
             'Attention! This trip is in high demand: {count} people are requesting it',
         bajarPasajeroViaje: 'Remove passenger from trip',

--- a/src/utils/tripSeatRequestsWarning.js
+++ b/src/utils/tripSeatRequestsWarning.js
@@ -1,0 +1,3 @@
+export function shouldShowTripSeatRequestsWarning(owner, passengerPendingCount) {
+    return Boolean(owner) && Number(passengerPendingCount) > 0;
+}

--- a/src/utils/tripSeatRequestsWarning.test.js
+++ b/src/utils/tripSeatRequestsWarning.test.js
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { shouldShowTripSeatRequestsWarning } from './tripSeatRequestsWarning.js';
+
+describe('shouldShowTripSeatRequestsWarning', () => {
+    it('returns true when the driver owns the trip and there are pending seat requests', () => {
+        expect(shouldShowTripSeatRequestsWarning(true, 1)).toBe(true);
+        expect(shouldShowTripSeatRequestsWarning(true, 3)).toBe(true);
+    });
+
+    it('returns false when the viewer is not the trip owner', () => {
+        expect(shouldShowTripSeatRequestsWarning(false, 2)).toBe(false);
+    });
+
+    it('returns false when there are no pending seat requests', () => {
+        expect(shouldShowTripSeatRequestsWarning(true, 0)).toBe(false);
+        expect(shouldShowTripSeatRequestsWarning(true, undefined)).toBe(false);
+        expect(shouldShowTripSeatRequestsWarning(true, null)).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
When a **driver** opens their own **trip detail** and the trip has **pending seat requests**, show a warning banner with a link to **My Trips** (`/my-trips`).
Message (ES): *"Tenés pedidos de asiento de pasajeros para este viaje, revisalos en Tus Viajes"*


Closes https://github.com/STS-Rosario/carpoolear/issues/220