### PR TITLE
Support ticket color: not for solved

### DIFF
--- a/src/components/views/AdminSupportTickets.view.test.js
+++ b/src/components/views/AdminSupportTickets.view.test.js
@@ -72,6 +72,7 @@ describe('AdminSupportTickets view', () => {
 
     it('shows icon marker when user was last to reply', () => {
         expect(viewSource).toContain('hasUserLastReply(ticket)');
+        expect(viewSource).toContain('hasUnreadUserReplyIndicator');
         expect(viewSource).toContain('glyphicon glyphicon-comment');
     });
 

--- a/src/components/views/AdminSupportTickets.vue
+++ b/src/components/views/AdminSupportTickets.vue
@@ -108,7 +108,7 @@ import { USER_TICKET_TYPE_OPTIONS } from '../../utils/supportTicketTypeOptions';
 import {
     parseAdminSupportTicketListFiltersFromRoute
 } from '../../utils/adminSupportTicketListFilters';
-import { getUpdatedAgeAttentionClass, hasUnreadAdminMessages } from '../../utils/supportTicketUpdatedAgeAttention';
+import { getUpdatedAgeAttentionClass, hasUnreadUserReplyIndicator } from '../../utils/supportTicketUpdatedAgeAttention';
 
 function userAppProfileLocation(userId) {
     return { name: 'profile', params: { id: userId } };
@@ -231,7 +231,7 @@ export default {
             }[key] || 'label label-default';
         },
         hasUserLastReply(ticket) {
-            return hasUnreadAdminMessages(ticket);
+            return hasUnreadUserReplyIndicator(ticket);
         },
         canLinkTicketOwnerProfile(ticket) {
             return Boolean(ticket && ticket.user && ticket.user.id);

--- a/src/utils/supportTicketStatusLabels.js
+++ b/src/utils/supportTicketStatusLabels.js
@@ -14,9 +14,14 @@ export const USER_TICKET_STATUS_LABEL_KEYS = {
     'Esperando respuesta': 'ticketEstadoEsperandoTuRespuesta'
 };
 
+/** Completed ticket statuses that should not use admin attention styling. */
+export const SOLVED_TICKET_STATUSES = new Set(['Resuelto', 'Cerrado']);
+
+export const SOLVED_TICKET_NEUTRAL_CLASS = 'label label-default';
+
 export const TICKET_STATUS_CLASS_MAP = {
-    Cerrado: 'label label-default',
-    Resuelto: 'label label-default',
+    Cerrado: SOLVED_TICKET_NEUTRAL_CLASS,
+    Resuelto: SOLVED_TICKET_NEUTRAL_CLASS,
     'Esperando respuesta': 'label label-warning',
     'En revision': 'label label-info',
     'Necesita revisión': 'label label-danger'

--- a/src/utils/supportTicketStatusLabels.js
+++ b/src/utils/supportTicketStatusLabels.js
@@ -16,7 +16,7 @@ export const USER_TICKET_STATUS_LABEL_KEYS = {
 
 export const TICKET_STATUS_CLASS_MAP = {
     Cerrado: 'label label-default',
-    Resuelto: 'label label-success',
+    Resuelto: 'label label-default',
     'Esperando respuesta': 'label label-warning',
     'En revision': 'label label-info',
     'Necesita revisión': 'label label-danger'

--- a/src/utils/supportTicketStatusLabels.test.js
+++ b/src/utils/supportTicketStatusLabels.test.js
@@ -16,4 +16,9 @@ describe('supportTicketStatusLabels', () => {
         expect(TICKET_STATUS_LABEL_KEYS.Resuelto).toBe('estadoResuelto');
         expect(USER_TICKET_STATUS_LABEL_KEYS.Resuelto).toBe('estadoResuelto');
     });
+
+    it('uses neutral status styling for resolved and closed tickets in admin', () => {
+        expect(TICKET_STATUS_CLASS_MAP.Resuelto).toBe('label label-default');
+        expect(TICKET_STATUS_CLASS_MAP.Cerrado).toBe('label label-default');
+    });
 });

--- a/src/utils/supportTicketStatusLabels.test.js
+++ b/src/utils/supportTicketStatusLabels.test.js
@@ -2,7 +2,9 @@ import { describe, it, expect } from 'vitest';
 import {
     TICKET_STATUS_LABEL_KEYS,
     USER_TICKET_STATUS_LABEL_KEYS,
-    TICKET_STATUS_CLASS_MAP
+    TICKET_STATUS_CLASS_MAP,
+    SOLVED_TICKET_STATUSES,
+    SOLVED_TICKET_NEUTRAL_CLASS
 } from './supportTicketStatusLabels';
 
 describe('supportTicketStatusLabels', () => {
@@ -18,7 +20,9 @@ describe('supportTicketStatusLabels', () => {
     });
 
     it('uses neutral status styling for resolved and closed tickets in admin', () => {
-        expect(TICKET_STATUS_CLASS_MAP.Resuelto).toBe('label label-default');
-        expect(TICKET_STATUS_CLASS_MAP.Cerrado).toBe('label label-default');
+        expect(SOLVED_TICKET_STATUSES.has('Resuelto')).toBe(true);
+        expect(SOLVED_TICKET_STATUSES.has('Cerrado')).toBe(true);
+        expect(TICKET_STATUS_CLASS_MAP.Resuelto).toBe(SOLVED_TICKET_NEUTRAL_CLASS);
+        expect(TICKET_STATUS_CLASS_MAP.Cerrado).toBe(SOLVED_TICKET_NEUTRAL_CLASS);
     });
 });

--- a/src/utils/supportTicketUpdatedAgeAttention.js
+++ b/src/utils/supportTicketUpdatedAgeAttention.js
@@ -1,10 +1,10 @@
 import dayjs from '../dayjs';
+import { SOLVED_TICKET_STATUSES } from './supportTicketStatusLabels';
 
 /** Statuses where admins are expected to take action (excluding user-wait states). */
 export const ADMIN_ATTENTION_STATUSES = new Set(['En revision', 'Necesita revisión']);
 
-/** Tickets that are done and should not show admin attention styling. */
-export const SOLVED_TICKET_STATUSES = new Set(['Resuelto', 'Cerrado']);
+export { SOLVED_TICKET_STATUSES };
 
 export const SUPPORT_TICKET_UPDATED_WARNING_DAYS = 2;
 export const SUPPORT_TICKET_UPDATED_CRITICAL_DAYS = 4;

--- a/src/utils/supportTicketUpdatedAgeAttention.js
+++ b/src/utils/supportTicketUpdatedAgeAttention.js
@@ -3,6 +3,9 @@ import dayjs from '../dayjs';
 /** Statuses where admins are expected to take action (excluding user-wait states). */
 export const ADMIN_ATTENTION_STATUSES = new Set(['En revision', 'Necesita revisión']);
 
+/** Tickets that are done and should not show admin attention styling. */
+export const SOLVED_TICKET_STATUSES = new Set(['Resuelto', 'Cerrado']);
+
 export const SUPPORT_TICKET_UPDATED_WARNING_DAYS = 2;
 export const SUPPORT_TICKET_UPDATED_CRITICAL_DAYS = 4;
 
@@ -15,8 +18,16 @@ export function hasUnreadAdminMessages(ticket) {
     return Number(ticket && ticket.unread_for_admin) > 0;
 }
 
+export function isSolvedSupportTicket(ticket) {
+    return SOLVED_TICKET_STATUSES.has(ticket && ticket.status);
+}
+
+export function hasUnreadUserReplyIndicator(ticket) {
+    return !isSolvedSupportTicket(ticket) && hasUnreadAdminMessages(ticket);
+}
+
 export function ticketNeedsAdminAttention(ticket) {
-    if (!ticket) return false;
+    if (!ticket || isSolvedSupportTicket(ticket)) return false;
     if (hasUnreadAdminMessages(ticket)) return true;
     return ADMIN_ATTENTION_STATUSES.has(ticket.status);
 }

--- a/src/utils/supportTicketUpdatedAgeAttention.test.js
+++ b/src/utils/supportTicketUpdatedAgeAttention.test.js
@@ -27,6 +27,11 @@ describe('ticketNeedsAdminAttention', () => {
         expect(ticketNeedsAdminAttention({ status: 'Resuelto', unread_for_admin: 0 })).toBe(false);
         expect(ticketNeedsAdminAttention({ status: 'Cerrado', unread_for_admin: 0 })).toBe(false);
     });
+
+    it('returns false for resolved or closed tickets even with unread admin messages', () => {
+        expect(ticketNeedsAdminAttention({ status: 'Resuelto', unread_for_admin: 1 })).toBe(false);
+        expect(ticketNeedsAdminAttention({ status: 'Cerrado', unread_for_admin: 1 })).toBe(false);
+    });
 });
 
 describe('getUpdatedAgeAttentionLevel', () => {
@@ -84,5 +89,20 @@ describe('getUpdatedAgeAttentionClass', () => {
             unread_for_admin: 0,
             updated_at: '2026-05-28T12:00:00'
         }, now)).toBe('');
+    });
+
+    it('returns empty string for resolved or closed tickets even when stale and unread', () => {
+        const staleResolved = {
+            status: 'Resuelto',
+            unread_for_admin: 1,
+            updated_at: '2026-05-20T08:00:00'
+        };
+        const staleClosed = {
+            status: 'Cerrado',
+            unread_for_admin: 1,
+            updated_at: '2026-05-20T08:00:00'
+        };
+        expect(getUpdatedAgeAttentionClass(staleResolved, now)).toBe('');
+        expect(getUpdatedAgeAttentionClass(staleClosed, now)).toBe('');
     });
 });

--- a/src/utils/supportTicketUpdatedAgeAttention.test.js
+++ b/src/utils/supportTicketUpdatedAgeAttention.test.js
@@ -3,7 +3,8 @@ import dayjs from '../dayjs';
 import {
     ticketNeedsAdminAttention,
     getUpdatedAgeAttentionLevel,
-    getUpdatedAgeAttentionClass
+    getUpdatedAgeAttentionClass,
+    hasUnreadUserReplyIndicator
 } from './supportTicketUpdatedAgeAttention.js';
 
 describe('ticketNeedsAdminAttention', () => {
@@ -31,6 +32,17 @@ describe('ticketNeedsAdminAttention', () => {
     it('returns false for resolved or closed tickets even with unread admin messages', () => {
         expect(ticketNeedsAdminAttention({ status: 'Resuelto', unread_for_admin: 1 })).toBe(false);
         expect(ticketNeedsAdminAttention({ status: 'Cerrado', unread_for_admin: 1 })).toBe(false);
+    });
+});
+
+describe('hasUnreadUserReplyIndicator', () => {
+    it('returns true when the user replied on an open ticket', () => {
+        expect(hasUnreadUserReplyIndicator({ status: 'Esperando respuesta', unread_for_admin: 1 })).toBe(true);
+    });
+
+    it('returns false for resolved or closed tickets even with unread admin messages', () => {
+        expect(hasUnreadUserReplyIndicator({ status: 'Resuelto', unread_for_admin: 1 })).toBe(false);
+        expect(hasUnreadUserReplyIndicator({ status: 'Cerrado', unread_for_admin: 1 })).toBe(false);
     });
 });
 


### PR DESCRIPTION

## Summary
Stop highlighting resolved and closed support tickets in the admin list so completed tickets no longer draw attention.
## Frontend
- Exclude `Resuelto` and `Cerrado` from admin attention styling, even when `unread_for_admin > 0`
- Remove stale **updated** column warning/critical colors for solved tickets
- Hide the unread user reply icon on solved tickets
- Use neutral status badges for `Resuelto` (was green) and `Cerrado`
- Centralize `SOLVED_TICKET_STATUSES` in `supportTicketStatusLabels.js`
**Files changed:** `AdminSupportTickets.vue`, `supportTicketUpdatedAgeAttention.js`, `supportTicketStatusLabels.js`, plus related unit tests
