### PR TITLE
Support ticket: textarea changes

### DIFF
--- a/src/components/elements/ToastUiEditor.view.test.js
+++ b/src/components/elements/ToastUiEditor.view.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const componentPath = path.resolve(__dirname, 'ToastUiEditor.vue');
+const componentSource = fs.readFileSync(componentPath, 'utf8');
+
+describe('ToastUiEditor resizable', () => {
+    it('declares a resizable prop defaulting to false', () => {
+        expect(componentSource).toMatch(/resizable:\s*\{[\s\S]*?type:\s*Boolean[\s\S]*?default:\s*false/);
+    });
+
+    it('applies a resizable class on the mount when resizable is enabled', () => {
+        expect(componentSource).toContain('toast-ui-editor-mount--resizable');
+        expect(componentSource).toContain(':class');
+        expect(componentSource).toMatch(/resizable[\s\S]*toast-ui-editor-mount--resizable/);
+    });
+
+    it('allows vertical resize on the editor root without blocking overflow', () => {
+        expect(componentSource).toContain('resize: vertical');
+        expect(componentSource).toMatch(/toast-ui-editor-mount--resizable[\s\S]*overflow:\s*auto/);
+    });
+});

--- a/src/components/elements/ToastUiEditor.view.test.js
+++ b/src/components/elements/ToastUiEditor.view.test.js
@@ -20,4 +20,14 @@ describe('ToastUiEditor resizable', () => {
         expect(componentSource).toContain('resize: vertical');
         expect(componentSource).toMatch(/toast-ui-editor-mount--resizable[\s\S]*overflow:\s*auto/);
     });
+
+    it('sets minHeight to the height prop when resizable so the editor cannot shrink below default', () => {
+        expect(componentSource).toMatch(/if\s*\(\s*this\.resizable\s*\)[\s\S]*merged\.minHeight\s*=\s*this\.height/);
+    });
+
+    it('allows markdown textarea resize inside a resizable mount', () => {
+        expect(componentSource).toMatch(
+            /\.toast-ui-editor-mount--resizable\s*:deep\(textarea\)[\s\S]*resize:\s*vertical/
+        );
+    });
 });

--- a/src/components/elements/ToastUiEditor.vue
+++ b/src/components/elements/ToastUiEditor.vue
@@ -1,5 +1,9 @@
 <template>
-    <div ref="mount" class="toast-ui-editor-mount" />
+    <div
+        ref="mount"
+        class="toast-ui-editor-mount"
+        :class="{ 'toast-ui-editor-mount--resizable': resizable }"
+    />
 </template>
 
 <script>
@@ -47,6 +51,10 @@ export default {
         options: {
             type: Object,
             default: () => ({})
+        },
+        resizable: {
+            type: Boolean,
+            default: false
         }
     },
     data() {
@@ -121,5 +129,11 @@ export default {
 <style scoped>
 .toast-ui-editor-mount {
     width: 100%;
+}
+
+.toast-ui-editor-mount--resizable {
+    resize: vertical;
+    overflow: auto;
+    min-height: 140px;
 }
 </style>

--- a/src/components/elements/ToastUiEditor.vue
+++ b/src/components/elements/ToastUiEditor.vue
@@ -84,6 +84,9 @@ export default {
                 previewStyle: this.previewStyle,
                 events: wrappedEvents
             };
+            if (this.resizable) {
+                merged.minHeight = this.height;
+            }
             return merged;
         }
     },
@@ -134,6 +137,9 @@ export default {
 .toast-ui-editor-mount--resizable {
     resize: vertical;
     overflow: auto;
-    min-height: 140px;
+}
+
+.toast-ui-editor-mount--resizable :deep(textarea) {
+    resize: vertical;
 }
 </style>

--- a/src/components/views/AdminSupportTicketDetail.view.test.js
+++ b/src/components/views/AdminSupportTicketDetail.view.test.js
@@ -176,4 +176,12 @@ describe('AdminSupportTicketDetail view', () => {
         expect(viewSource).toContain('categoriaTicketGuardada');
         expect(viewSource).toContain('errorGuardandoCategoriaTicket');
     });
+
+    it('uses a taller, vertically resizable admin reply editor', () => {
+        expect(viewSource).toContain('supportTicketReplyEditor');
+        expect(viewSource).toContain(':height="supportTicketReplyEditorHeight"');
+        expect(viewSource).toContain('resizable');
+        expect(viewSource).toContain(':class="supportTicketReplyEditorClass"');
+        expect(viewSource).not.toContain('height="140px"');
+    });
 });

--- a/src/components/views/AdminSupportTicketDetail.vue
+++ b/src/components/views/AdminSupportTicketDetail.vue
@@ -84,7 +84,9 @@
                 :initial-value="replyEditorInitialValue"
                 :options="editorOptions"
                 initial-edit-type="wysiwyg"
-                height="140px"
+                :height="supportTicketReplyEditorHeight"
+                resizable
+                :class="supportTicketReplyEditorClass"
             />
             <input ref="attachmentInput" class="mtop-10" type="file" accept="image/*" multiple @change="onAttachments" />
             <div class="reply-actions">
@@ -195,6 +197,10 @@ import {
     TICKET_STATUS_LABEL_KEYS as STATUS_LABEL_KEYS
 } from '../../utils/supportTicketStatusLabels';
 import { USER_TICKET_TYPE_OPTIONS } from '../../utils/supportTicketTypeOptions';
+import {
+    SUPPORT_TICKET_REPLY_EDITOR_HEIGHT,
+    SUPPORT_TICKET_REPLY_EDITOR_CLASS
+} from '../../utils/supportTicketReplyEditor';
 
 const PRIORITY_LABEL_KEYS = {
     low: 'prioridadBaja',
@@ -228,6 +234,8 @@ export default {
                 hideModeSwitch: true,
                 toolbarItems: [['bold', 'italic', 'strike'], ['ul', 'ol']]
             },
+            supportTicketReplyEditorHeight: SUPPORT_TICKET_REPLY_EDITOR_HEIGHT,
+            supportTicketReplyEditorClass: SUPPORT_TICKET_REPLY_EDITOR_CLASS,
             replyTemplateModalOpen: false,
             replyTemplateSearch: '',
             replyTemplatesLoading: false,

--- a/src/components/views/TicketDetail.view.test.js
+++ b/src/components/views/TicketDetail.view.test.js
@@ -113,4 +113,12 @@ describe('TicketDetail user view', () => {
         expect(viewSource).toContain("dialogs.message(this.$t('ticketCerrado')");
         expect(viewSource).toContain("dialogs.message(this.$t('errorCerrandoTicket')");
     });
+
+    it('uses a taller, vertically resizable reply editor', () => {
+        expect(viewSource).toContain('supportTicketReplyEditor');
+        expect(viewSource).toContain(':height="supportTicketReplyEditorHeight"');
+        expect(viewSource).toContain('resizable');
+        expect(viewSource).toContain(':class="supportTicketReplyEditorClass"');
+        expect(viewSource).not.toContain('height="140px"');
+    });
 });

--- a/src/components/views/TicketDetail.vue
+++ b/src/components/views/TicketDetail.vue
@@ -42,7 +42,9 @@
                     :initial-value="''"
                     :options="editorOptions"
                     initial-edit-type="wysiwyg"
-                    height="140px"
+                    :height="supportTicketReplyEditorHeight"
+                    resizable
+                    :class="supportTicketReplyEditorClass"
                 />
                 <label class="control-label mtop-10">{{ $t('adjuntarImagenes') }}</label>
                 <input ref="attachmentInput" class="mtop-10" type="file" accept="image/*" multiple @change="onAttachments" />
@@ -75,6 +77,10 @@ import {
     TICKET_STATUS_CLASS_MAP as STATUS_CLASS_MAP,
     USER_TICKET_STATUS_LABEL_KEYS as STATUS_LABEL_KEYS
 } from '../../utils/supportTicketStatusLabels';
+import {
+    SUPPORT_TICKET_REPLY_EDITOR_HEIGHT,
+    SUPPORT_TICKET_REPLY_EDITOR_CLASS
+} from '../../utils/supportTicketReplyEditor';
 
 const SUCCESS_TOAST_OPTIONS = { estado: 'success', duration: 2 };
 const ERROR_TOAST_OPTIONS = { estado: 'error', duration: 3 };
@@ -92,6 +98,8 @@ export default {
                 hideModeSwitch: true,
                 toolbarItems: [['bold', 'italic', 'strike'], ['ul', 'ol']]
             },
+            supportTicketReplyEditorHeight: SUPPORT_TICKET_REPLY_EDITOR_HEIGHT,
+            supportTicketReplyEditorClass: SUPPORT_TICKET_REPLY_EDITOR_CLASS,
             replyEditorKey: 0,
             replySubmitting: false
         };

--- a/src/utils/supportTicketReplyEditor.js
+++ b/src/utils/supportTicketReplyEditor.js
@@ -1,0 +1,5 @@
+/** Default height for user/admin support ticket reply composers (was 140px). */
+export const SUPPORT_TICKET_REPLY_EDITOR_HEIGHT = '280px';
+
+/** Class on ToastUiEditor mount for reply-specific layout (e.g. vertical resize). */
+export const SUPPORT_TICKET_REPLY_EDITOR_CLASS = 'support-ticket-reply-editor';

--- a/src/utils/supportTicketReplyEditor.test.js
+++ b/src/utils/supportTicketReplyEditor.test.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import {
+    SUPPORT_TICKET_REPLY_EDITOR_HEIGHT,
+    SUPPORT_TICKET_REPLY_EDITOR_CLASS
+} from './supportTicketReplyEditor';
+
+describe('supportTicketReplyEditor', () => {
+    it('uses doubled default height for reply composers', () => {
+        expect(SUPPORT_TICKET_REPLY_EDITOR_HEIGHT).toBe('280px');
+    });
+
+    it('exposes a shared mount class for reply editor styling', () => {
+        expect(SUPPORT_TICKET_REPLY_EDITOR_CLASS).toBe('support-ticket-reply-editor');
+    });
+});


### PR DESCRIPTION
## Summary
Support ticket reply composers (user and admin) are taller by default and can be resized vertically.
## Frontend
- **Reply editor height:** default increased from `140px` to `280px` via shared constant `SUPPORT_TICKET_REPLY_EDITOR_HEIGHT` in `supportTicketReplyEditor.js`.
- **`ToastUiEditor`:** new `resizable` prop enables vertical resize on the editor mount (`resize: vertical`, `overflow: auto`), sets `minHeight` to match `height`, and restores vertical resize on inner markdown `textarea` elements (overrides global `textarea { resize: none }`).
- **Views wired:** `TicketDetail.vue` (user replies) and `AdminSupportTicketDetail.vue` (admin replies) use the shared height, `resizable`, and `support-ticket-reply-editor` class.
- **Tests:** unit/view tests for the util, `ToastUiEditor`, and both ticket detail views.
