### PR TITLE
Fix Facebook/Apple login deprecation copy in modal

### DIFF
--- a/src/components/views/Login.vue
+++ b/src/components/views/Login.vue
@@ -274,7 +274,7 @@
                 <template #body><div>
                     <div class="text-left color-black login-modal">
                         <p>
-                            {{ $t('ingresoRegistroYaNoFunciona') }} {{ modalType === 'facebook' ? $t('facebook') : $t('apple') }}.
+                            {{ $t('ingresoRegistroYaNoFunciona') }} {{ modalType === 'facebook' ? $t('facebook') : $t('apple') }} {{ $t('ingresoRegistroYaNoFuncionaMas') }}
                         </p>
                         <p>
                             <span>{{ $t('escribinosMesaAyudaMigracionLead') }}</span>

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -1051,6 +1051,7 @@ const messages = {
         teniasCuentaVinculada:
             '¿Tenías cuenta de Carpoolear vinculada a tu cuenta de',
         ingresoRegistroYaNoFunciona: 'El ingreso/registro via',
+        ingresoRegistroYaNoFuncionaMas: 'ya no funciona más.',
         y: 'y',
         buenasRutas: '¡Buenas rutas!',
         apple: 'Apple',
@@ -2162,9 +2163,11 @@ const messages = {
         teniasCuentaVinculada:
             '¿Tenías cuenta de Carpoolear vinculada a tu cuenta de',
         ingresoRegistroYaNoFunciona: 'El ingreso/registro via',
+        ingresoRegistroYaNoFuncionaMas: 'ya no funciona más.',
         y: 'y',
         buenasRutas: '¡Buenas rutas!',
         apple: 'Apple',
+        facebook: 'Facebook',
         notificacionesNoHabilitadas: 'No tenés habilitadas las notificaciones',
         notificacionesNoAceptastePermisos:
             'Parece que no aceptaste los permisos para que te podamos enviar notificaciones (en nuevos mensajes, etc.), presioná el botón para hacerlo:',
@@ -3407,6 +3410,7 @@ const messages = {
         teniasCuentaVinculada:
             'Did you have a Carpoolear account linked to your',
         ingresoRegistroYaNoFunciona: 'Login/registration via',
+        ingresoRegistroYaNoFuncionaMas: 'no longer works.',
         y: 'and',
         buenasRutas: 'Safe travels!',
         apple: 'Apple',

--- a/src/language/loginSocialDeprecationMessage.test.js
+++ b/src/language/loginSocialDeprecationMessage.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import messages from './i18n';
+
+/** Mirrors Login.vue modal body: prefix + provider + suffix. */
+function loginSocialDeprecationMessage(locale, modalType) {
+    const m = messages[locale];
+    const provider = modalType === 'facebook' ? m.facebook : m.apple;
+    return `${m.ingresoRegistroYaNoFunciona} ${provider} ${m.ingresoRegistroYaNoFuncionaMas}`;
+}
+
+const loginViewPath = path.resolve(
+    __dirname,
+    '../components/views/Login.vue'
+);
+const loginViewSource = fs.readFileSync(loginViewPath, 'utf8');
+
+describe('Login social deprecation message (i18n)', () => {
+    it('arg + facebook interpolates to the full Spanish sentence', () => {
+        expect(loginSocialDeprecationMessage('arg', 'facebook')).toBe(
+            'El ingreso/registro via Facebook ya no funciona más.'
+        );
+    });
+
+    it.each(['arg', 'chl'])(
+        '%s locale has facebook/apple and suffix keys for the modal',
+        (locale) => {
+            const m = messages[locale];
+            expect(m.ingresoRegistroYaNoFuncionaMas).toBe(
+                'ya no funciona más.'
+            );
+            expect(m.facebook).toBe('Facebook');
+            expect(m.apple).toBe('Apple');
+        }
+    );
+});
+
+describe('Login.vue social deprecation copy', () => {
+    it('uses ingresoRegistroYaNoFuncionaMas after the provider name', () => {
+        expect(loginViewSource).toContain("$t('ingresoRegistroYaNoFunciona')");
+        expect(loginViewSource).toContain(
+            "$t('ingresoRegistroYaNoFuncionaMas')"
+        );
+        expect(loginViewSource).not.toMatch(
+            /\$t\('apple'\)\s*\}\}\s*\./
+        );
+    });
+});


### PR DESCRIPTION
Add ingresoRegistroYaNoFuncionaMas i18n suffix so the message reads "ya no funciona más." after the provider name, and regression-test the Spanish Facebook sentence.