### PR TITLE
Login FB Apple: tweak message

### DIFF
--- a/src/components/views/Login.vue
+++ b/src/components/views/Login.vue
@@ -298,13 +298,13 @@
                             }}</a>
                             <span>{{ $t('escribinosMesaAyudaMigracionMid') }}</span>
                             <a
-                                href="https://www.instagram.com/carpoolear/?hl=en"
+                                :href="carpoolearInstagramUrl"
                                 target="_blank"
                                 rel="noopener noreferrer"
                             >{{ $t('footerInstagram') }}</a>
                             <span>{{ $t('escribinosMesaAyudaMigracionOr') }}</span>
                             <a
-                                href="https://www.facebook.com/Carpoolear"
+                                :href="carpoolearFacebookUrl"
                                 target="_blank"
                                 rel="noopener noreferrer"
                             >{{ $t('footerFacebook') }}</a>
@@ -328,6 +328,10 @@ import bus from '../../services/bus-event';
 import Spinner from '../Spinner.vue';
 import cache from '../../services/cache';
 import { isOfflineApiError } from '../../utils/apiErrors.js';
+import {
+    CARPOOLEAR_FACEBOOK_URL,
+    CARPOOLEAR_INSTAGRAM_URL
+} from '../../utils/carpoolearSocialUrls.js';
 
 export default {
     name: 'login',
@@ -352,6 +356,8 @@ export default {
             showUserNotActiveInfo: false,
             showModalLogin: false,
             modalType: 'facebook',
+            carpoolearFacebookUrl: CARPOOLEAR_FACEBOOK_URL,
+            carpoolearInstagramUrl: CARPOOLEAR_INSTAGRAM_URL,
             showUserBannedInfo: false,
             app_logo:
                 process.env.ROUTE_BASE +

--- a/src/components/views/Login.vue
+++ b/src/components/views/Login.vue
@@ -293,7 +293,21 @@
                         </p>
                         <p>
                             <span>{{ $t('escribinosMesaAyudaMigracionLead') }}</span>
-                            <router-link :to="{ name: 'tickets' }">{{ $t('mesaAyuda') }}</router-link>{{ $t('mesaAyudaContactoTail') }}
+                            <a :href="'mailto:' + config.admin_email">{{
+                                config.admin_email
+                            }}</a>
+                            <span>{{ $t('escribinosMesaAyudaMigracionMid') }}</span>
+                            <a
+                                href="https://www.instagram.com/carpoolear/?hl=en"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >{{ $t('footerInstagram') }}</a>
+                            <span>{{ $t('escribinosMesaAyudaMigracionOr') }}</span>
+                            <a
+                                href="https://www.facebook.com/Carpoolear"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >{{ $t('footerFacebook') }}</a>
                         </p>
                         <p>{{ $t('buenasRutas') }}</p>
                     </div>

--- a/src/components/views/Login.vue
+++ b/src/components/views/Login.vue
@@ -281,10 +281,6 @@
                     <span>
                         {{ $t('teniasCuentaVinculada') }} {{ modalType === 'facebook' ? $t('facebook') : $t('apple') }}?
                     </span>
-                    <i
-                        v-on:click="toggleModalLogin"
-                        class="fa fa-times float-right-close"
-                    ></i>
                 </h3></template>
                 <template #body><div>
                     <div class="text-left color-black login-modal">

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -111,7 +111,9 @@ const messages = {
         mesaAyudaContactoLead: 'Podés contactarnos desde la ',
         mesaAyudaContactoTail: '.',
         escribinosMesaAyudaMigracionLead:
-            'Para recuperar tu cuenta y migrarla a una cuenta vinculada a correo, escribinos desde la ',
+            'Para recuperar tu cuenta y migrarla a una cuenta vinculada a correo, escribinos a ',
+        escribinosMesaAyudaMigracionMid: ' o por mensaje a ',
+        escribinosMesaAyudaMigracionOr: ' o ',
         unaswered_messages_limit: 'Límites de consultas por un viaje',
         unaswered_messages_limitDescription:
             'Establece un máximo de consultas (solicitudes o mensajes) que podés recibir por un viaje.',
@@ -1489,7 +1491,9 @@ const messages = {
         mesaAyudaContactoLead: 'Podés contactarnos desde la ',
         mesaAyudaContactoTail: '.',
         escribinosMesaAyudaMigracionLead:
-            'Para recuperar tu cuenta y migrarla a una cuenta vinculada a correo, escribinos desde la ',
+            'Para recuperar tu cuenta y migrarla a una cuenta vinculada a correo, escribinos a ',
+        escribinosMesaAyudaMigracionMid: ' o por mensaje a ',
+        escribinosMesaAyudaMigracionOr: ' o ',
         requisitosRegister:
             'Se requiere que cargue: licencia de conductor, seguro del vehículo ...',
         RegistrarNuevoUsuario: 'Registrate',
@@ -2634,7 +2638,9 @@ const messages = {
         mesaAyudaContactoLead: 'You can contact us through the ',
         mesaAyudaContactoTail: '.',
         escribinosMesaAyudaMigracionLead:
-            'To recover your account and link it to an email login, reach us through the ',
+            'To recover your account and migrate it to an email-linked account, write us at ',
+        escribinosMesaAyudaMigracionMid: ' or message us on ',
+        escribinosMesaAyudaMigracionOr: ' or ',
         unaswered_messages_limit: 'Query limits per trip',
         unaswered_messages_limitDescription:
             'Set a maximum number of queries (requests or messages) you can receive per trip.',

--- a/src/language/loginSocialMigrationContact.test.js
+++ b/src/language/loginSocialMigrationContact.test.js
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import messages from './i18n';
+
+const MIGRATION_CONTACT_ES = {
+    escribinosMesaAyudaMigracionLead:
+        'Para recuperar tu cuenta y migrarla a una cuenta vinculada a correo, escribinos a ',
+    escribinosMesaAyudaMigracionMid: ' o por mensaje a ',
+    escribinosMesaAyudaMigracionOr: ' o '
+};
+
+const MIGRATION_CONTACT_BY_LOCALE = {
+    arg: MIGRATION_CONTACT_ES,
+    chl: MIGRATION_CONTACT_ES,
+    en: {
+        escribinosMesaAyudaMigracionLead:
+            'To recover your account and migrate it to an email-linked account, write us at ',
+        escribinosMesaAyudaMigracionMid: ' or message us on ',
+        escribinosMesaAyudaMigracionOr: ' or '
+    }
+};
+
+const CARPOOLEAR_FACEBOOK_URL = 'https://www.facebook.com/Carpoolear';
+const CARPOOLEAR_INSTAGRAM_URL =
+    'https://www.instagram.com/carpoolear/?hl=en';
+
+const loginViewPath = path.resolve(
+    __dirname,
+    '../components/views/Login.vue'
+);
+const loginViewSource = fs.readFileSync(loginViewPath, 'utf8');
+
+describe('Login social migration contact (i18n)', () => {
+    it.each(Object.entries(MIGRATION_CONTACT_BY_LOCALE))(
+        '%s locale has migration contact copy for email and social networks',
+        (locale, expected) => {
+            Object.entries(expected).forEach(([key, label]) => {
+                expect(messages[locale][key]).toBe(label);
+            });
+        }
+    );
+
+    it('arg locale no longer points migration help to mesa de ayuda', () => {
+        expect(messages.arg.escribinosMesaAyudaMigracionLead).not.toContain(
+            'escribinos desde la'
+        );
+    });
+});
+
+describe('Login.vue social migration contact links', () => {
+    it('shows mailto admin email and Carpoolear Instagram/Facebook profile links', () => {
+        expect(loginViewSource).toContain(
+            "$t('escribinosMesaAyudaMigracionLead')"
+        );
+        expect(loginViewSource).toContain(
+            "$t('escribinosMesaAyudaMigracionMid')"
+        );
+        expect(loginViewSource).toContain(
+            "$t('escribinosMesaAyudaMigracionOr')"
+        );
+        expect(loginViewSource).toContain(
+            ":href=\"'mailto:' + config.admin_email\""
+        );
+        expect(loginViewSource).toContain(CARPOOLEAR_FACEBOOK_URL);
+        expect(loginViewSource).toContain(CARPOOLEAR_INSTAGRAM_URL);
+        expect(loginViewSource).toContain("$t('footerInstagram')");
+        expect(loginViewSource).toContain("$t('footerFacebook')");
+    });
+
+    it('does not route migration contact through mesa de ayuda tickets', () => {
+        expect(loginViewSource).not.toMatch(
+            /escribinosMesaAyudaMigracionLead[\s\S]{0,300}router-link[^>]*name:\s*'tickets'/
+        );
+    });
+});

--- a/src/language/loginSocialMigrationContact.test.js
+++ b/src/language/loginSocialMigrationContact.test.js
@@ -2,6 +2,10 @@ import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import messages from './i18n';
+import {
+    CARPOOLEAR_FACEBOOK_URL,
+    CARPOOLEAR_INSTAGRAM_URL
+} from '../utils/carpoolearSocialUrls';
 
 const MIGRATION_CONTACT_ES = {
     escribinosMesaAyudaMigracionLead:
@@ -20,10 +24,6 @@ const MIGRATION_CONTACT_BY_LOCALE = {
         escribinosMesaAyudaMigracionOr: ' or '
     }
 };
-
-const CARPOOLEAR_FACEBOOK_URL = 'https://www.facebook.com/Carpoolear';
-const CARPOOLEAR_INSTAGRAM_URL =
-    'https://www.instagram.com/carpoolear/?hl=en';
 
 const loginViewPath = path.resolve(
     __dirname,
@@ -62,8 +62,15 @@ describe('Login.vue social migration contact links', () => {
         expect(loginViewSource).toContain(
             ":href=\"'mailto:' + config.admin_email\""
         );
-        expect(loginViewSource).toContain(CARPOOLEAR_FACEBOOK_URL);
-        expect(loginViewSource).toContain(CARPOOLEAR_INSTAGRAM_URL);
+        expect(loginViewSource).toContain('carpoolearFacebookUrl');
+        expect(loginViewSource).toContain('carpoolearInstagramUrl');
+        expect(loginViewSource).toContain('carpoolearSocialUrls');
+        expect(CARPOOLEAR_FACEBOOK_URL).toBe(
+            'https://www.facebook.com/Carpoolear'
+        );
+        expect(CARPOOLEAR_INSTAGRAM_URL).toBe(
+            'https://www.instagram.com/carpoolear/?hl=en'
+        );
         expect(loginViewSource).toContain("$t('footerInstagram')");
         expect(loginViewSource).toContain("$t('footerFacebook')");
     });

--- a/src/language/loginSocialMigrationContact.test.js
+++ b/src/language/loginSocialMigrationContact.test.js
@@ -80,4 +80,10 @@ describe('Login.vue social migration contact links', () => {
             /escribinosMesaAyudaMigracionLead[\s\S]{0,300}router-link[^>]*name:\s*'tickets'/
         );
     });
+
+    it('relies on Modal header close only (no duplicate green float-right-close)', () => {
+        expect(loginViewSource).not.toMatch(
+            /showModalLogin[\s\S]{0,600}float-right-close/
+        );
+    });
 });

--- a/src/utils/carpoolearSocialUrls.js
+++ b/src/utils/carpoolearSocialUrls.js
@@ -1,0 +1,3 @@
+export const CARPOOLEAR_FACEBOOK_URL = 'https://www.facebook.com/Carpoolear';
+export const CARPOOLEAR_INSTAGRAM_URL =
+    'https://www.instagram.com/carpoolear/?hl=en';


### PR DESCRIPTION
## Summary
Updates the Apple/Facebook login deprecation modal so account recovery/migration instructions point users to email and Carpoolear social profiles instead of Mesa de ayuda.
### Frontend
- **Login modal** (`Login.vue`): Replaces the Mesa de ayuda `router-link` with:
  - `mailto:` link using `config.admin_email`
  - External links to Carpoolear Instagram and Facebook (same URLs as footer/header)
- **i18n** (`i18n.js`): New copy for `arg`, `chl`, and `en`:
  - `escribinosMesaAyudaMigracionLead` — text before the email
  - `escribinosMesaAyudaMigracionMid` — “ o por mensaje a ” / “ or message us on ”
  - `escribinosMesaAyudaMigracionOr` — “ o ” / “ or ”
- **Shared URLs** (`carpoolearSocialUrls.js`): Centralizes Facebook/Instagram profile URLs used by the modal
- **Tests** (`loginSocialMigrationContact.test.js`): TDD coverage for i18n strings and modal markup (no tickets route)
