### PR TITLE
Admin user detail all properties

### DIFF
--- a/src/components/AdminReviewSubjectUserLine.view.test.js
+++ b/src/components/AdminReviewSubjectUserLine.view.test.js
@@ -13,9 +13,8 @@ describe('AdminReviewSubjectUserLine component', () => {
         expect(source).toContain('userName');
     });
 
-    it('includes public profile link in parentheses when userId is present', () => {
-        expect(source).toContain("name: 'profile'");
-        expect(source).toContain('params: { id: userId }');
-        expect(source).toContain("{{ $t('verPerfilPublico') }}");
+    it('does not link to the public profile route', () => {
+        expect(source).not.toContain("name: 'profile'");
+        expect(source).not.toContain("{{ $t('verPerfilPublico') }}");
     });
 });

--- a/src/components/AdminReviewSubjectUserLine.vue
+++ b/src/components/AdminReviewSubjectUserLine.vue
@@ -3,7 +3,6 @@
         <router-link v-if="userId" :to="getAdminUserProfileRoute(userId)">
             {{ userName }}
         </router-link>
-        <template v-if="userId">&nbsp;(<router-link :to="{ name: 'profile', params: { id: userId } }" target="_blank">{{ $t('verPerfilPublico') }}</router-link>)</template>
         <span v-else>{{ userName || $t('na') }}</span>
     </p>
 </template>

--- a/src/components/elements/AdminRatingCard.vue
+++ b/src/components/elements/AdminRatingCard.vue
@@ -25,10 +25,7 @@
                     <span class="admin-rating-card__sep" aria-hidden="true">·</span>
                     <router-link
                         class="admin-rating-card__user"
-                        :to="{
-                            name: 'profile',
-                            params: { id: counterparty.id }
-                        }"
+                        :to="getAdminUserProfileRoute(counterparty.id)"
                     >
                         {{ counterparty.name }}
                     </router-link>
@@ -119,6 +116,8 @@
 </template>
 
 <script>
+import { getAdminUserProfileRoute } from '../../utils/adminProfileRoute';
+
 export default {
     name: 'admin-rating-card',
     props: {
@@ -148,6 +147,9 @@ export default {
         }
     },
     emits: ['edit', 'save', 'cancel', 'update:editForm'],
+    methods: {
+        getAdminUserProfileRoute
+    },
     computed: {
         pillClass() {
             return Number(this.rate.rating) === 1

--- a/src/components/elements/AdminReferenceCard.vue
+++ b/src/components/elements/AdminReferenceCard.vue
@@ -9,10 +9,7 @@
                 <router-link
                     v-if="author"
                     class="admin-reference-card__user"
-                    :to="{
-                        name: 'profile',
-                        params: { id: author.id }
-                    }"
+                    :to="getAdminUserProfileRoute(author.id)"
                 >
                     {{ author.name }}
                 </router-link>
@@ -71,6 +68,8 @@
 </template>
 
 <script>
+import { getAdminUserProfileRoute } from '../../utils/adminProfileRoute';
+
 export default {
     name: 'admin-reference-card',
     props: {
@@ -95,7 +94,10 @@ export default {
             default: false
         }
     },
-    emits: ['edit', 'save', 'cancel', 'update:editComment']
+    emits: ['edit', 'save', 'cancel', 'update:editComment'],
+    methods: {
+        getAdminUserProfileRoute
+    }
 };
 </script>
 

--- a/src/components/views/AdminManualIdentityValidations.view.test.js
+++ b/src/components/views/AdminManualIdentityValidations.view.test.js
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const viewPath = path.resolve(__dirname, 'AdminManualIdentityValidations.vue');
+const viewSource = fs.readFileSync(viewPath, 'utf8');
+
+describe('AdminManualIdentityValidations view', () => {
+    it('links user profile action to the admin user profile route', () => {
+        expect(viewSource).toContain('getAdminUserProfileRoute');
+        expect(viewSource).not.toContain("name: 'profile'");
+    });
+});

--- a/src/components/views/AdminManualIdentityValidations.vue
+++ b/src/components/views/AdminManualIdentityValidations.vue
@@ -40,8 +40,7 @@
                                 <td>
                                     <router-link
                                         v-if="item.user_id"
-                                        :to="{ name: 'profile', params: { id: item.user_id } }"
-                                        target="_blank"
+                                        :to="getAdminUserProfileRoute(item.user_id)"
                                         class="btn btn-link btn-sm"
                                     >
                                         {{ $t('verPerfil') }}
@@ -73,6 +72,7 @@
 import AdminLayout from '../layouts/AdminLayout.vue';
 import Loading from '../Loading';
 import { AdminApi } from '../../services/api';
+import { getAdminUserProfileRoute } from '../../utils/adminProfileRoute';
 
 export default {
     name: 'AdminManualIdentityValidations',
@@ -82,6 +82,7 @@ export default {
         };
     },
     methods: {
+        getAdminUserProfileRoute,
         formatDate(value) {
             if (!value) return '-';
             return new Date(value).toLocaleString();

--- a/src/components/views/AdminMpRejectedValidations.view.test.js
+++ b/src/components/views/AdminMpRejectedValidations.view.test.js
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const viewPath = path.resolve(__dirname, 'AdminMpRejectedValidations.vue');
+const viewSource = fs.readFileSync(viewPath, 'utf8');
+
+describe('AdminMpRejectedValidations view', () => {
+    it('links user profile action to the admin user profile route', () => {
+        expect(viewSource).toContain('getAdminUserProfileRoute');
+        expect(viewSource).not.toContain("name: 'profile'");
+    });
+});

--- a/src/components/views/AdminMpRejectedValidations.vue
+++ b/src/components/views/AdminMpRejectedValidations.vue
@@ -33,8 +33,7 @@
                                 <td>
                                     <router-link
                                         v-if="item.user_id"
-                                        :to="{ name: 'profile', params: { id: item.user_id } }"
-                                        target="_blank"
+                                        :to="getAdminUserProfileRoute(item.user_id)"
                                         class="btn btn-link btn-sm"
                                     >
                                         {{ $t('verPerfil') }}
@@ -66,6 +65,7 @@
 import AdminLayout from '../layouts/AdminLayout.vue';
 import Loading from '../Loading';
 import { AdminApi } from '../../services/api';
+import { getAdminUserProfileRoute } from '../../utils/adminProfileRoute';
 
 export default {
     name: 'AdminMpRejectedValidations',
@@ -75,6 +75,7 @@ export default {
         };
     },
     methods: {
+        getAdminUserProfileRoute,
         formatDate(value) {
             if (!value) return '-';
             return new Date(value).toLocaleString();

--- a/src/components/views/AdminSupportTicketDetail.view.test.js
+++ b/src/components/views/AdminSupportTicketDetail.view.test.js
@@ -20,11 +20,12 @@ describe('AdminSupportTicketDetail view', () => {
         expect(viewSource).toContain('ticket-priority-label');
     });
 
-    it('shows user name with app profile link and admin profile link label', () => {
+    it('links non-admin reply authors to the admin user profile', () => {
         expect(viewSource).toContain('replyAuthorLabel(reply)');
-        expect(viewSource).toContain("name: 'profile'");
-        expect(viewSource).toContain("name: 'admin-users-user'");
-        expect(viewSource).toContain("{{ $t('verPerfilEnAdmin') }}");
+        expect(viewSource).toContain('userAdminProfileRoute()');
+        expect(viewSource).toContain('getAdminUserProfileRoute');
+        expect(viewSource).not.toContain("name: 'profile'");
+        expect(viewSource).not.toContain("{{ $t('verPerfilEnAdmin') }}");
     });
 
     it('shows Carpoolear team plus admin name and id for staff replies', () => {

--- a/src/components/views/AdminSupportTicketDetail.vue
+++ b/src/components/views/AdminSupportTicketDetail.vue
@@ -43,16 +43,10 @@
                     <strong>
                         <span v-if="reply.is_admin">{{ adminReplyAuthorLabel(reply) }}</span>
                         <span v-else>
-                            <router-link v-if="canLinkUserProfile()" :to="userAppProfileRoute()">
+                            <router-link v-if="canLinkUserProfile()" :to="userAdminProfileRoute()">
                                 {{ replyAuthorLabel(reply) }}
                             </router-link>
                             <span v-else>{{ replyAuthorLabel(reply) }}</span>
-                            (
-                            <router-link v-if="canLinkUserProfile()" :to="userAdminProfileRoute()">
-                                {{ $t('verPerfilEnAdmin') }}
-                            </router-link>
-                            <span v-else>{{ $t('verPerfilEnAdmin') }}</span>
-                            )
                         </span>
                     </strong>
                     <small class="reply-meta-date" :title="fullDate(reply.created_at)">{{ relativeDate(reply.created_at) }}</small>
@@ -197,6 +191,7 @@ import {
     TICKET_STATUS_LABEL_KEYS as STATUS_LABEL_KEYS
 } from '../../utils/supportTicketStatusLabels';
 import { USER_TICKET_TYPE_OPTIONS } from '../../utils/supportTicketTypeOptions';
+import { getAdminUserProfileRoute } from '../../utils/adminProfileRoute';
 import {
     SUPPORT_TICKET_REPLY_EDITOR_HEIGHT,
     SUPPORT_TICKET_REPLY_EDITOR_CLASS
@@ -351,11 +346,8 @@ export default {
         canLinkUserProfile() {
             return Boolean(this.ticket && this.ticket.user && this.ticket.user.id);
         },
-        userAppProfileRoute() {
-            return { name: 'profile', params: { id: this.ticket.user.id } };
-        },
         userAdminProfileRoute() {
-            return { name: 'admin-users-user', params: { userId: this.ticket.user.id } };
+            return getAdminUserProfileRoute(this.ticket.user.id);
         },
         backToTicketsRoute() {
             return { name: 'admin-support-tickets' };

--- a/src/components/views/AdminSupportTickets.view.test.js
+++ b/src/components/views/AdminSupportTickets.view.test.js
@@ -46,10 +46,11 @@ describe('AdminSupportTickets view', () => {
         expect(viewSource).toContain('support-tickets-table__owner');
     });
 
-    it('links ticket owner display name to the public profile route when linkable', () => {
+    it('links ticket owner display name to the admin user profile route when linkable', () => {
         expect(viewSource).toContain('canLinkTicketOwnerProfile(ticket)');
-        expect(viewSource).toContain('ticketOwnerAppProfileRoute(ticket)');
-        expect(viewSource).toContain("name: 'profile'");
+        expect(viewSource).toContain('ticketOwnerAdminProfileRoute(ticket)');
+        expect(viewSource).toContain('getAdminUserProfileRoute');
+        expect(viewSource).not.toContain("name: 'profile'");
     });
 
     it('uses compact narrow columns and a wide subject column class', () => {

--- a/src/components/views/AdminSupportTickets.vue
+++ b/src/components/views/AdminSupportTickets.vue
@@ -66,7 +66,7 @@
                                 <span class="support-tickets-table__owner-sep" aria-hidden="true"> · </span>
                                 <router-link
                                     v-if="canLinkTicketOwnerProfile(ticket)"
-                                    :to="ticketOwnerAppProfileRoute(ticket)"
+                                    :to="ticketOwnerAdminProfileRoute(ticket)"
                                 >{{ ticketOwnerDisplayName(ticket) }}</router-link>
                                 <span v-else>{{ ticketOwnerDisplayName(ticket) }}</span>
                             </span>
@@ -109,10 +109,7 @@ import {
     parseAdminSupportTicketListFiltersFromRoute
 } from '../../utils/adminSupportTicketListFilters';
 import { getUpdatedAgeAttentionClass, hasUnreadUserReplyIndicator } from '../../utils/supportTicketUpdatedAgeAttention';
-
-function userAppProfileLocation(userId) {
-    return { name: 'profile', params: { id: userId } };
-}
+import { getAdminUserProfileRoute } from '../../utils/adminProfileRoute';
 
 const ticketTypeOptions = USER_TICKET_TYPE_OPTIONS;
 
@@ -242,8 +239,8 @@ export default {
         canLinkTicketOwnerProfile(ticket) {
             return Boolean(ticket && ticket.user && ticket.user.id);
         },
-        ticketOwnerAppProfileRoute(ticket) {
-            return userAppProfileLocation(ticket.user.id);
+        ticketOwnerAdminProfileRoute(ticket) {
+            return getAdminUserProfileRoute(ticket.user.id);
         },
         ticketOwnerDisplayName(ticket) {
             const u = ticket && ticket.user;

--- a/src/components/views/AdminUserDetail.view.test.js
+++ b/src/components/views/AdminUserDetail.view.test.js
@@ -46,4 +46,19 @@ describe('AdminUserDetail view', () => {
         expect(source).toContain('user.references');
         expect(source).toContain('adminUserNavLabel(');
     });
+
+    it('highlights banned status at the top with colored banner', () => {
+        expect(source).toContain('getAdminUserBannedBanner');
+        expect(source).toContain('admin-user-detail__status');
+        expect(source).toContain('bannedBanner.modifier');
+        expect(source).toContain("'alert-' + bannedBanner.modifier");
+    });
+
+    it('renders all user properties from the admin profile payload', () => {
+        expect(source).toContain('buildAdminUserPropertyRows');
+        expect(source).toContain('admin-user-detail__properties');
+        expect(source).toContain('propertyRows');
+        expect(source).toContain('row.label');
+        expect(source).toContain('row.value');
+    });
 });

--- a/src/components/views/AdminUserDetail.vue
+++ b/src/components/views/AdminUserDetail.vue
@@ -23,6 +23,13 @@
                         v-else-if="user"
                         class="user-settings settings-container user-admin-view"
                     >
+                        <div
+                            class="admin-user-detail__status alert"
+                            :class="'alert-' + bannedBanner.modifier"
+                            role="status"
+                        >
+                            <strong>{{ bannedBanner.label }}</strong>
+                        </div>
                         <h3>
                             {{ user.name }}
                             <small class="text-muted">#{{ user.id }}</small>
@@ -37,35 +44,29 @@
                                 {{ $t('verPerfilPublico') }}
                             </router-link>
                         </p>
-                        <p>
-                            <strong>{{ $t('eMail') }}:</strong>
-                            {{ user.email || '—' }}
-                        </p>
-                        <p>
-                            <strong>{{ $t('numeroDeTelefono') }}:</strong>
-                            {{ user.mobile_phone || '—' }}
-                        </p>
-                        <p>
-                            <strong>{{ $t('doc') }}:</strong>
-                            {{ user.nro_doc || '—' }}
-                        </p>
-                        <p v-if="config && config.module_facebook_profile_url_enabled">
-                            <strong>Perfil de Facebook:</strong>
-                            <span v-if="user.facebook_profile_url">
-                                <a
-                                    :href="user.facebook_profile_url"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                >
-                                    {{ user.facebook_profile_url }}
-                                </a>
-                            </span>
-                            <span v-else>—</span>
-                        </p>
-                        <p>
-                            <strong>{{ $t('ultimaConexion') }}</strong>
-                            {{ user.last_connection || '—' }}
-                        </p>
+                        <dl class="admin-user-detail__properties">
+                            <div
+                                v-for="row in propertyRows"
+                                :key="row.key"
+                                class="admin-user-detail__property"
+                            >
+                                <dt>{{ row.label }}</dt>
+                                <dd>
+                                    <a
+                                        v-if="
+                                            row.key === 'facebook_profile_url' &&
+                                            row.value !== '—'
+                                        "
+                                        :href="row.value"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                    >
+                                        {{ row.value }}
+                                    </a>
+                                    <span v-else>{{ row.value }}</span>
+                                </dd>
+                            </div>
+                        </dl>
                         <p class="user-admin-view-nav">
                             <router-link
                                 :to="{
@@ -143,6 +144,10 @@ import { useAuthStore } from '../../stores/auth';
 import AdminLayout from '../layouts/AdminLayout.vue';
 import { adminUserSupportTicketsRoute } from '../../utils/adminUserSupportTicketsLink';
 import { formatAdminUserNavLabelFromKey } from '../../utils/adminUserNavLabel';
+import {
+    buildAdminUserPropertyRows,
+    getAdminUserBannedBanner
+} from '../../utils/adminUserDetailProperties';
 import router from '../../router';
 import { UserApi } from '../../services/api';
 import dialogs from '../../services/dialogs.js';
@@ -159,7 +164,21 @@ export default {
     computed: {
         ...mapState(useAuthStore, {
             config: 'appConfig'
-        })
+        }),
+        bannedBanner() {
+            return getAdminUserBannedBanner(this.user, this.$t.bind(this));
+        },
+        propertyRows() {
+            const rows = buildAdminUserPropertyRows(this.user, {
+                translate: this.$t.bind(this)
+            });
+
+            if (this.config && this.config.module_facebook_profile_url_enabled) {
+                return rows;
+            }
+
+            return rows.filter((row) => row.key !== 'facebook_profile_url');
+        }
     },
     methods: {
         ...mapActions(useConversationsStore, {
@@ -258,5 +277,35 @@ export default {
 
 .admin-user-detail__back {
     margin-bottom: 12px;
+}
+
+.admin-user-detail__status {
+    margin-bottom: 16px;
+}
+
+.admin-user-detail__properties {
+    margin: 0 0 16px;
+}
+
+.admin-user-detail__property {
+    display: grid;
+    grid-template-columns: minmax(140px, 32%) 1fr;
+    gap: 8px 16px;
+    padding: 8px 0;
+    border-bottom: 1px solid #eee;
+}
+
+.admin-user-detail__property:last-child {
+    border-bottom: none;
+}
+
+.admin-user-detail__property dt {
+    margin: 0;
+    font-weight: 600;
+}
+
+.admin-user-detail__property dd {
+    margin: 0;
+    word-break: break-word;
 }
 </style>

--- a/src/components/views/AdminUserDetail.vue
+++ b/src/components/views/AdminUserDetail.vue
@@ -169,15 +169,12 @@ export default {
             return getAdminUserBannedBanner(this.user, this.$t.bind(this));
         },
         propertyRows() {
-            const rows = buildAdminUserPropertyRows(this.user, {
-                translate: this.$t.bind(this)
+            return buildAdminUserPropertyRows(this.user, {
+                translate: this.$t.bind(this),
+                showFacebookProfileUrl: !!(
+                    this.config && this.config.module_facebook_profile_url_enabled
+                )
             });
-
-            if (this.config && this.config.module_facebook_profile_url_enabled) {
-                return rows;
-            }
-
-            return rows.filter((row) => row.key !== 'facebook_profile_url');
         }
     },
     methods: {

--- a/src/components/views/AdminUserRatings.view.test.js
+++ b/src/components/views/AdminUserRatings.view.test.js
@@ -21,11 +21,12 @@ describe('AdminUserRatings view', () => {
 });
 
 describe('AdminRatingCard', () => {
-    it('shows rating id, trip link, profile link, pill, and comment', () => {
+    it('shows rating id, trip link, admin profile link, pill, and comment', () => {
         expect(cardSource).toContain('admin-rating-card__row');
         expect(cardSource).toContain('admin-rating-card__id');
         expect(cardSource).toContain("name: 'detail_trip'");
-        expect(cardSource).toContain("name: 'profile'");
+        expect(cardSource).toContain('getAdminUserProfileRoute');
+        expect(cardSource).not.toContain("name: 'profile'");
         expect(cardSource).toContain('admin-rating-pill--positive');
         expect(cardSource).toContain('admin-rating-pill--negative');
         expect(cardSource).toContain('rate.comment');

--- a/src/components/views/AdminUserRecommendations.view.test.js
+++ b/src/components/views/AdminUserRecommendations.view.test.js
@@ -17,10 +17,11 @@ describe('AdminUserRecommendations view', () => {
 });
 
 describe('AdminReferenceCard', () => {
-    it('shows reference id, author link, comment, and edit on one row', () => {
+    it('shows reference id, author admin profile link, comment, and edit on one row', () => {
         expect(cardSource).toContain('admin-reference-card__row');
         expect(cardSource).toContain('admin-reference-card__id');
-        expect(cardSource).toContain("name: 'profile'");
+        expect(cardSource).toContain('getAdminUserProfileRoute');
+        expect(cardSource).not.toContain("name: 'profile'");
         expect(cardSource).toContain('reference.comment');
         expect(cardSource).toContain('adminUsuariosEditarFila');
     });

--- a/src/components/views/UsersDeleteList.view.test.js
+++ b/src/components/views/UsersDeleteList.view.test.js
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const viewPath = path.resolve(__dirname, 'UsersDeleteList.vue');
+const viewSource = fs.readFileSync(viewPath, 'utf8');
+
+describe('UsersDeleteList view', () => {
+    it('links delete request user to the admin user profile route', () => {
+        expect(viewSource).toContain('getAdminUserProfileRoute');
+        expect(viewSource).not.toContain("name: 'profile'");
+    });
+});

--- a/src/components/views/UsersDeleteList.vue
+++ b/src/components/views/UsersDeleteList.vue
@@ -80,11 +80,10 @@
                                 <label>{{ $t('usuarioLabel') }} {{ currentRequest.user.name }}</label>
                                 <div style="margin-top: 8px;">
                                     <router-link
-                                        :to="{ name: 'profile', params: { id: currentRequest.user.id } }"
-                                        target="_blank"
+                                        :to="getAdminUserProfileRoute(currentRequest.user.id)"
                                         class="btn btn-link btn-sm"
                                     >
-                                        {{ $t('verPerfilPublico') }}
+                                        {{ $t('verPerfilEnAdmin') }}
                                     </router-link>
                                     <router-link
                                         :to="{ name: 'admin-users-edit', params: { userId: String(currentRequest.user.id) } }"
@@ -140,6 +139,7 @@ import Spinner from '../Spinner.vue';
 import { AdminApi } from '../../services/api';
 import dialogs from '../../services/dialogs.js';
 import dayjs from '../../dayjs';
+import { getAdminUserProfileRoute } from '../../utils/adminProfileRoute';
 
 export default {
     name: 'admin-users-delete-list',
@@ -157,6 +157,7 @@ export default {
         };
     },
     methods: {
+        getAdminUserProfileRoute,
         formatDate(dateString) {
             if (!dateString) return '-';
             return dayjs(dateString).format('DD/MM/YYYY HH:mm');

--- a/src/utils/adminProfileRoute.js
+++ b/src/utils/adminProfileRoute.js
@@ -3,6 +3,6 @@ export const ADMIN_USER_PROFILE_ROUTE_NAME = 'admin-users-user';
 export function getAdminUserProfileRoute(userId) {
     return {
         name: ADMIN_USER_PROFILE_ROUTE_NAME,
-        params: { userId }
+        params: { userId: String(userId) }
     };
 }

--- a/src/utils/adminProfileRoute.test.js
+++ b/src/utils/adminProfileRoute.test.js
@@ -8,7 +8,14 @@ describe('getAdminUserProfileRoute', () => {
     it('builds admin user detail route from user id', () => {
         expect(getAdminUserProfileRoute(42)).toEqual({
             name: ADMIN_USER_PROFILE_ROUTE_NAME,
-            params: { userId: 42 }
+            params: { userId: '42' }
+        });
+    });
+
+    it('stringifies string user ids for route params', () => {
+        expect(getAdminUserProfileRoute('99')).toEqual({
+            name: ADMIN_USER_PROFILE_ROUTE_NAME,
+            params: { userId: '99' }
         });
     });
 });

--- a/src/utils/adminUserDetailProperties.js
+++ b/src/utils/adminUserDetailProperties.js
@@ -1,3 +1,116 @@
+const EMPTY_VALUE = '—';
+
+const ADMIN_USER_PROPERTY_DEFINITIONS = [
+    { key: 'id', label: 'ID' },
+    { key: 'banned', labelKey: 'usuarioSuspendido', type: 'boolean' },
+    { key: 'active', labelKey: 'usuarioActivo', type: 'boolean' },
+    { key: 'name', labelKey: 'nombreYApellido' },
+    { key: 'username', labelKey: 'username' },
+    { key: 'email', labelKey: 'eMail' },
+    { key: 'mobile_phone', labelKey: 'numeroDeTelefono' },
+    { key: 'phone_verified', labelKey: 'phone_verified', type: 'boolean' },
+    { key: 'phone_verified_at', labelKey: 'phone_verified_at' },
+    { key: 'nro_doc', labelKey: 'doc' },
+    { key: 'is_admin', labelKey: 'is_admin', type: 'boolean' },
+    { key: 'is_member', labelKey: 'is_member', type: 'boolean' },
+    { key: 'has_pin', labelKey: 'has_pin', type: 'boolean' },
+    { key: 'description', labelKey: 'acercaDeMi' },
+    { key: 'private_note', labelKey: 'notaPrivada' },
+    { key: 'image', labelKey: 'image' },
+    { key: 'birthday', labelKey: 'birthday' },
+    { key: 'gender', labelKey: 'gender' },
+    { key: 'facebook_profile_url', label: 'Perfil de Facebook' },
+    { key: 'data_visibility', labelKey: 'data_visibility' },
+    { key: 'identity_validated', labelKey: 'identity_validated', type: 'boolean' },
+    { key: 'identity_validated_at', labelKey: 'identity_validated_at' },
+    { key: 'identity_validation_type', labelKey: 'identity_validation_type' },
+    {
+        key: 'identity_validation_rejected_at',
+        labelKey: 'identity_validation_rejected_at'
+    },
+    {
+        key: 'identity_validation_reject_reason',
+        labelKey: 'identity_validation_reject_reason'
+    },
+    { key: 'validate_by_date', labelKey: 'validate_by_date' },
+    { key: 'driver_is_verified', labelKey: 'driver_is_verified', type: 'boolean' },
+    { key: 'driver_data_docs', labelKey: 'driver_data_docs', type: 'json' },
+    { key: 'patente', labelKey: 'patente' },
+    { key: 'car_description', labelKey: 'car_description' },
+    { key: 'cars', labelKey: 'cars', type: 'json' },
+    { key: 'emails_notifications', labelKey: 'emails_notifications', type: 'boolean' },
+    {
+        key: 'do_not_alert_request_seat',
+        labelKey: 'do_not_alert_request_seat',
+        type: 'boolean'
+    },
+    {
+        key: 'do_not_alert_accept_passenger',
+        labelKey: 'do_not_alert_accept_passenger',
+        type: 'boolean'
+    },
+    {
+        key: 'do_not_alert_pending_rates',
+        labelKey: 'do_not_alert_pending_rates',
+        type: 'boolean'
+    },
+    { key: 'do_not_alert_pricing', labelKey: 'do_not_alert_pricing', type: 'boolean' },
+    { key: 'monthly_donate', labelKey: 'monthly_donate', type: 'boolean' },
+    { key: 'unaswered_messages_limit', labelKey: 'unaswered_messages_limit' },
+    { key: 'autoaccept_requests', labelKey: 'autoaccept_requests', type: 'boolean' },
+    { key: 'on_boarding_view', labelKey: 'on_boarding_view' },
+    { key: 'account_number', labelKey: 'account_number' },
+    { key: 'account_type', labelKey: 'account_type' },
+    { key: 'account_bank', labelKey: 'account_bank' },
+    { key: 'positive_ratings', labelKey: 'positive_ratings' },
+    { key: 'negative_ratings', labelKey: 'negative_ratings' },
+    { key: 'references', labelKey: 'references' },
+    { key: 'support_tickets_count', labelKey: 'support_tickets_count' },
+    { key: 'admin_trips_count', labelKey: 'admin_trips_count' },
+    { key: 'admin_ratings_count', labelKey: 'admin_ratings_count' },
+    { key: 'last_connection', labelKey: 'ultimaConexion' },
+    { key: 'created_at', labelKey: 'created_at' }
+];
+
+function isTruthyFlag(value) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    return Number(value) > 0;
+}
+
+export function formatAdminUserPropertyValue(value, type = 'text') {
+    if (type === 'boolean') {
+        if (value === null || value === undefined || value === '') {
+            return EMPTY_VALUE;
+        }
+        return isTruthyFlag(value) ? 'Sí' : 'No';
+    }
+
+    if (type === 'json') {
+        if (value === null || value === undefined) {
+            return EMPTY_VALUE;
+        }
+        return JSON.stringify(value);
+    }
+
+    if (value === null || value === undefined || value === '') {
+        return EMPTY_VALUE;
+    }
+
+    return String(value);
+}
+
+function resolvePropertyLabel(definition, translate) {
+    if (definition.label) {
+        return definition.label;
+    }
+    if (definition.labelKey) {
+        return translate(definition.labelKey);
+    }
+    return definition.key;
+}
+
 export function getAdminUserBannedBanner(user, translate) {
     const isBanned = Number(user?.banned) > 0;
 
@@ -14,6 +127,17 @@ export function getAdminUserBannedBanner(user, translate) {
     };
 }
 
-export function buildAdminUserPropertyRows() {
-    return [];
+export function buildAdminUserPropertyRows(user, { translate }) {
+    if (!user) {
+        return [];
+    }
+
+    return ADMIN_USER_PROPERTY_DEFINITIONS.map((definition) => ({
+        key: definition.key,
+        label: resolvePropertyLabel(definition, translate),
+        value: formatAdminUserPropertyValue(
+            user[definition.key],
+            definition.type || 'text'
+        )
+    }));
 }

--- a/src/utils/adminUserDetailProperties.js
+++ b/src/utils/adminUserDetailProperties.js
@@ -79,6 +79,10 @@ function isTruthyFlag(value) {
     return Number(value) > 0;
 }
 
+function isUserBanned(user) {
+    return isTruthyFlag(user?.banned);
+}
+
 export function formatAdminUserPropertyValue(value, type = 'text') {
     if (type === 'boolean') {
         if (value === null || value === undefined || value === '') {
@@ -112,9 +116,7 @@ function resolvePropertyLabel(definition, translate) {
 }
 
 export function getAdminUserBannedBanner(user, translate) {
-    const isBanned = Number(user?.banned) > 0;
-
-    if (isBanned) {
+    if (isUserBanned(user)) {
         return {
             label: translate('usuarioSuspendido'),
             modifier: 'danger'

--- a/src/utils/adminUserDetailProperties.js
+++ b/src/utils/adminUserDetailProperties.js
@@ -129,12 +129,15 @@ export function getAdminUserBannedBanner(user, translate) {
     };
 }
 
-export function buildAdminUserPropertyRows(user, { translate }) {
+export function buildAdminUserPropertyRows(
+    user,
+    { translate, showFacebookProfileUrl = true }
+) {
     if (!user) {
         return [];
     }
 
-    return ADMIN_USER_PROPERTY_DEFINITIONS.map((definition) => ({
+    const rows = ADMIN_USER_PROPERTY_DEFINITIONS.map((definition) => ({
         key: definition.key,
         label: resolvePropertyLabel(definition, translate),
         value: formatAdminUserPropertyValue(
@@ -142,4 +145,10 @@ export function buildAdminUserPropertyRows(user, { translate }) {
             definition.type || 'text'
         )
     }));
+
+    if (showFacebookProfileUrl) {
+        return rows;
+    }
+
+    return rows.filter((row) => row.key !== 'facebook_profile_url');
 }

--- a/src/utils/adminUserDetailProperties.js
+++ b/src/utils/adminUserDetailProperties.js
@@ -5,7 +5,6 @@ const ADMIN_USER_PROPERTY_DEFINITIONS = [
     { key: 'banned', labelKey: 'usuarioSuspendido', type: 'boolean' },
     { key: 'active', labelKey: 'usuarioActivo', type: 'boolean' },
     { key: 'name', labelKey: 'nombreYApellido' },
-    { key: 'username', labelKey: 'username' },
     { key: 'email', labelKey: 'eMail' },
     { key: 'mobile_phone', labelKey: 'numeroDeTelefono' },
     { key: 'phone_verified', labelKey: 'phone_verified', type: 'boolean' },

--- a/src/utils/adminUserDetailProperties.js
+++ b/src/utils/adminUserDetailProperties.js
@@ -1,0 +1,19 @@
+export function getAdminUserBannedBanner(user, translate) {
+    const isBanned = Number(user?.banned) > 0;
+
+    if (isBanned) {
+        return {
+            label: translate('usuarioSuspendido'),
+            modifier: 'danger'
+        };
+    }
+
+    return {
+        label: translate('usuarioActivo'),
+        modifier: 'success'
+    };
+}
+
+export function buildAdminUserPropertyRows() {
+    return [];
+}

--- a/src/utils/adminUserDetailProperties.test.js
+++ b/src/utils/adminUserDetailProperties.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import {
+    getAdminUserBannedBanner,
+    buildAdminUserPropertyRows
+} from './adminUserDetailProperties';
+
+const translate = (key) =>
+    ({
+        usuarioSuspendido: 'Usuario suspendido',
+        usuarioActivo: 'Usuario activo',
+        eMail: 'Email',
+        doc: 'DNI',
+        ultimaConexion: 'Última conexión'
+    }[key] || key);
+
+describe('getAdminUserBannedBanner', () => {
+    it('returns danger styling when user is banned', () => {
+        expect(getAdminUserBannedBanner({ banned: 1 }, translate)).toEqual({
+            label: 'Usuario suspendido',
+            modifier: 'danger'
+        });
+    });
+
+    it('returns success styling when user is not banned', () => {
+        expect(getAdminUserBannedBanner({ banned: 0 }, translate)).toEqual({
+            label: 'Usuario activo',
+            modifier: 'success'
+        });
+    });
+});

--- a/src/utils/adminUserDetailProperties.test.js
+++ b/src/utils/adminUserDetailProperties.test.js
@@ -28,3 +28,76 @@ describe('getAdminUserBannedBanner', () => {
         });
     });
 });
+
+describe('buildAdminUserPropertyRows', () => {
+    const sampleUser = {
+        id: 42,
+        name: 'Jane Doe',
+        email: 'jane@example.test',
+        nro_doc: '30123456',
+        banned: 0,
+        active: 1,
+        is_admin: 0,
+        mobile_phone: '+5491112345678',
+        last_connection: '2025-06-01 12:00:00',
+        identity_validated: true,
+        has_pin: 1,
+        references: 3,
+        support_tickets_count: 2,
+        admin_trips_count: 5,
+        admin_ratings_count: 1,
+        cars: [{ patente: 'ABC123', description: 'Fiat' }],
+        driver_data_docs: { license: 'ok' }
+    };
+
+    it('returns ordered rows with labels and formatted values', () => {
+        const rows = buildAdminUserPropertyRows(sampleUser, { translate });
+
+        expect(rows.length).toBeGreaterThan(10);
+        expect(rows[0]).toEqual({ key: 'id', label: 'ID', value: '42' });
+        expect(rows.find((row) => row.key === 'email')).toEqual({
+            key: 'email',
+            label: 'Email',
+            value: 'jane@example.test'
+        });
+        expect(rows.find((row) => row.key === 'banned')).toEqual({
+            key: 'banned',
+            label: 'usuarioSuspendido',
+            value: 'No'
+        });
+        expect(rows.find((row) => row.key === 'has_pin')).toEqual({
+            key: 'has_pin',
+            label: 'has_pin',
+            value: 'Sí'
+        });
+        expect(rows.find((row) => row.key === 'identity_validated')).toEqual({
+            key: 'identity_validated',
+            label: 'identity_validated',
+            value: 'Sí'
+        });
+        expect(rows.find((row) => row.key === 'cars')).toEqual({
+            key: 'cars',
+            label: 'cars',
+            value: '[{"patente":"ABC123","description":"Fiat"}]'
+        });
+    });
+
+    it('formats empty values as em dash', () => {
+        const rows = buildAdminUserPropertyRows(
+            { id: 1, name: 'Test', description: null, mobile_phone: '' },
+            { translate }
+        );
+
+        expect(rows.find((row) => row.key === 'description').value).toBe('—');
+        expect(rows.find((row) => row.key === 'mobile_phone').value).toBe('—');
+    });
+
+    it('places banned before other properties in row order', () => {
+        const rows = buildAdminUserPropertyRows(sampleUser, { translate });
+        const bannedIndex = rows.findIndex((row) => row.key === 'banned');
+        const emailIndex = rows.findIndex((row) => row.key === 'email');
+
+        expect(bannedIndex).toBeGreaterThanOrEqual(0);
+        expect(bannedIndex).toBeLessThan(emailIndex);
+    });
+});

--- a/src/utils/adminUserDetailProperties.test.js
+++ b/src/utils/adminUserDetailProperties.test.js
@@ -62,7 +62,7 @@ describe('buildAdminUserPropertyRows', () => {
         });
         expect(rows.find((row) => row.key === 'banned')).toEqual({
             key: 'banned',
-            label: 'usuarioSuspendido',
+            label: 'Usuario suspendido',
             value: 'No'
         });
         expect(rows.find((row) => row.key === 'has_pin')).toEqual({

--- a/src/utils/adminUserDetailProperties.test.js
+++ b/src/utils/adminUserDetailProperties.test.js
@@ -100,4 +100,13 @@ describe('buildAdminUserPropertyRows', () => {
         expect(bannedIndex).toBeGreaterThanOrEqual(0);
         expect(bannedIndex).toBeLessThan(emailIndex);
     });
+
+    it('hides facebook profile url when module flag is disabled', () => {
+        const rows = buildAdminUserPropertyRows(
+            { ...sampleUser, facebook_profile_url: 'https://facebook.com/jane' },
+            { translate, showFacebookProfileUrl: false }
+        );
+
+        expect(rows.find((row) => row.key === 'facebook_profile_url')).toBeUndefined();
+    });
 });


### PR DESCRIPTION
### Frontend (`carpoolear`)
- Admin user detail (`AdminUserDetail.vue`) now shows a colored status banner at the top highlighting whether the user is **Suspendido** (red) or **Activo** (green).
- Replaces the hand-picked field list with a full property grid driven by `adminUserDetailProperties.js`, listing all admin-visible user fields from the profile API in a logical order (status, identity, account, profile, validation, driver, settings, bank, stats, timestamps).
- Booleans render as Sí/No, objects/arrays as JSON, empty values as —. Facebook URL remains a clickable link and is hidden when `module_facebook_profile_url_enabled` is off.
- TDD: utility and view contract tests added; 10 commits following red/green/refactor cycles.
