### PR TITLE
Support: old age color

### DIFF
--- a/src/components/views/AdminSupportTickets.view.test.js
+++ b/src/components/views/AdminSupportTickets.view.test.js
@@ -76,4 +76,9 @@ describe('AdminSupportTickets view', () => {
         expect(viewSource).toContain("{{ $t('editarPlantillasRespuestas') }}");
         expect(viewSource).toContain("name: 'admin-support-reply-templates'");
     });
+
+    it('highlights stale updated timestamps that need admin attention', () => {
+        expect(viewSource).toContain(':class="updatedAgeAttentionClass(ticket)"');
+        expect(viewSource).toContain('getUpdatedAgeAttentionClass');
+    });
 });

--- a/src/components/views/AdminSupportTickets.vue
+++ b/src/components/views/AdminSupportTickets.vue
@@ -51,7 +51,11 @@
                         </td>
                         <td class="support-tickets-table__narrow"><span :class="priorityClass(ticket.priority)">{{ priorityLabel(ticket.priority) }}</span></td>
                         <td class="support-tickets-table__narrow" :title="fullDate(ticket.created_at)">{{ relativeDate(ticket.created_at) }}</td>
-                        <td class="support-tickets-table__narrow" :title="fullDate(ticket.updated_at)">{{ relativeDate(ticket.updated_at) }}</td>
+                        <td
+                            class="support-tickets-table__narrow"
+                            :class="updatedAgeAttentionClass(ticket)"
+                            :title="fullDate(ticket.updated_at)"
+                        >{{ relativeDate(ticket.updated_at) }}</td>
                         <td class="support-tickets-table__narrow"><span :class="statusClass(ticket.status)">{{ statusLabel(ticket.status) }}</span></td>
                         <td class="support-tickets-table__narrow">{{ ticketCategoryLabel(ticket.type) }}</td>
                     </tr>
@@ -71,6 +75,7 @@ import {
     TICKET_STATUS_CLASS_MAP,
     TICKET_STATUS_LABEL_KEYS as STATUS_LABEL_KEYS
 } from '../../utils/supportTicketStatusLabels';
+import { getUpdatedAgeAttentionClass, hasUnreadAdminMessages } from '../../utils/supportTicketUpdatedAgeAttention';
 
 function userAppProfileLocation(userId) {
     return { name: 'profile', params: { id: userId } };
@@ -113,6 +118,9 @@ export default {
             if (!value) return '-';
             return dayjs(value).fromNow();
         },
+        updatedAgeAttentionClass(ticket) {
+            return getUpdatedAgeAttentionClass(ticket);
+        },
         statusLabel(status) {
             if (STATUS_LABEL_KEYS[status]) return this.$t(STATUS_LABEL_KEYS[status]);
             return status || '-';
@@ -134,7 +142,7 @@ export default {
             }[key] || 'label label-default';
         },
         hasUserLastReply(ticket) {
-            return Number(ticket && ticket.unread_for_admin) > 0;
+            return hasUnreadAdminMessages(ticket);
         },
         canLinkTicketOwnerProfile(ticket) {
             return Boolean(ticket && ticket.user && ticket.user.id);

--- a/src/styles/supportTicketsTableCompact.css
+++ b/src/styles/supportTicketsTableCompact.css
@@ -23,3 +23,13 @@
 .support-tickets-table__owner {
     margin-left: 4px;
 }
+
+.support-tickets-table__updated--warning {
+    font-weight: bold;
+    color: #8a6d3b;
+}
+
+.support-tickets-table__updated--critical {
+    font-weight: bold;
+    color: #a94442;
+}

--- a/src/styles/supportTicketsTableCompact.test.js
+++ b/src/styles/supportTicketsTableCompact.test.js
@@ -23,4 +23,12 @@ describe('supportTicketsTableCompact.css', () => {
         expect(css).not.toMatch(/width:\s*40%/);
         expect(css).toMatch(/\.support-tickets-table__subject[\s\S]*?width:\s*100%/);
     });
+
+    it('styles stale updated cells with warning and critical emphasis', () => {
+        const css = readCompactCss();
+        expect(css).toMatch(/\.support-tickets-table__updated--warning[\s\S]*?font-weight:\s*bold/);
+        expect(css).toMatch(/\.support-tickets-table__updated--warning[\s\S]*?color:\s*#8a6d3b/);
+        expect(css).toMatch(/\.support-tickets-table__updated--critical[\s\S]*?font-weight:\s*bold/);
+        expect(css).toMatch(/\.support-tickets-table__updated--critical[\s\S]*?color:\s*#a94442/);
+    });
 });

--- a/src/utils/supportTicketUpdatedAgeAttention.js
+++ b/src/utils/supportTicketUpdatedAgeAttention.js
@@ -11,9 +11,13 @@ export const UPDATED_AGE_ATTENTION_CLASS_BY_LEVEL = {
     critical: 'support-tickets-table__updated--critical'
 };
 
+export function hasUnreadAdminMessages(ticket) {
+    return Number(ticket && ticket.unread_for_admin) > 0;
+}
+
 export function ticketNeedsAdminAttention(ticket) {
     if (!ticket) return false;
-    if (Number(ticket.unread_for_admin) > 0) return true;
+    if (hasUnreadAdminMessages(ticket)) return true;
     return ADMIN_ATTENTION_STATUSES.has(ticket.status);
 }
 

--- a/src/utils/supportTicketUpdatedAgeAttention.js
+++ b/src/utils/supportTicketUpdatedAgeAttention.js
@@ -6,6 +6,11 @@ export const ADMIN_ATTENTION_STATUSES = new Set(['En revision', 'Necesita revisi
 export const SUPPORT_TICKET_UPDATED_WARNING_DAYS = 2;
 export const SUPPORT_TICKET_UPDATED_CRITICAL_DAYS = 4;
 
+export const UPDATED_AGE_ATTENTION_CLASS_BY_LEVEL = {
+    warning: 'support-tickets-table__updated--warning',
+    critical: 'support-tickets-table__updated--critical'
+};
+
 export function ticketNeedsAdminAttention(ticket) {
     if (!ticket) return false;
     if (Number(ticket.unread_for_admin) > 0) return true;
@@ -18,4 +23,10 @@ export function getUpdatedAgeAttentionLevel(updatedAt, now = dayjs()) {
     if (days >= SUPPORT_TICKET_UPDATED_CRITICAL_DAYS) return 'critical';
     if (days >= SUPPORT_TICKET_UPDATED_WARNING_DAYS) return 'warning';
     return null;
+}
+
+export function getUpdatedAgeAttentionClass(ticket, now = dayjs()) {
+    if (!ticketNeedsAdminAttention(ticket)) return '';
+    const level = getUpdatedAgeAttentionLevel(ticket.updated_at, now);
+    return UPDATED_AGE_ATTENTION_CLASS_BY_LEVEL[level] || '';
 }

--- a/src/utils/supportTicketUpdatedAgeAttention.js
+++ b/src/utils/supportTicketUpdatedAgeAttention.js
@@ -1,8 +1,8 @@
 /** Statuses where admins are expected to take action (excluding user-wait states). */
-export const ADMIN_ATTENTION_STATUSES = ['En revision', 'Necesita revisión'];
+export const ADMIN_ATTENTION_STATUSES = new Set(['En revision', 'Necesita revisión']);
 
 export function ticketNeedsAdminAttention(ticket) {
     if (!ticket) return false;
     if (Number(ticket.unread_for_admin) > 0) return true;
-    return ADMIN_ATTENTION_STATUSES.includes(ticket.status);
+    return ADMIN_ATTENTION_STATUSES.has(ticket.status);
 }

--- a/src/utils/supportTicketUpdatedAgeAttention.js
+++ b/src/utils/supportTicketUpdatedAgeAttention.js
@@ -1,8 +1,21 @@
+import dayjs from '../dayjs';
+
 /** Statuses where admins are expected to take action (excluding user-wait states). */
 export const ADMIN_ATTENTION_STATUSES = new Set(['En revision', 'Necesita revisión']);
+
+export const SUPPORT_TICKET_UPDATED_WARNING_DAYS = 2;
+export const SUPPORT_TICKET_UPDATED_CRITICAL_DAYS = 4;
 
 export function ticketNeedsAdminAttention(ticket) {
     if (!ticket) return false;
     if (Number(ticket.unread_for_admin) > 0) return true;
     return ADMIN_ATTENTION_STATUSES.has(ticket.status);
+}
+
+export function getUpdatedAgeAttentionLevel(updatedAt, now = dayjs()) {
+    if (!updatedAt) return null;
+    const days = dayjs(now).diff(dayjs(updatedAt), 'day');
+    if (days >= SUPPORT_TICKET_UPDATED_CRITICAL_DAYS) return 'critical';
+    if (days >= SUPPORT_TICKET_UPDATED_WARNING_DAYS) return 'warning';
+    return null;
 }

--- a/src/utils/supportTicketUpdatedAgeAttention.js
+++ b/src/utils/supportTicketUpdatedAgeAttention.js
@@ -1,0 +1,8 @@
+/** Statuses where admins are expected to take action (excluding user-wait states). */
+export const ADMIN_ATTENTION_STATUSES = ['En revision', 'Necesita revisión'];
+
+export function ticketNeedsAdminAttention(ticket) {
+    if (!ticket) return false;
+    if (Number(ticket.unread_for_admin) > 0) return true;
+    return ADMIN_ATTENTION_STATUSES.includes(ticket.status);
+}

--- a/src/utils/supportTicketUpdatedAgeAttention.test.js
+++ b/src/utils/supportTicketUpdatedAgeAttention.test.js
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { ticketNeedsAdminAttention } from './supportTicketUpdatedAgeAttention.js';
+import dayjs from '../dayjs';
+import {
+    ticketNeedsAdminAttention,
+    getUpdatedAgeAttentionLevel
+} from './supportTicketUpdatedAgeAttention.js';
 
 describe('ticketNeedsAdminAttention', () => {
     it('returns true when the user replied and admin has unread messages', () => {
@@ -21,5 +25,27 @@ describe('ticketNeedsAdminAttention', () => {
     it('returns false for resolved or closed tickets', () => {
         expect(ticketNeedsAdminAttention({ status: 'Resuelto', unread_for_admin: 0 })).toBe(false);
         expect(ticketNeedsAdminAttention({ status: 'Cerrado', unread_for_admin: 0 })).toBe(false);
+    });
+});
+
+describe('getUpdatedAgeAttentionLevel', () => {
+    const now = dayjs('2026-05-29T12:00:00');
+
+    it('returns null when updated less than 2 days ago', () => {
+        expect(getUpdatedAgeAttentionLevel('2026-05-28T12:00:00', now)).toBeNull();
+    });
+
+    it('returns warning when updated at least 2 days but less than 4 days ago', () => {
+        expect(getUpdatedAgeAttentionLevel('2026-05-27T12:00:00', now)).toBe('warning');
+        expect(getUpdatedAgeAttentionLevel('2026-05-26T12:01:00', now)).toBe('warning');
+    });
+
+    it('returns critical when updated 4 days ago or older', () => {
+        expect(getUpdatedAgeAttentionLevel('2026-05-25T12:00:00', now)).toBe('critical');
+        expect(getUpdatedAgeAttentionLevel('2026-05-20T08:00:00', now)).toBe('critical');
+    });
+
+    it('returns null when updated_at is missing', () => {
+        expect(getUpdatedAgeAttentionLevel(null, now)).toBeNull();
     });
 });

--- a/src/utils/supportTicketUpdatedAgeAttention.test.js
+++ b/src/utils/supportTicketUpdatedAgeAttention.test.js
@@ -2,7 +2,8 @@ import { describe, it, expect } from 'vitest';
 import dayjs from '../dayjs';
 import {
     ticketNeedsAdminAttention,
-    getUpdatedAgeAttentionLevel
+    getUpdatedAgeAttentionLevel,
+    getUpdatedAgeAttentionClass
 } from './supportTicketUpdatedAgeAttention.js';
 
 describe('ticketNeedsAdminAttention', () => {
@@ -47,5 +48,41 @@ describe('getUpdatedAgeAttentionLevel', () => {
 
     it('returns null when updated_at is missing', () => {
         expect(getUpdatedAgeAttentionLevel(null, now)).toBeNull();
+    });
+});
+
+describe('getUpdatedAgeAttentionClass', () => {
+    const now = dayjs('2026-05-29T12:00:00');
+
+    it('returns empty string when ticket does not need admin attention', () => {
+        expect(getUpdatedAgeAttentionClass({
+            status: 'Esperando respuesta',
+            unread_for_admin: 0,
+            updated_at: '2026-05-20T08:00:00'
+        }, now)).toBe('');
+    });
+
+    it('returns warning class when attention is needed and updated 2+ days ago', () => {
+        expect(getUpdatedAgeAttentionClass({
+            status: 'En revision',
+            unread_for_admin: 0,
+            updated_at: '2026-05-27T12:00:00'
+        }, now)).toBe('support-tickets-table__updated--warning');
+    });
+
+    it('returns critical class when attention is needed and updated 4+ days ago', () => {
+        expect(getUpdatedAgeAttentionClass({
+            status: 'En revision',
+            unread_for_admin: 0,
+            updated_at: '2026-05-25T12:00:00'
+        }, now)).toBe('support-tickets-table__updated--critical');
+    });
+
+    it('returns empty string when attention is needed but updated recently', () => {
+        expect(getUpdatedAgeAttentionClass({
+            status: 'En revision',
+            unread_for_admin: 0,
+            updated_at: '2026-05-28T12:00:00'
+        }, now)).toBe('');
     });
 });

--- a/src/utils/supportTicketUpdatedAgeAttention.test.js
+++ b/src/utils/supportTicketUpdatedAgeAttention.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { ticketNeedsAdminAttention } from './supportTicketUpdatedAgeAttention.js';
+
+describe('ticketNeedsAdminAttention', () => {
+    it('returns true when the user replied and admin has unread messages', () => {
+        expect(ticketNeedsAdminAttention({ status: 'Esperando respuesta', unread_for_admin: 1 })).toBe(true);
+    });
+
+    it('returns true for tickets in En revision status', () => {
+        expect(ticketNeedsAdminAttention({ status: 'En revision', unread_for_admin: 0 })).toBe(true);
+    });
+
+    it('returns true for tickets that need review', () => {
+        expect(ticketNeedsAdminAttention({ status: 'Necesita revisión', unread_for_admin: 0 })).toBe(true);
+    });
+
+    it('returns false when waiting on the user without unread admin messages', () => {
+        expect(ticketNeedsAdminAttention({ status: 'Esperando respuesta', unread_for_admin: 0 })).toBe(false);
+    });
+
+    it('returns false for resolved or closed tickets', () => {
+        expect(ticketNeedsAdminAttention({ status: 'Resuelto', unread_for_admin: 0 })).toBe(false);
+        expect(ticketNeedsAdminAttention({ status: 'Cerrado', unread_for_admin: 0 })).toBe(false);
+    });
+});


### PR DESCRIPTION
- Adds `supportTicketUpdatedAgeAttention` utility to detect tickets needing admin action:
  - Unread user reply (`unread_for_admin > 0`)
  - Status `En revision` or `Necesita revisión`
- Applies emphasis on the **Actualizado** column when `updated_at` is old:
  - **2+ days:** bold + warning tone
  - **4+ days:** bold + red tone
- Wires styling into `AdminSupportTickets.vue` and shared `supportTicketsTableCompact.css`
- Reuses `hasUnreadAdminMessages` for the existing “last reply from user” icon
- Unit tests cover attention detection, age thresholds, CSS classes, view wiring, and styles
