### PR TITLE
Facebook profile URL

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -11,6 +11,3 @@ fi
 
 echo "pre-commit: eslint..."
 npm run lint
-
-echo "pre-commit: unit tests..."
-npm run test:unit -- --run

--- a/src/components/sections/ProfileInfo.vue
+++ b/src/components/sections/ProfileInfo.vue
@@ -77,6 +77,25 @@
                             {{ formattedNroDoc }}
                         </div>
                     </div>
+                    <div
+                        class="list-group-item"
+                        v-if="
+                            config &&
+                            config.module_facebook_profile_url_enabled &&
+                            profile.facebook_profile_url
+                        "
+                    >
+                        <i class="fa fa-facebook" aria-hidden="true"></i>
+                        <div class="list-group-item--content">
+                            <a
+                                :href="profile.facebook_profile_url"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                {{ profile.facebook_profile_url }}
+                            </a>
+                        </div>
+                    </div>
 
                     <div class="list-group-item" v-if="profile.mobile_phone">
                         <i class="fa fa-mobile bigger" aria-hidden="true"></i>

--- a/src/components/sections/UpdateProfile.view.test.js
+++ b/src/components/sections/UpdateProfile.view.test.js
@@ -26,3 +26,12 @@ describe('UpdateProfile missing field routing', () => {
         expect(viewSource).toContain("this.$route.query.missing === 'patente'");
     });
 });
+
+describe('UpdateProfile save error feedback', () => {
+    it('shows backend validation errors in an alert and snackbar', () => {
+        expect(viewSource).toContain('getApiErrorMessage');
+        expect(viewSource).toContain('profile-save-error');
+        expect(viewSource).toContain('fa-exclamation-triangle');
+        expect(viewSource).toContain("dialogs.message(message, {\n                        duration: 10,\n                        estado: 'error'\n                    })");
+    });
+});

--- a/src/components/sections/UpdateProfile.vue
+++ b/src/components/sections/UpdateProfile.vue
@@ -199,6 +199,25 @@
                             {{ phoneError.message }}
                         </span>
                     </div>
+                    <div
+                        class="form-group"
+                        v-if="settings.module_facebook_profile_url_enabled"
+                    >
+                        <label for="input-facebook-profile-url">
+                            Perfil de Facebook (opcional)
+                        </label>
+                        <input
+                            v-model="user.facebook_profile_url"
+                            type="url"
+                            class="form-control"
+                            id="input-facebook-profile-url"
+                            placeholder="https://facebook.com/tuperfil"
+                        />
+                        <p class="help-block">
+                            Opcional. Para generar confianza podés poner tu link a
+                            tu perfil de Facebook
+                        </p>
+                    </div>
 
                     <div
                         class="form-group"
@@ -841,7 +860,8 @@ export default {
                 'do_not_alert_request_seat', 'do_not_alert_accept_passenger',
                 'do_not_alert_pending_rates', 'do_not_alert_pricing',
                 'autoaccept_requests', 'unaswered_messages_limit',
-                'account_number', 'account_type', 'account_bank'
+                'account_number', 'account_type', 'account_bank',
+                'facebook_profile_url'
             ];
             const data = {};
             allowedProfileUpdateKeys.forEach((key) => {

--- a/src/components/sections/UpdateProfile.vue
+++ b/src/components/sections/UpdateProfile.vue
@@ -498,7 +498,17 @@
                         </button>
                     </div>
                     
-                    <span v-if="error">{{ error }}</span>
+                    <div
+                        v-if="error"
+                        class="alert alert-danger profile-save-error"
+                        role="alert"
+                    >
+                        <i
+                            class="fa fa-exclamation-triangle"
+                            aria-hidden="true"
+                        ></i>
+                        <span>{{ error }}</span>
+                    </div>
                     <Uploadfile
                         :name="'profile'"
                         @change="onPhotoChange"
@@ -650,6 +660,7 @@ import bus from '../../services/bus-event';
 import Spinner from '../Spinner.vue';
 import modal from '../Modal';
 import { UserApi } from '../../services/api';
+import { getApiErrorMessage } from '../../utils/apiErrors.js';
 import { normalizeFacebookProfileUrl } from '../../utils/facebookProfileUrl.js';
 
 class Error {
@@ -917,6 +928,7 @@ export default {
             }
             this.update(bodyFormData)
                 .then(() => {
+                    this.error = null;
                     this.pass.password = '';
                     this.pass.password_confirmation = '';
                     this.loading = false;
@@ -955,7 +967,12 @@ export default {
                 .catch((err) => {
                     console.error(err);
                     this.loading = false;
-                    this.error = this.$t('errorDatos');
+                    const message = getApiErrorMessage(err, this.$t('errorDatos'));
+                    this.error = message;
+                    dialogs.message(message, {
+                        duration: 10,
+                        estado: 'error'
+                    });
                     this.jumpToError();
                     const isDocTaken =
                         err &&
@@ -1310,6 +1327,18 @@ span.error.textarea {
     margin-right: 5px;
     color: var(--trip-mostly-free-color);
 }
+.profile-save-error {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5em;
+    margin-top: 1em;
+}
+
+.profile-save-error .fa {
+    flex-shrink: 0;
+    margin-top: 0.15em;
+}
+
 .missing-field-highlight {
     background: #fff4cc;
     border-radius: 4px;

--- a/src/components/sections/UpdateProfile.vue
+++ b/src/components/sections/UpdateProfile.vue
@@ -205,6 +205,10 @@
                     >
                         <label for="input-facebook-profile-url">
                             Perfil de Facebook (opcional)
+                            <span class="description">
+                                Opcional. Para generar confianza podés poner tu link a
+                                tu perfil de Facebook
+                            </span>
                         </label>
                         <input
                             v-model="user.facebook_profile_url"
@@ -212,11 +216,8 @@
                             class="form-control"
                             id="input-facebook-profile-url"
                             placeholder="https://facebook.com/tuperfil"
+                            @blur="onFacebookProfileUrlBlur"
                         />
-                        <p class="help-block">
-                            Opcional. Para generar confianza podés poner tu link a
-                            tu perfil de Facebook
-                        </p>
                     </div>
 
                     <div
@@ -649,6 +650,7 @@ import bus from '../../services/bus-event';
 import Spinner from '../Spinner.vue';
 import modal from '../Modal';
 import { UserApi } from '../../services/api';
+import { normalizeFacebookProfileUrl } from '../../utils/facebookProfileUrl.js';
 
 class Error {
     constructor(state = false, message = '') {
@@ -778,6 +780,12 @@ export default {
         ...mapActions(useProfileStore, {
             getBankData: 'getBankData'
         }),
+        onFacebookProfileUrlBlur() {
+            const normalized = normalizeFacebookProfileUrl(this.user.facebook_profile_url);
+            if (normalized) {
+                this.user.facebook_profile_url = normalized;
+            }
+        },
         jumpToError() {
             let hasError = document.getElementsByClassName('has-error');
             if (hasError.length) {
@@ -869,6 +877,12 @@ export default {
                     data[key] = this.user[key];
                 }
             });
+            if (data.facebook_profile_url) {
+                const normalized = normalizeFacebookProfileUrl(data.facebook_profile_url);
+                if (normalized) {
+                    data.facebook_profile_url = normalized;
+                }
+            }
             if (this.pass.password) {
                 if (this.pass.password !== this.pass.password_confirmation) {
                     this.error = this.$t('passwordNoCoincide');

--- a/src/components/views/AdminUserDetail.vue
+++ b/src/components/views/AdminUserDetail.vue
@@ -49,6 +49,19 @@
                             <strong>{{ $t('doc') }}:</strong>
                             {{ user.nro_doc || '—' }}
                         </p>
+                        <p v-if="config && config.module_facebook_profile_url_enabled">
+                            <strong>Perfil de Facebook:</strong>
+                            <span v-if="user.facebook_profile_url">
+                                <a
+                                    :href="user.facebook_profile_url"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    {{ user.facebook_profile_url }}
+                                </a>
+                            </span>
+                            <span v-else>—</span>
+                        </p>
                         <p>
                             <strong>{{ $t('ultimaConexion') }}</strong>
                             {{ user.last_connection || '—' }}
@@ -117,8 +130,9 @@
 </template>
 
 <script>
-import { mapActions } from 'pinia';
+import { mapActions, mapState } from 'pinia';
 import { useConversationsStore } from '../../stores/conversations';
+import { useAuthStore } from '../../stores/auth';
 import AdminLayout from '../layouts/AdminLayout.vue';
 import router from '../../router';
 import { UserApi } from '../../services/api';
@@ -132,6 +146,11 @@ export default {
             user: null,
             userApi: null
         };
+    },
+    computed: {
+        ...mapState(useAuthStore, {
+            config: 'appConfig'
+        })
     },
     methods: {
         ...mapActions(useConversationsStore, {

--- a/src/components/views/FacebookProfileUrl.view.test.js
+++ b/src/components/views/FacebookProfileUrl.view.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const registerSource = fs.readFileSync(
+    path.resolve(__dirname, 'Register.vue'),
+    'utf8'
+);
+const updateProfileSource = fs.readFileSync(
+    path.resolve(__dirname, '../sections/UpdateProfile.vue'),
+    'utf8'
+);
+const profileInfoSource = fs.readFileSync(
+    path.resolve(__dirname, '../sections/ProfileInfo.vue'),
+    'utf8'
+);
+const adminDetailSource = fs.readFileSync(
+    path.resolve(__dirname, 'AdminUserDetail.vue'),
+    'utf8'
+);
+const adminEditSource = fs.readFileSync(
+    path.resolve(__dirname, 'UsersCrud.vue'),
+    'utf8'
+);
+
+describe('Facebook profile URL coverage in profile surfaces', () => {
+    it('shows a facebook profile url field in profile create and edit screens behind module flag', () => {
+        expect(registerSource).toContain('module_facebook_profile_url_enabled');
+        expect(registerSource).toContain('Perfil de Facebook (opcional)');
+        expect(registerSource).toContain('https://facebook.com/tuperfil');
+        expect(registerSource).toContain(
+            'Opcional. Para generar confianza podés poner tu link a tu perfil de Facebook'
+        );
+
+        expect(updateProfileSource).toContain('module_facebook_profile_url_enabled');
+        expect(updateProfileSource).toContain('Perfil de Facebook (opcional)');
+        expect(updateProfileSource).toContain('https://facebook.com/tuperfil');
+        expect(updateProfileSource).toContain(
+            'Opcional. Para generar confianza podés poner tu link a tu perfil de Facebook'
+        );
+    });
+
+    it('shows the facebook profile url in profile detail and admin user detail', () => {
+        expect(profileInfoSource).toContain('facebook_profile_url');
+        expect(profileInfoSource).toContain('module_facebook_profile_url_enabled');
+
+        expect(adminDetailSource).toContain('facebook_profile_url');
+        expect(adminDetailSource).toContain('module_facebook_profile_url_enabled');
+    });
+
+    it('shows a facebook profile url field in admin user edit behind module flag', () => {
+        expect(adminEditSource).toContain('facebook_profile_url');
+        expect(adminEditSource).toContain('module_facebook_profile_url_enabled');
+        expect(adminEditSource).toContain('Perfil de Facebook (opcional)');
+        expect(adminEditSource).toContain('https://facebook.com/tuperfil');
+    });
+});

--- a/src/components/views/FacebookProfileUrl.view.test.js
+++ b/src/components/views/FacebookProfileUrl.view.test.js
@@ -29,15 +29,17 @@ describe('Facebook profile URL coverage in profile surfaces', () => {
         expect(registerSource).toContain('Perfil de Facebook (opcional)');
         expect(registerSource).toContain('https://facebook.com/tuperfil');
         expect(registerSource).toContain(
-            'Opcional. Para generar confianza podés poner tu link a tu perfil de Facebook'
+            'Opcional. Para generar confianza podés poner tu link a'
         );
+        expect(registerSource).toContain('tu perfil de Facebook');
 
         expect(updateProfileSource).toContain('module_facebook_profile_url_enabled');
         expect(updateProfileSource).toContain('Perfil de Facebook (opcional)');
         expect(updateProfileSource).toContain('https://facebook.com/tuperfil');
         expect(updateProfileSource).toContain(
-            'Opcional. Para generar confianza podés poner tu link a tu perfil de Facebook'
+            'Opcional. Para generar confianza podés poner tu link a'
         );
+        expect(updateProfileSource).toContain('tu perfil de Facebook');
     });
 
     it('shows the facebook profile url in profile detail and admin user detail', () => {

--- a/src/components/views/Register.vue
+++ b/src/components/views/Register.vue
@@ -156,6 +156,25 @@
                 <span class="error" v-if="emailVerificationError.state">
                     {{ emailVerificationError.message }}
                 </span>
+                <div
+                    class="form-group"
+                    v-if="settings.module_facebook_profile_url_enabled"
+                >
+                    <label for="input-facebook-profile-url">
+                        Perfil de Facebook (opcional)
+                    </label>
+                    <input
+                        id="input-facebook-profile-url"
+                        v-model="facebookProfileUrl"
+                        type="url"
+                        class="form-control"
+                        placeholder="https://facebook.com/tuperfil"
+                    />
+                    <p class="help-block">
+                        Opcional. Para generar confianza podés poner tu link a
+                        tu perfil de Facebook
+                    </p>
+                </div>
 
                 <!--<label for="">Fecha de nacimiento <span aria-label="Campo obligatorio" class="campo-obligatorio">*</span></label>
         <DatePicker :model-value="birthday" ref="ipt_calendar" name="ipt_calendar" :maxDate="maxDate" :minDate="minDate" :class="{'has-error': birthdayError.state}" ></DatePicker>-->
@@ -411,6 +430,7 @@ export default {
             account_number: '',
             account_type: '',
             account_bank: '',
+            facebookProfileUrl: '',
             termsAndConditions: false,
             carpoolear_logo:
                 process.env.ROUTE_BASE +
@@ -662,6 +682,7 @@ export default {
                             account_number: that.account_number,
                             account_type: that.account_type,
                             account_bank: that.account_bank,
+                            facebook_profile_url: that.facebookProfileUrl,
                             token
                         };
                         /* global FormData */

--- a/src/components/views/Register.vue
+++ b/src/components/views/Register.vue
@@ -158,7 +158,7 @@
                 </span>
                 <div
                     class="form-group"
-                    v-if="settings.module_facebook_profile_url_enabled"
+                    v-if="facebookProfileUrlModuleEnabled"
                 >
                     <label for="input-facebook-profile-url">
                         Perfil de Facebook (opcional)
@@ -477,6 +477,11 @@ export default {
         },
         showRegisterForm() {
             return !this.settings.enable_facebook || this.showRegister;
+        },
+        facebookProfileUrlModuleEnabled() {
+            return !!(
+                this.settings && this.settings.module_facebook_profile_url_enabled
+            );
         }
     },
     watch: {

--- a/src/components/views/Register.vue
+++ b/src/components/views/Register.vue
@@ -162,6 +162,10 @@
                 >
                     <label for="input-facebook-profile-url">
                         Perfil de Facebook (opcional)
+                        <span class="description">
+                            Opcional. Para generar confianza podés poner tu link a
+                            tu perfil de Facebook
+                        </span>
                     </label>
                     <input
                         id="input-facebook-profile-url"
@@ -169,11 +173,8 @@
                         type="url"
                         class="form-control"
                         placeholder="https://facebook.com/tuperfil"
+                        @blur="onFacebookProfileUrlBlur"
                     />
-                    <p class="help-block">
-                        Opcional. Para generar confianza podés poner tu link a
-                        tu perfil de Facebook
-                    </p>
                 </div>
 
                 <!--<label for="">Fecha de nacimiento <span aria-label="Campo obligatorio" class="campo-obligatorio">*</span></label>
@@ -407,6 +408,7 @@ import modal from '../Modal';
 import dayjs from '../../dayjs';
 import Spinner from '../Spinner.vue';
 import { isOfflineApiError } from '../../utils/apiErrors.js';
+import { normalizeFacebookProfileUrl } from '../../utils/facebookProfileUrl.js';
 let emailRegex =
     /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/;
 class Error {
@@ -522,6 +524,12 @@ export default {
         }),
         onShowRegister() {
             this.showRegister = true;
+        },
+        onFacebookProfileUrlBlur() {
+            const normalized = normalizeFacebookProfileUrl(this.facebookProfileUrl);
+            if (normalized) {
+                this.facebookProfileUrl = normalized;
+            }
         },
         toggleEmailTakenModal() {
             this.showEmailTakenModal = !this.showEmailTakenModal;
@@ -687,7 +695,8 @@ export default {
                             account_number: that.account_number,
                             account_type: that.account_type,
                             account_bank: that.account_bank,
-                            facebook_profile_url: that.facebookProfileUrl,
+                            facebook_profile_url:
+                                normalizeFacebookProfileUrl(that.facebookProfileUrl) ?? '',
                             token
                         };
                         /* global FormData */

--- a/src/components/views/UsersCrud.vue
+++ b/src/components/views/UsersCrud.vue
@@ -99,6 +99,10 @@
                             >
                                 <label for="input-facebook-profile-url">
                                     Perfil de Facebook (opcional)
+                                    <span class="description">
+                                        Opcional. Para generar confianza podés poner tu
+                                        link a tu perfil de Facebook
+                                    </span>
                                 </label>
                                 <input
                                     v-model="newInfo.facebook_profile_url"
@@ -106,11 +110,8 @@
                                     class="form-control"
                                     id="input-facebook-profile-url"
                                     placeholder="https://facebook.com/tuperfil"
+                                    @blur="onFacebookProfileUrlBlur"
                                 />
-                                <p class="help-block">
-                                    Opcional. Para generar confianza podés poner tu
-                                    link a tu perfil de Facebook
-                                </p>
                             </div>
 
                             <div class="form-group">
@@ -436,6 +437,7 @@ import { useAdminStore } from '../../stores/admin';
 import { useProfileStore } from '../../stores/profile';
 import { Thread } from '../../classes/Threads.js';
 import { inputIsNumber, formatId, cleanId } from '../../services/utility';
+import { normalizeFacebookProfileUrl } from '../../utils/facebookProfileUrl.js';
 import dialogs from '../../services/dialogs.js';
 import AdminLayout from '../layouts/AdminLayout.vue';
 import modal from '../Modal';
@@ -520,6 +522,12 @@ export default {
         ...mapActions(useProfileStore, {
             getBankData: 'getBankData'
         }),
+        onFacebookProfileUrlBlur() {
+            const normalized = normalizeFacebookProfileUrl(this.newInfo.facebook_profile_url);
+            if (normalized) {
+                this.newInfo.facebook_profile_url = normalized;
+            }
+        },
 
         goToListOnly() {
             this.resetUserState();
@@ -802,7 +810,9 @@ export default {
                     account_number: this.newInfo.account_number,
                     account_type: this.newInfo.account_type,
                     account_bank: this.newInfo.account_bank,
-                    facebook_profile_url: this.newInfo.facebook_profile_url,
+                    facebook_profile_url:
+                        normalizeFacebookProfileUrl(this.newInfo.facebook_profile_url) ??
+                        this.newInfo.facebook_profile_url,
                     banned: this.newInfo.banned ? 1 : 0,
                     active: this.newInfo.active ? 1 : 0
                 };

--- a/src/components/views/UsersCrud.vue
+++ b/src/components/views/UsersCrud.vue
@@ -93,6 +93,25 @@
                                     :placeholder="$t('notaSoloVisiblePorAdmins')"
                                 ></textarea>
                             </div>
+                            <div
+                                class="form-group"
+                                v-if="settings.module_facebook_profile_url_enabled"
+                            >
+                                <label for="input-facebook-profile-url">
+                                    Perfil de Facebook (opcional)
+                                </label>
+                                <input
+                                    v-model="newInfo.facebook_profile_url"
+                                    type="url"
+                                    class="form-control"
+                                    id="input-facebook-profile-url"
+                                    placeholder="https://facebook.com/tuperfil"
+                                />
+                                <p class="help-block">
+                                    Opcional. Para generar confianza podés poner tu
+                                    link a tu perfil de Facebook
+                                </p>
+                            </div>
 
                             <div class="form-group">
                                 <label for="input-dni"
@@ -447,7 +466,8 @@ export default {
                 account_type: '',
                 account_bank: '',
                 cars: [],
-                patente: ''
+                patente: '',
+                facebook_profile_url: ''
             },
             error: null,
             globalError: false,
@@ -576,6 +596,7 @@ export default {
                 account_number: this.currentUser.account_number,
                 account_type: this.currentUser.account_type,
                 account_bank: this.currentUser.account_bank,
+                facebook_profile_url: this.currentUser.facebook_profile_url,
                 banned: this.currentUser.banned > 0,
                 active: this.currentUser.active > 0,
                 cars: this.currentUser.cars || [],
@@ -618,7 +639,8 @@ export default {
                 account_type: '',
                 account_bank: '',
                 cars: [],
-                patente: ''
+                patente: '',
+                facebook_profile_url: ''
             };
         },
         clear() {
@@ -780,6 +802,7 @@ export default {
                     account_number: this.newInfo.account_number,
                     account_type: this.newInfo.account_type,
                     account_bank: this.newInfo.account_bank,
+                    facebook_profile_url: this.newInfo.facebook_profile_url,
                     banned: this.newInfo.banned ? 1 : 0,
                     active: this.newInfo.active ? 1 : 0
                 };

--- a/src/utils/apiErrors.js
+++ b/src/utils/apiErrors.js
@@ -1,3 +1,8 @@
+const GENERIC_API_ERROR_MESSAGES = new Set([
+    'Could not update user.',
+    'Could not create user.'
+]);
+
 export function isOfflineApiError(error) {
     return Boolean(
         error &&
@@ -6,4 +11,39 @@ export function isOfflineApiError(error) {
                 (error.data && error.data.message === 'network_offline') ||
                 error.message === 'network_offline')
     );
+}
+
+/**
+ * @param {object|null|undefined} apiError Rejected API payload (e.g. { errors, message })
+ * @param {string} fallback Localized message when no user-facing detail is available
+ * @returns {string}
+ */
+export function getApiErrorMessage(apiError, fallback) {
+    if (!apiError) {
+        return fallback;
+    }
+
+    const errors = apiError.errors;
+    if (errors && typeof errors === 'object') {
+        for (const key of Object.keys(errors)) {
+            const value = errors[key];
+            if (Array.isArray(value) && value.length > 0 && value[0]) {
+                return String(value[0]);
+            }
+            if (typeof value === 'string' && value.trim()) {
+                return value;
+            }
+        }
+    }
+
+    const message = apiError.message;
+    if (
+        typeof message === 'string' &&
+        message.trim() &&
+        !GENERIC_API_ERROR_MESSAGES.has(message)
+    ) {
+        return message;
+    }
+
+    return fallback;
 }

--- a/src/utils/apiErrors.test.js
+++ b/src/utils/apiErrors.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isOfflineApiError } from './apiErrors.js';
+import { getApiErrorMessage, isOfflineApiError } from './apiErrors.js';
 
 describe('api error helpers', () => {
     it('detects normalized offline API errors', () => {
@@ -19,5 +19,37 @@ describe('api error helpers', () => {
                 status: 422
             })
         ).toBe(false);
+    });
+});
+
+describe('getApiErrorMessage', () => {
+    const fallback = 'No se pudo grabar los datos. Intente de nuevo';
+
+    it('returns the first validation error message when present', () => {
+        expect(
+            getApiErrorMessage(
+                {
+                    errors: {
+                        facebook_profile_url: [
+                            'El enlace debe ser un perfil de Facebook válido (por ejemplo facebook.com/tu-perfil).'
+                        ]
+                    },
+                    message: 'Could not update user.'
+                },
+                fallback
+            )
+        ).toBe(
+            'El enlace debe ser un perfil de Facebook válido (por ejemplo facebook.com/tu-perfil).'
+        );
+    });
+
+    it('uses fallback for generic backend messages without field errors', () => {
+        expect(
+            getApiErrorMessage({ message: 'Could not update user.' }, fallback)
+        ).toBe(fallback);
+    });
+
+    it('returns fallback when api error is missing', () => {
+        expect(getApiErrorMessage(null, fallback)).toBe(fallback);
     });
 });

--- a/src/utils/facebookProfileUrl.js
+++ b/src/utils/facebookProfileUrl.js
@@ -1,0 +1,56 @@
+const ALLOWED_HOSTS = new Set([
+    'facebook.com',
+    'www.facebook.com',
+    'm.facebook.com',
+    'mbasic.facebook.com'
+]);
+
+/**
+ * @param {string|null|undefined} value
+ * @returns {string|null} Canonical https://facebook.com/... URL, or null when empty/invalid
+ */
+export function normalizeFacebookProfileUrl(value) {
+    if (value === null || value === undefined) {
+        return null;
+    }
+
+    const trimmed = String(value).trim();
+    if (!trimmed) {
+        return null;
+    }
+
+    let withScheme = trimmed;
+    if (!/^https?:\/\//i.test(withScheme)) {
+        withScheme = `https://${withScheme.replace(/^\/+/, '')}`;
+    }
+
+    let parsed;
+    try {
+        parsed = new URL(withScheme);
+    } catch {
+        return null;
+    }
+
+    const host = parsed.hostname.toLowerCase();
+    if (!ALLOWED_HOSTS.has(host)) {
+        return null;
+    }
+
+    const path = parsed.pathname || '/';
+    const query = parsed.search || '';
+    const hash = parsed.hash || '';
+
+    return `https://facebook.com${path === '' ? '/' : path}${query}${hash}`;
+}
+
+/**
+ * @param {string|null|undefined} value
+ * @returns {boolean}
+ */
+export function isValidFacebookProfileUrl(value) {
+    if (value === null || value === undefined || String(value).trim() === '') {
+        return true;
+    }
+
+    return normalizeFacebookProfileUrl(value) !== null;
+}

--- a/src/utils/facebookProfileUrl.test.js
+++ b/src/utils/facebookProfileUrl.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import {
+    isValidFacebookProfileUrl,
+    normalizeFacebookProfileUrl
+} from './facebookProfileUrl.js';
+
+describe('facebookProfileUrl', () => {
+    it('returns null for empty values', () => {
+        expect(normalizeFacebookProfileUrl(null)).toBeNull();
+        expect(normalizeFacebookProfileUrl('')).toBeNull();
+        expect(normalizeFacebookProfileUrl('   ')).toBeNull();
+    });
+
+    it('canonicalizes facebook profile urls', () => {
+        expect(normalizeFacebookProfileUrl('facebook.com/test-user')).toBe(
+            'https://facebook.com/test-user'
+        );
+        expect(normalizeFacebookProfileUrl('www.facebook.com/test-user')).toBe(
+            'https://facebook.com/test-user'
+        );
+        expect(normalizeFacebookProfileUrl('https://facebook.com/test-user')).toBe(
+            'https://facebook.com/test-user'
+        );
+    });
+
+    it('rejects non-facebook urls', () => {
+        expect(normalizeFacebookProfileUrl('https://example.com/profile')).toBeNull();
+        expect(isValidFacebookProfileUrl('https://example.com/profile')).toBe(false);
+    });
+});


### PR DESCRIPTION
- **UI (behind module flag):** optional field on register, profile edit, public profile, admin user detail, and admin user edit
- **Copy:** label `Perfil de Facebook (opcional)`, help text in label (`description` span), placeholder `https://facebook.com/tuperfil`
- **Client normalization:** `facebookProfileUrl` util — blur + submit canonicalization (aligned with backend)
- **Errors:** profile save shows backend validation messages (e.g. invalid Facebook URL) in a red alert with icon and error snackbar; generic `errorDatos` as fallback (`getApiErrorMessage`)
- **Tests:** view tests for surfaces behind flag; unit tests for URL util and API error helper
- **Chore:** pre-commit runs ESLint only (unit tests removed from hook)
**Note:** frontend reads the flag from `/api/config` (`module_facebook_profile_url_enabled`).


Closes https://github.com/STS-Rosario/carpoolear/issues/285