### PR TITLE
Block UI when API is unreachable but device is online

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,6 +6,7 @@
         <OfflineStatusBar />
         <ForceUpgradeModal v-if="showForceUpgrade" />
         <MaintenanceFullscreen v-else-if="passengerMaintenanceWall" />
+        <ServerDownFullscreen v-else-if="serverDownWallVisible" />
         <template v-else>
             <IdentityValidationPromptModal
                 :suppress="identityPromptSuppress"
@@ -55,6 +56,8 @@ import IdentityValidationPromptModal from './components/IdentityValidationPrompt
 import MaintenanceFullscreen from './components/MaintenanceFullscreen.vue';
 import MaintenanceAdminBanner from './components/MaintenanceAdminBanner.vue';
 import OfflineStatusBar from './components/OfflineStatusBar.vue';
+import ServerDownFullscreen from './components/ServerDownFullscreen.vue';
+import { useServerStatusStore } from './stores/serverStatus';
 
 export default {
     name: 'app',
@@ -154,7 +157,9 @@ export default {
             return Capacitor.isNativePlatform() ? base : base + ' - build 111';
         },
         ...mapState(useCordovaStore, {
-            deviceReady: 'deviceReady'
+            deviceReady: 'deviceReady',
+            networkReady: 'networkReady',
+            networkState: 'networkState'
         }),
         ...mapState(useBackgroundStore, {
             backgroundStyle: 'backgroundStyle'
@@ -169,6 +174,9 @@ export default {
             isFacebokApp: 'isFacebokApp',
             firsTimeMobileAppOpen: 'firsTimeMobileAppOpen',
             isBrowser: 'isBrowser'
+        }),
+        ...mapState(useServerStatusStore, {
+            serverUnavailable: 'serverUnavailable'
         }),
         onBoardingVisibility() {
             let moduleEnabled =
@@ -205,6 +213,15 @@ export default {
                 'reset-password-confirm'
             ]);
             return !allowed.has(this.$route.name);
+        },
+        serverDownWallVisible() {
+            if (!this.serverUnavailable) {
+                return false;
+            }
+            if (this.networkReady && !this.networkState) {
+                return false;
+            }
+            return true;
         },
         maintenanceAdminStickyVisible() {
             const cfg = this.appConfig && this.appConfig.maintenance;
@@ -254,7 +271,8 @@ export default {
         IdentityValidationPromptModal,
         MaintenanceFullscreen,
         MaintenanceAdminBanner,
-        OfflineStatusBar
+        OfflineStatusBar,
+        ServerDownFullscreen
     }
 };
 </script>

--- a/src/components/ServerDownFullscreen.view.test.js
+++ b/src/components/ServerDownFullscreen.view.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('ServerDownFullscreen component', () => {
+    it('renders a blocking fullscreen message with retry controls', () => {
+        const componentPath = path.resolve(
+            __dirname,
+            'ServerDownFullscreen.vue'
+        );
+        const source = fs.readFileSync(componentPath, 'utf8');
+
+        expect(source).toContain("name: 'server-down-fullscreen'");
+        expect(source).toContain('serverDownTitle');
+        expect(source).toContain('serverDownLead');
+        expect(source).toContain('serverDownRetryButton');
+        expect(source).toContain('position: fixed');
+        expect(source).toContain('z-index: 10001');
+    });
+
+    it('is mounted at the app root after maintenance handling', () => {
+        const appPath = path.resolve(__dirname, '../App.vue');
+        const source = fs.readFileSync(appPath, 'utf8');
+
+        expect(source).toContain('<ServerDownFullscreen v-else-if="serverDownWallVisible" />');
+        expect(source).toContain(
+            "import ServerDownFullscreen from './components/ServerDownFullscreen.vue'"
+        );
+        expect(source).toContain('serverDownWallVisible');
+    });
+});

--- a/src/components/ServerDownFullscreen.vue
+++ b/src/components/ServerDownFullscreen.vue
@@ -1,0 +1,93 @@
+<template>
+    <div class="server-down-fullscreen">
+        <div class="server-down-fullscreen__inner">
+            <h1 class="server-down-fullscreen__title">
+                {{ $t('serverDownTitle') }}
+            </h1>
+            <p class="server-down-fullscreen__lead">
+                {{ $t('serverDownLead') }}
+            </p>
+            <p
+                v-if="checking"
+                class="server-down-fullscreen__checking"
+                role="status"
+                aria-live="polite"
+            >
+                {{ $t('serverDownRetrying') }}
+            </p>
+            <button
+                type="button"
+                class="btn btn-primary server-down-fullscreen__retry"
+                :disabled="checking"
+                @click="onRetry"
+            >
+                {{ $t('serverDownRetryButton') }}
+            </button>
+        </div>
+    </div>
+</template>
+
+<script>
+import { mapActions, mapState } from 'pinia';
+import { useServerStatusStore } from '../stores/serverStatus';
+
+export default {
+    name: 'server-down-fullscreen',
+    computed: {
+        ...mapState(useServerStatusStore, {
+            checking: 'checking'
+        })
+    },
+    methods: {
+        ...mapActions(useServerStatusStore, {
+            tryRecover: 'tryRecover'
+        }),
+        onRetry() {
+            this.tryRecover();
+        }
+    }
+};
+</script>
+
+<style scoped>
+.server-down-fullscreen {
+    position: fixed;
+    inset: 0;
+    z-index: 10001;
+    overflow: auto;
+    background: #f4f6f8;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    text-align: center;
+}
+
+.server-down-fullscreen__inner {
+    max-width: 36rem;
+}
+
+.server-down-fullscreen__title {
+    font-size: 1.75rem;
+    font-weight: 600;
+    margin: 0 0 1rem;
+    color: #1a2b3c;
+}
+
+.server-down-fullscreen__lead {
+    font-size: 1.05rem;
+    margin: 0 0 1.25rem;
+    color: #333;
+    line-height: 1.5;
+}
+
+.server-down-fullscreen__checking {
+    margin: 0 0 1rem;
+    color: #666;
+    font-size: 0.95rem;
+}
+
+.server-down-fullscreen__retry {
+    min-width: 10rem;
+}
+</style>

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -276,6 +276,11 @@ const messages = {
             'Ocurrió un error al procesar el registro, por favor vuelva a intentar.',
         offlineStatusBarMessage:
             'Sin conexión a internet. Revisá tu conexión.',
+        serverDownTitle: 'Carpoolear no está disponible',
+        serverDownLead:
+            'Estamos teniendo problemas para conectar con el servidor. Por favor esperá un momento e intentá de nuevo.',
+        serverDownRetrying: 'Reintentando conexión…',
+        serverDownRetryButton: 'Reintentar ahora',
         valorDonacion: 'Tienes que seleccionar un valor de donación.',
         correctamenteSubscripto:
             'Te subscribiste correctamente. Te avisaremos cuando hayan viajes similares',
@@ -1651,6 +1656,11 @@ const messages = {
             'Ocurrió un error al procesar el registro, por favor vuelva a intentar.',
         offlineStatusBarMessage:
             'Sin conexión a internet. Revisá tu conexión.',
+        serverDownTitle: 'Carpoolear no está disponible',
+        serverDownLead:
+            'Estamos teniendo problemas para conectar con el servidor. Por favor esperá un momento e intentá de nuevo.',
+        serverDownRetrying: 'Reintentando conexión…',
+        serverDownRetryButton: 'Reintentar ahora',
         buscoConductor: 'Conductor',
         buscoPasajero: 'Pasajero',
         iniciarSesion: 'Comparte auto para llegar al lugar donde quierés ir',
@@ -2780,6 +2790,11 @@ const messages = {
             'An error occurred while processing the registration, please try again.',
         offlineStatusBarMessage:
             'No internet connection. Check your connection.',
+        serverDownTitle: 'Carpoolear is unavailable',
+        serverDownLead:
+            'We are having trouble connecting to the server. Please wait a moment and try again.',
+        serverDownRetrying: 'Retrying connection…',
+        serverDownRetryButton: 'Retry now',
         valorDonacion: 'You must select a donation amount.',
         correctamenteSubscripto:
             'You subscribed successfully. We will notify you when there are similar trips.',

--- a/src/services/network.js
+++ b/src/services/network.js
@@ -2,6 +2,11 @@
 import TaggedList from '../classes/TaggedList';
 import axios from 'axios';
 import { Capacitor } from '@capacitor/core';
+import {
+    createServerUnavailableError,
+    isMaintenanceResponse,
+    isServerUnavailableHttpStatus
+} from '../utils/serverErrors';
 
 const API_URL = import.meta.env.VITE_API_URL;
 const OFFLINE_ERROR = {
@@ -110,22 +115,68 @@ export default {
         }
     },
 
+    async isDeviceOnline() {
+        try {
+            const { useCordovaStore } = await import('../stores/cordova');
+            const cordovaStore = useCordovaStore();
+            if (cordovaStore.networkReady) {
+                return cordovaStore.networkState;
+            }
+        } catch (e) {
+            console.warn('isDeviceOnline:', e);
+        }
+
+        return typeof navigator === 'undefined' || navigator.onLine !== false;
+    },
+
+    async markServerUnavailable() {
+        try {
+            const { useServerStatusStore } = await import(
+                '../stores/serverStatus'
+            );
+            useServerStatusStore().markServerUnavailable();
+        } catch (e) {
+            console.warn('markServerUnavailable:', e);
+        }
+    },
+
+    async clearServerUnavailable() {
+        try {
+            const { useServerStatusStore } = await import(
+                '../stores/serverStatus'
+            );
+            useServerStatusStore().clearServerUnavailable();
+        } catch (e) {
+            console.warn('clearServerUnavailable:', e);
+        }
+    },
+
+    async handleTransportFailure() {
+        if (await this.isDeviceOnline()) {
+            await this.markServerUnavailable();
+            return createServerUnavailableError();
+        }
+
+        await this.markOffline();
+        return this.createOfflineError();
+    },
+
     processResponse(response, source) {
         const promise = new MyPromise((resolve, reject) => {
             response
                 .then((response) => {
-                    resolve(response.data);
+                    return Promise.resolve(this.clearServerUnavailable()).then(
+                        () => {
+                            resolve(response.data);
+                        }
+                    );
                 })
                 .catch(async (resp) => {
                     // Revisar el tipo de error!
                     if (resp.response) {
                         const data = resp.response.data;
                         const status = resp.response.status;
-                        if (
-                            status === 503 &&
-                            data &&
-                            data.maintenance === true
-                        ) {
+                        if (isMaintenanceResponse(status, data)) {
                             import('../stores/auth').then(
                                 ({ useAuthStore }) => {
                                     try {
@@ -140,13 +191,17 @@ export default {
                                     }
                                 }
                             );
+                        } else if (
+                            isServerUnavailableHttpStatus(status) &&
+                            (await this.isDeviceOnline())
+                        ) {
+                            await this.markServerUnavailable();
                         }
                         reject({ data, status });
                     } else if (axios.isCancel && axios.isCancel(resp)) {
                         reject(resp);
                     } else {
-                        await this.markOffline();
-                        reject(this.createOfflineError());
+                        reject(await this.handleTransportFailure());
                     }
                 });
         });

--- a/src/services/network.test.js
+++ b/src/services/network.test.js
@@ -12,7 +12,8 @@ vi.mock('axios', () => ({
 
 vi.mock('@capacitor/core', () => ({
     Capacitor: {
-        getPlatform: vi.fn(() => 'web')
+        getPlatform: vi.fn(() => 'web'),
+        isNativePlatform: vi.fn(() => false)
     }
 }));
 
@@ -25,7 +26,8 @@ vi.mock('../cordova/apple.js', () => ({
 }));
 
 vi.mock('../services/api', () => ({
-    AuthApi: class AuthApiMock {}
+    AuthApi: class AuthApiMock {},
+    UserApi: class UserApiMock {}
 }));
 
 vi.mock('../services/bus-event.js', () => ({
@@ -50,7 +52,7 @@ describe('network transport errors', () => {
         const network = await import('./network');
         const { useCordovaStore } = await import('../stores/cordova');
         const store = useCordovaStore();
-        store.setNetworkState(true);
+        store.setNetworkState(false);
 
         const source = { cancel: vi.fn() };
         const request = network.default.processResponse(
@@ -69,5 +71,104 @@ describe('network transport errors', () => {
         });
         expect(store.networkReady).toBe(true);
         expect(store.networkState).toBe(false);
+    });
+
+    it('marks server unavailable when transport fails but the device is online', async () => {
+        const network = await import('./network');
+        const { useCordovaStore } = await import('../stores/cordova');
+        const { useServerStatusStore } = await import('../stores/serverStatus');
+        const cordovaStore = useCordovaStore();
+        const serverStatusStore = useServerStatusStore();
+        cordovaStore.setNetworkState(true);
+
+        const source = { cancel: vi.fn() };
+        const request = network.default.processResponse(
+            Promise.reject(
+                Object.assign(new Error('Network Error'), {
+                    code: 'ERR_NETWORK'
+                })
+            ),
+            source
+        );
+
+        await expect(request).rejects.toEqual({
+            data: { message: 'server_unavailable' },
+            status: 0,
+            serverUnavailable: true
+        });
+        expect(cordovaStore.networkState).toBe(true);
+        expect(serverStatusStore.serverUnavailable).toBe(true);
+    });
+
+    it('marks server unavailable for gateway HTTP errors while online', async () => {
+        const network = await import('./network');
+        const { useCordovaStore } = await import('../stores/cordova');
+        const { useServerStatusStore } = await import('../stores/serverStatus');
+        useCordovaStore().setNetworkState(true);
+
+        const source = { cancel: vi.fn() };
+        const request = network.default.processResponse(
+            Promise.reject({
+                response: {
+                    status: 502,
+                    data: { message: 'Bad Gateway' }
+                }
+            }),
+            source
+        );
+
+        await expect(request).rejects.toEqual({
+            data: { message: 'Bad Gateway' },
+            status: 502
+        });
+        expect(useServerStatusStore().serverUnavailable).toBe(true);
+    });
+
+    it('does not mark server unavailable for maintenance 503 responses', async () => {
+        const network = await import('./network');
+        const { useAuthStore } = await import('../stores/auth');
+        const { useCordovaStore } = await import('../stores/cordova');
+        const { useServerStatusStore } = await import('../stores/serverStatus');
+        useCordovaStore().setNetworkState(true);
+        useAuthStore().setAppConfig({ maintenance: { enabled: false } });
+
+        const source = { cancel: vi.fn() };
+        const request = network.default.processResponse(
+            Promise.reject({
+                response: {
+                    status: 503,
+                    data: {
+                        maintenance: true,
+                        enabled: true,
+                        mode: 'strict',
+                        message: 'Planned work'
+                    }
+                }
+            }),
+            source
+        );
+
+        await expect(request).rejects.toMatchObject({ status: 503 });
+        await vi.waitFor(() => {
+            expect(useAuthStore().appConfig.maintenance.enabled).toBe(true);
+        });
+        expect(useServerStatusStore().serverUnavailable).toBe(false);
+    });
+
+    it('clears server unavailable after a successful response', async () => {
+        const network = await import('./network');
+        const { useServerStatusStore } = await import('../stores/serverStatus');
+        const serverStatusStore = useServerStatusStore();
+        serverStatusStore.serverUnavailable = true;
+        serverStatusStore.stopRetryPolling();
+
+        const source = { cancel: vi.fn() };
+        const request = network.default.processResponse(
+            Promise.resolve({ data: { ok: true } }),
+            source
+        );
+
+        await expect(request).resolves.toEqual({ ok: true });
+        expect(serverStatusStore.serverUnavailable).toBe(false);
     });
 });

--- a/src/services/network.test.js
+++ b/src/services/network.test.js
@@ -108,12 +108,14 @@ describe('network transport errors', () => {
 
         const source = { cancel: vi.fn() };
         const request = network.default.processResponse(
-            Promise.reject({
-                response: {
-                    status: 502,
-                    data: { message: 'Bad Gateway' }
-                }
-            }),
+            Promise.reject(
+                Object.assign(new Error('Bad Gateway'), {
+                    response: {
+                        status: 502,
+                        data: { message: 'Bad Gateway' }
+                    }
+                })
+            ),
             source
         );
 
@@ -134,17 +136,19 @@ describe('network transport errors', () => {
 
         const source = { cancel: vi.fn() };
         const request = network.default.processResponse(
-            Promise.reject({
-                response: {
-                    status: 503,
-                    data: {
-                        maintenance: true,
-                        enabled: true,
-                        mode: 'strict',
-                        message: 'Planned work'
+            Promise.reject(
+                Object.assign(new Error('Service Unavailable'), {
+                    response: {
+                        status: 503,
+                        data: {
+                            maintenance: true,
+                            enabled: true,
+                            mode: 'strict',
+                            message: 'Planned work'
+                        }
                     }
-                }
-            }),
+                })
+            ),
             source
         );
 

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -307,9 +307,7 @@ export const useAuthStore = defineStore('auth', {
                 });
         },
 
-        getConfig() {
-            localConfig.__isLocal = true;
-            this.setAppConfig(localConfig);
+        reloadConfigFromServer() {
             return authApi.config().then((response) => {
                 const isConfigObject =
                     response &&
@@ -317,15 +315,27 @@ export const useAuthStore = defineStore('auth', {
                     !Array.isArray(response);
                 if (!isConfigObject) {
                     console.error(
-                        'getConfig: expected JSON object from /api/config; keeping local config only.'
+                        'reloadConfigFromServer: expected JSON object from /api/config.'
                     );
-                    return localConfig;
+                    return Promise.reject(response);
                 }
                 response.__isLocal = false;
                 console.log('Loading config from server: ', response);
                 const config = { ...localConfig, ...response };
                 this.setAppConfig(config);
-                return response;
+                return import('./serverStatus').then(({ useServerStatusStore }) => {
+                    useServerStatusStore().clearServerUnavailable();
+                    return response;
+                });
+            });
+        },
+
+        getConfig() {
+            localConfig.__isLocal = true;
+            this.setAppConfig(localConfig);
+            return this.reloadConfigFromServer().catch((error) => {
+                console.warn('getConfig: remote config unavailable.', error);
+                return localConfig;
             });
         },
 

--- a/src/stores/cordova.js
+++ b/src/stores/cordova.js
@@ -39,8 +39,21 @@ export const useCordovaStore = defineStore('cordova', {
         },
 
         setNetworkState(connected) {
+            const wasOnline = this._deviceOnline;
             this.networkReady = true;
             this._deviceOnline = Boolean(connected);
+            if (connected && !wasOnline) {
+                import('./serverStatus')
+                    .then(({ useServerStatusStore }) => {
+                        const serverStatusStore = useServerStatusStore();
+                        if (serverStatusStore.serverUnavailable) {
+                            serverStatusStore.tryRecover();
+                        }
+                    })
+                    .catch((e) => {
+                        console.warn('setNetworkState tryRecover:', e);
+                    });
+            }
         },
 
         setOnline() {

--- a/src/stores/serverStatus.js
+++ b/src/stores/serverStatus.js
@@ -1,0 +1,71 @@
+import { defineStore } from 'pinia';
+
+const RETRY_INTERVAL_MS = 15000;
+
+export const useServerStatusStore = defineStore('serverStatus', {
+    state: () => ({
+        serverUnavailable: false,
+        checking: false,
+        _retryTimerId: null
+    }),
+
+    actions: {
+        markServerUnavailable() {
+            if (this.serverUnavailable) {
+                return;
+            }
+            this.serverUnavailable = true;
+            this.startRetryPolling();
+        },
+
+        clearServerUnavailable() {
+            this.serverUnavailable = false;
+            this.stopRetryPolling();
+        },
+
+        startRetryPolling() {
+            if (this._retryTimerId) {
+                return;
+            }
+            this.tryRecover();
+            this._retryTimerId = setInterval(() => {
+                this.tryRecover();
+            }, RETRY_INTERVAL_MS);
+        },
+
+        stopRetryPolling() {
+            if (!this._retryTimerId) {
+                return;
+            }
+            clearInterval(this._retryTimerId);
+            this._retryTimerId = null;
+        },
+
+        async tryRecover() {
+            if (this.checking) {
+                return;
+            }
+
+            try {
+                const { useCordovaStore } = await import('./cordova');
+                const cordovaStore = useCordovaStore();
+                if (cordovaStore.networkReady && !cordovaStore.networkState) {
+                    return;
+                }
+            } catch (e) {
+                console.warn('tryRecover network check:', e);
+            }
+
+            this.checking = true;
+            try {
+                const { useAuthStore } = await import('./auth');
+                const authStore = useAuthStore();
+                await authStore.reloadConfigFromServer();
+            } catch (e) {
+                // Server still unreachable; keep blocking UI.
+            } finally {
+                this.checking = false;
+            }
+        }
+    }
+});

--- a/src/utils/serverErrors.js
+++ b/src/utils/serverErrors.js
@@ -1,0 +1,31 @@
+export const SERVER_UNAVAILABLE_ERROR = {
+    data: { message: 'server_unavailable' },
+    status: 0,
+    serverUnavailable: true
+};
+
+export function isMaintenanceResponse(status, data) {
+    return status === 503 && data && data.maintenance === true;
+}
+
+export function isServerUnavailableHttpStatus(status) {
+    return status === 502 || status === 503 || status === 504;
+}
+
+export function createServerUnavailableError() {
+    return {
+        data: { ...SERVER_UNAVAILABLE_ERROR.data },
+        status: SERVER_UNAVAILABLE_ERROR.status,
+        serverUnavailable: SERVER_UNAVAILABLE_ERROR.serverUnavailable
+    };
+}
+
+export function isServerUnavailableApiError(error) {
+    return Boolean(
+        error &&
+            (error.serverUnavailable === true ||
+                (error.data &&
+                    error.data.message === 'server_unavailable') ||
+                error.message === 'server_unavailable')
+    );
+}

--- a/src/utils/serverErrors.test.js
+++ b/src/utils/serverErrors.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+    createServerUnavailableError,
+    isMaintenanceResponse,
+    isServerUnavailableApiError,
+    isServerUnavailableHttpStatus
+} from './serverErrors';
+
+describe('serverErrors', () => {
+    it('detects maintenance 503 responses', () => {
+        expect(
+            isMaintenanceResponse(503, { maintenance: true, message: 'DB work' })
+        ).toBe(true);
+        expect(isMaintenanceResponse(503, { message: 'Gateway timeout' })).toBe(
+            false
+        );
+    });
+
+    it('detects server-unavailable HTTP statuses', () => {
+        expect(isServerUnavailableHttpStatus(502)).toBe(true);
+        expect(isServerUnavailableHttpStatus(503)).toBe(true);
+        expect(isServerUnavailableHttpStatus(504)).toBe(true);
+        expect(isServerUnavailableHttpStatus(500)).toBe(false);
+    });
+
+    it('creates and detects normalized server-unavailable API errors', () => {
+        const error = createServerUnavailableError();
+        expect(error).toEqual({
+            data: { message: 'server_unavailable' },
+            status: 0,
+            serverUnavailable: true
+        });
+        expect(isServerUnavailableApiError(error)).toBe(true);
+    });
+});


### PR DESCRIPTION
Show a fullscreen server-down state with auto-retry on /api/config so users don't keep acting against a dead backend, separate from device offline and planned maintenance.