### PR TITLE
Restore full blue background on carpooleado trip cards

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1117,7 +1117,7 @@
       color: var(--trip-mostly-free-color);
       border-color: var(--trip-mostly-free-color);
   }
-  .trip-fill .card_heading {
+  .trip-fill .card-trip .card_heading {
       box-shadow: none;
       background: transparent;
       border: none;

--- a/src/styles/main.carpoolear.css
+++ b/src/styles/main.carpoolear.css
@@ -1355,7 +1355,7 @@ textarea {
     border-color: var(--trip-mostly-free-color);
 }
 
-.trip-fill .card_heading {
+.trip-fill .card-trip .card_heading {
     box-shadow: none;
     background: transparent;
     border: none;

--- a/src/styles/main.example.css
+++ b/src/styles/main.example.css
@@ -985,7 +985,7 @@ textarea {
     color: var(--trip-mostly-free-color);
     border-color: var(--trip-mostly-free-color);
 }
-.trip-fill .card_heading {
+.trip-fill .card-trip .card_heading {
     box-shadow: none;
     background: transparent;
     border: none;


### PR DESCRIPTION
Increase trip-fill header selector specificity so it overrides the default orange card heading and the card renders entirely blue when full.