### PR TITLE
Modal carpoodatos

### DIFF
--- a/src/components/views/MyTrips.view.test.js
+++ b/src/components/views/MyTrips.view.test.js
@@ -25,3 +25,13 @@ describe('MyTrips trip card navigation', () => {
         expect(source).not.toContain(':clickModal="user.is_admin"');
     });
 });
+
+describe('MyTrips pending rates carpoodatos modal', () => {
+    it('does not show the carpoodatos hint modal for pending ratings', () => {
+        expect(source).not.toContain('showModalPendingRates');
+        expect(source).not.toContain('carpoodatosImportanteCalificar');
+        expect(source).not.toContain('carpoodatosTiempoCalificar');
+        expect(source).not.toContain('carpoodatosNoBorrar');
+        expect(source).not.toContain('carpoodatosDeciLoQuePensas');
+    });
+});

--- a/src/components/views/MyTrips.vue
+++ b/src/components/views/MyTrips.vue
@@ -53,72 +53,6 @@
         <div class="col-xs-24">
             <modal
                 :name="'modal'"
-                v-if="showModalPendingRates"
-                @close="toPendingRates"
-                :title="$t('carpoodatos')"
-                :body="'Body'"
-                :hide-footer="true"
-            >
-                <template #header><h3>
-                    <span>{{ $t('carpoodatos') }}</span>
-                    <i
-                        v-on:click="toPendingRates"
-                        class="fa fa-times float-right-close"
-                    ></i>
-                </h3></template>
-                <template #body><div>
-                    <div class="text-left carpoodatos">
-                        <p>
-                            <b>{{ $t('carpoodatosImportanteCalificar').split('.')[0] }}</b>
-                            {{ $t('carpoodatosImportanteCalificar').split('.')[1] }}
-                        </p>
-                        <p>
-                            <b
-                                >{{ $t('carpoodatosTiempoCalificar').split('.')[0] }}</b
-                            >
-                            {{ $t('carpoodatosTiempoCalificar').split('.')[1] }}
-                        </p>
-                        <p>
-                            <b
-                                >{{ $t('carpoodatosNoBorrar').split('.')[0] }}</b
-                            >
-                            {{ $t('carpoodatosNoBorrar').split('.')[1] }}
-                        </p>
-                        <p>
-                            <b>{{ $t('carpoodatosDeciLoQuePensas').split('.')[0] }}</b>
-                            {{ $t('carpoodatosDeciLoQuePensas').split('.')[1] }}
-                        </p>
-                        <p>
-                            {{ $t('carpoodatosContacto') }}
-                            <a :href="'mailto:' + config.admin_email">
-                                {{ config.admin_email }}
-                            </a>
-                            {{ $t('oNuestrasRedesSociales') }}
-                        </p>
-                    </div>
-                    <div class="check" style="margin-bottom: 10px">
-                        <label class="check-inline">
-                            <input
-                                type="checkbox"
-                                name="pendingRatesValor"
-                                value="0"
-                                v-model="pendingRatesValue"
-                            />
-                            <span>{{ $t('carpoodatosNoVolverAMostrar') }}</span>
-                        </label>
-                    </div>
-                    <div class="text-center">
-                        <button
-                            class="btn btn-accept-request"
-                            @click="toPendingRates"
-                        >
-                            {{ $t('carpoodatosEntiendo') }}
-                        </button>
-                    </div>
-                </div></template>
-            </modal>
-            <modal
-                :name="'modal'"
                 v-if="showModalRequestDonation"
                 @close="onModalClose"
                 :title="'Test'"
@@ -409,10 +343,7 @@ export default {
         return {
             showModalRequestDonation: false,
             donateValue: 0,
-            modalTripId: 0,
-            showModalPendingRates: false,
-            pendingRatesValue: 0,
-            alreadyAlerted: false
+            modalTripId: 0
         };
     },
     mounted() {
@@ -477,8 +408,7 @@ export default {
             findSubscriptions: 'index'
         }),
         ...mapActions(useProfileStore, {
-            registerDonation: 'registerDonation',
-            changeProperty: 'changeProperty'
+            registerDonation: 'registerDonation'
         }),
         findTrip(id) {
             if (this.trips) {
@@ -603,18 +533,6 @@ export default {
             }
         },
 
-        toPendingRates() {
-            if (this.pendingRatesValue) {
-                let data = {
-                    property: 'do_not_alert_pending_rates',
-                    value: 1
-                };
-                this.changeProperty(data).then(() => {
-                    console.log('do not alert success');
-                });
-            }
-            this.showModalPendingRates = false;
-        },
         onMessageModalClose() {
             this.showModalRequestDonation = false;
             let data = {
@@ -694,18 +612,8 @@ export default {
         passengerTrips: function () {
             this.updateScroll();
         },
-        pendingRates: function (newValue, oldValue) {
+        pendingRates: function () {
             this.updateScroll();
-            if (
-                !this.user.do_not_alert_pending_rates &&
-                !this.config.disable_user_hints
-            ) {
-                console.log('pendingRates', newValue, oldValue);
-                if (newValue && newValue.length > 0 && !this.alreadyAlerted) {
-                    this.alreadyAlerted = true;
-                    this.showModalPendingRates = true;
-                }
-            }
         },
         pendingRequest: function () {
             this.updateScroll();

--- a/src/components/views/MyTrips.vue
+++ b/src/components/views/MyTrips.vue
@@ -533,16 +533,6 @@ export default {
             }
         },
 
-        onMessageModalClose() {
-            this.showModalRequestDonation = false;
-            let data = {
-                has_donated: 0,
-                has_denied: 1,
-                ammount: 0,
-                trip_id: this.modalTripId
-            };
-            this.registerDonation(data);
-        },
         onModalClose() {
             this.showModalRequestDonation = false;
             let data = {

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -804,15 +804,6 @@ const messages = {
         pendientesDeContestar: 'Pendientes de contestar',
         noHayPendientesDeContestar: 'No hay pendientes de contestar',
         carpoodatos: 'Carpoodatos',
-        carpoodatosImportanteCalificar:
-            'Importante: Calificá a tus compañeros de viaje.',
-        carpoodatosTiempoCalificar:
-            'Tenés 30 días para calificar desde que finalizó el viaje.',
-        carpoodatosNoBorrar: 'No borres el viaje de tu historial.',
-        carpoodatosDeciLoQuePensas: 'Decí lo que pensás.',
-        carpoodatosContacto: 'Si tenés algún problema, contactanos a',
-        carpoodatosNoVolverAMostrar: 'No volver a mostrar',
-        carpoodatosEntiendo: 'Entiendo',
         buenisimoCompartirViaje: '¡Buenísimo compartir viaje!',
         ayudanosPlataforma: 'Ayudanos a mantener la plataforma',
         elegiPropiaAventura: 'Elegí tu propia aventura',
@@ -1694,15 +1685,6 @@ const messages = {
         pendientesDeContestar: 'Pendientes de contestar',
         noHayPendientesDeContestar: 'No hay pendientes de contestar',
         carpoodatos: 'Carpoodatos',
-        carpoodatosImportanteCalificar:
-            'Importante: Calificá a tus compañeros de viaje.',
-        carpoodatosTiempoCalificar:
-            'Tenés 30 días para calificar desde que finalizó el viaje.',
-        carpoodatosNoBorrar: 'No borres el viaje de tu historial.',
-        carpoodatosDeciLoQuePensas: 'Decí lo que pensás.',
-        carpoodatosContacto: 'Si tenés algún problema, contactanos a',
-        carpoodatosNoVolverAMostrar: 'No volver a mostrar',
-        carpoodatosEntiendo: 'Entiendo',
         buenisimoCompartirViaje: '¡Buenísimo compartir viaje!',
         ayudanosPlataforma: 'Ayudanos a mantener la plataforma',
         elegiPropiaAventura: 'Elegí tu propia aventura',
@@ -3326,15 +3308,6 @@ const messages = {
         pendientesDeContestar: 'Pending response',
         noHayPendientesDeContestar: 'No pending responses',
         carpoodatos: 'Carpoodata',
-        carpoodatosImportanteCalificar:
-            'Important: Rate your travel companions.',
-        carpoodatosTiempoCalificar:
-            'You have 30 days to rate from when the trip ended.',
-        carpoodatosNoBorrar: 'Do not delete the trip from your history.',
-        carpoodatosDeciLoQuePensas: 'Say what you think.',
-        carpoodatosContacto: 'If you have any problems, contact us at',
-        carpoodatosNoVolverAMostrar: 'Do not show again',
-        carpoodatosEntiendo: 'I understand',
         buenisimoCompartirViaje: 'Sharing a ride is awesome!',
         ayudanosPlataforma: 'Help us maintain the platform',
         elegiPropiaAventura: 'Choose your own adventure',


### PR DESCRIPTION
## Summary
Removes the Carpoodatos hint popup that appeared on **My Trips** when users had pending ratings.
### Frontend
- Removed the pending-ratings Carpoodatos modal from `MyTrips.vue` (template, auto-open watcher, and related state/handlers)
- Removed unused i18n strings for that modal (`carpoodatosImportanteCalificar`, `carpoodatosTiempoCalificar`, `carpoodatosNoBorrar`, `carpoodatosDeciLoQuePensas`, `carpoodatosContacto`, `carpoodatosNoVolverAMostrar`, `carpoodatosEntiendo`) in ES and EN
- Added a view test asserting the modal is no longer present
- Removed duplicate dead code (`onMessageModalClose`)
