### PR TITLE
Messages loading indicator

### DIFF
--- a/src/stores/conversations.js
+++ b/src/stores/conversations.js
@@ -26,9 +26,10 @@ function normalizeConversation(conv) {
 }
 
 /** Deduplicate list by normalized id (keep first occurrence) and normalise each item. */
+/** Preserve null (loading); empty array means fetch completed with no rows. */
 function deduplicateList(list) {
     if (list == null) return null;
-    if (!list.length) return list;
+    if (list.length === 0) return list;
     const seen = new Set();
     return list
         .filter((item) => {

--- a/src/stores/conversations.js
+++ b/src/stores/conversations.js
@@ -27,7 +27,8 @@ function normalizeConversation(conv) {
 
 /** Deduplicate list by normalized id (keep first occurrence) and normalise each item. */
 function deduplicateList(list) {
-    if (!list || !list.length) return list || [];
+    if (list == null) return null;
+    if (!list.length) return list;
     const seen = new Set();
     return list
         .filter((item) => {

--- a/src/stores/conversations.test.js
+++ b/src/stores/conversations.test.js
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+
+vi.mock('../services/api', () => ({
+    ConversationApi: class ConversationApiMock {
+        constructor() {
+            return {};
+        }
+    }
+}));
+
+vi.mock('../services/dialogs.js', () => ({
+    default: {
+        message: vi.fn()
+    }
+}));
+
+vi.mock('../i18n', () => ({
+    default: {
+        global: {
+            t: (key) => key
+        }
+    }
+}));
+
+vi.mock('../utils/routerLazy.js', () => ({
+    fireLazyRouterPush: vi.fn(),
+    lazyRouterPush: vi.fn()
+}));
+
+describe('conversations store list getter', () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+    });
+
+    it('returns null while conversations are loading so UI can show loading state', async () => {
+        const { useConversationsStore } = await import('./conversations');
+        const store = useConversationsStore();
+
+        store._list = null;
+
+        expect(store.list).toBeNull();
+    });
+
+    it('returns empty array after loading when user has no conversations', async () => {
+        const { useConversationsStore } = await import('./conversations');
+        const store = useConversationsStore();
+
+        store._list = [];
+
+        expect(store.list).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary
Fixes the messages/conversations list showing "No tienes conversaciones..." while data is still loading. It now correctly shows the loading indicator ("Cargando conversaciones...") until the API responds.
## Frontend
- **Root cause:** The `list` getter in the conversations store coerced `_list: null` (loading) into `[]`, so the `Loading` component treated the state as empty instead of in-flight.
- **Fix:** `deduplicateList` now preserves `null` during fetch and only returns `[]` after a completed fetch with no conversations.
- **Tests:** Added unit tests in `src/stores/conversations.test.js` covering loading (`null`) vs empty (`[]`) states.
