### PR TITLE
Allow editing names

### DIFF
--- a/src/components/sections/UpdateProfile.view.test.js
+++ b/src/components/sections/UpdateProfile.view.test.js
@@ -49,3 +49,22 @@ describe('UpdateProfile save error feedback', () => {
         expect(viewSource).toContain("dialogs.message(message, {\n                        duration: 10,\n                        estado: 'error'\n                    })");
     });
 });
+
+describe('UpdateProfile name editing', () => {
+    it('locks the name field when identity is validated', () => {
+        expect(viewSource).toContain('isNameLockedByValidation');
+        expect(viewSource).toContain(':disabled="isNameLockedByValidation"');
+        expect(viewSource).toContain('identity_validated');
+        expect(viewSource).toContain('identity_validated_at');
+    });
+
+    it('includes name in the profile save payload when identity is not validated', () => {
+        expect(viewSource).toContain('isNameLockedByValidation');
+        expect(viewSource).toContain("data['name'] = this.user.name");
+    });
+
+    it('shows support contact hint when name is locked', () => {
+        expect(viewSource).toContain('nameInputTitle');
+        expect(viewSource).toContain('nombreValidadoContacteSoporte');
+    });
+});

--- a/src/components/sections/UpdateProfile.vue
+++ b/src/components/sections/UpdateProfile.vue
@@ -782,15 +782,18 @@ export default {
                 return this.user.nro_doc;
             }
         },
-        isDniLockedByValidation() {
+        isIdentityValidated() {
             return !!(
                 this.user &&
                 this.user.identity_validated &&
                 this.user.identity_validated_at
             );
         },
+        isDniLockedByValidation() {
+            return this.isIdentityValidated;
+        },
         isNameLockedByValidation() {
-            return this.isDniLockedByValidation;
+            return this.isIdentityValidated;
         },
         dniInputTitle() {
             return this.isDniLockedByValidation

--- a/src/components/sections/UpdateProfile.vue
+++ b/src/components/sections/UpdateProfile.vue
@@ -86,7 +86,8 @@
                             id="input-name"
                             :placeholder="$t('placeholderNombre')"
                             :class="{ 'has-error': nombreError.state }"
-                            :disabled="!firstTime"
+                            :disabled="isNameLockedByValidation"
+                            :title="nameInputTitle"
                         />
                         <span class="error" v-if="nombreError.state">
                             {{ nombreError.message }}
@@ -788,9 +789,17 @@ export default {
                 this.user.identity_validated_at
             );
         },
+        isNameLockedByValidation() {
+            return this.isDniLockedByValidation;
+        },
         dniInputTitle() {
             return this.isDniLockedByValidation
                 ? this.$t('dniValidadoContacteSoporte')
+                : '';
+        },
+        nameInputTitle() {
+            return this.isNameLockedByValidation
+                ? this.$t('nombreValidadoContacteSoporte')
                 : '';
         },
         iptPhone() {
@@ -975,7 +984,7 @@ export default {
             if (this.user && this.user.nro_doc) {
                 this.user.nro_doc = cleanId(this.user.nro_doc, this.config.profile_id_format);
             }
-            // Only send properties the backend allows for profile edit (name/email are read-only)
+            // Only send properties the backend allows for profile edit (email is read-only)
             const allowedProfileUpdateKeys = [
                 'birthday', 'gender', 'description', 'mobile_phone', 'emails_notifications',
                 'nro_doc', 'data_visibility',
@@ -991,6 +1000,9 @@ export default {
                     data[key] = this.user[key];
                 }
             });
+            if (!this.isNameLockedByValidation && this.user.name !== undefined) {
+                data['name'] = this.user.name;
+            }
             if (data.facebook_profile_url) {
                 const normalized = normalizeFacebookProfileUrl(data.facebook_profile_url);
                 if (normalized) {

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -1028,6 +1028,8 @@ const messages = {
         tituloCampoRequerido: 'Campo requerido',
         dniValidadoContacteSoporte:
             'Su cuenta ya fue verificada; para editar el DNI contacte a la mesa de ayuda.',
+        nombreValidadoContacteSoporte:
+            'Su cuenta ya fue verificada; para editar el nombre contacte a la mesa de ayuda.',
         ultimaConexion: 'Última conexión:',
         verMasMensajes: 'Ver más mensajes',
         escribirMensaje: 'Escribir mensaje...',
@@ -2177,6 +2179,8 @@ const messages = {
         tituloCampoRequerido: 'Required field',
         dniValidadoContacteSoporte:
             'Su cuenta ya fue verificada; para editar el DNI contacte a la mesa de ayuda.',
+        nombreValidadoContacteSoporte:
+            'Su cuenta ya fue verificada; para editar el nombre contacte a la mesa de ayuda.',
         ultimaConexion: 'Última conexión:',
         verMasMensajes: 'Ver más mensajes',
         escribirMensaje: 'Escribir mensaje...',
@@ -3474,6 +3478,8 @@ const messages = {
         tituloCampoRequerido: 'Required field',
         dniValidadoContacteSoporte:
             'Your account has been verified; to edit your document number contact the help desk.',
+        nombreValidadoContacteSoporte:
+            'Your account has been verified; to edit your name contact the help desk.',
         ultimaConexion: 'Last connection:',
         verMasMensajes: 'View more messages',
         escribirMensaje: 'Write message...',


### PR DESCRIPTION
- **UpdateProfile:** name field enabled until identity is validated; disabled afterward (same rule as DNI)
- Includes `name` in the save payload only when identity is not validated
- Added `nombreValidadoContacteSoporte` tooltip/i18n (ES + EN)
- Added view tests for field locking, save payload, and support hint
