### PR TITLE
Max price check fix

### DIFF
--- a/src/components/views/NewTrip.view.test.js
+++ b/src/components/views/NewTrip.view.test.js
@@ -5,6 +5,22 @@ import path from 'node:path';
 const viewPath = path.resolve(__dirname, 'NewTrip.vue');
 const viewSource = fs.readFileSync(viewPath, 'utf8');
 
+describe('NewTrip.vue max contribution validation timing', () => {
+    it('defers max contribution checks until trip-info cap is available', () => {
+        expect(viewSource).toContain("from '../../utils/tripMaxPriceValidation.js'");
+        expect(viewSource).toContain('exceedsMaximumSeatPrice');
+        expect(viewSource).toMatch(
+            /validatePrice\(\)[\s\S]*?maximumTripPriceCents:\s*this\.maximum_trip_price_cents/s
+        );
+        expect(viewSource).toMatch(
+            /validateReturnPrice\(\)[\s\S]*?maximumTripPriceCents:\s*this\.maximum_return_trip_price_cents/s
+        );
+        expect(viewSource).not.toMatch(
+            /this\.calcRoute\(type\);\s*\n\s*this\.recalculateRecommendedPrice\(\);/
+        );
+    });
+});
+
 describe('NewTrip.vue seat price API mapping', () => {
     it('imports seat price helpers for voluntary -1 sentinel', () => {
         expect(viewSource).toMatch(/from '\.\.\/\.\.\/utils\/tripSeatPrice\.js'/);

--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -2009,6 +2009,7 @@ import {
     seatPriceCentsForApi
 } from '../../utils/tripSeatPrice.js';
 import { seatPriceCentsFromTripPriceCents } from '../../utils/tripPriceOccupants.js';
+import { exceedsMaximumSeatPrice } from '../../utils/tripMaxPriceValidation.js';
 import { isRearMaxTwoCompatibleWithSeats, shouldBlockSeatSelection } from '../../utils/tripRearComfortSeats.js';
 import {
     activeCarsWithPlate,
@@ -2797,7 +2798,11 @@ export default {
                     );
                 } else if (
                     this.config.module_max_price_enabled &&
-                    seatP > this.maximum_seat_price_cents / 100
+                    exceedsMaximumSeatPrice({
+                        seatPriceUnits: seatP,
+                        maximumSeatPriceCents: this.maximum_seat_price_cents,
+                        maximumTripPriceCents: this.maximum_trip_price_cents
+                    })
                 ) {
                     globalError = true;
                     this.priceError.state = true;
@@ -2945,8 +2950,13 @@ export default {
                     } else if (
                         this.config.module_trip_creation_payment_enabled &&
                         this.config.module_max_price_enabled &&
-                        returnSeatP >
-                            this.maximum_return_seat_price_cents / 100
+                        exceedsMaximumSeatPrice({
+                            seatPriceUnits: returnSeatP,
+                            maximumSeatPriceCents:
+                                this.maximum_return_seat_price_cents,
+                            maximumTripPriceCents:
+                                this.maximum_return_trip_price_cents
+                        })
                     ) {
                         globalError = true;
                         this.returnPriceError.state = true;
@@ -3203,7 +3213,6 @@ export default {
             }
 
             this.calcRoute(type);
-            this.recalculateRecommendedPrice();
         },
 
         getPlaceholder(index) {
@@ -3349,9 +3358,12 @@ export default {
         validatePrice() {
             const p = parseSeatPriceInput(this.price);
             if (
-                p !== null &&
                 this.config.module_max_price_enabled &&
-                p > this.maximum_seat_price_cents / 100
+                exceedsMaximumSeatPrice({
+                    seatPriceUnits: p,
+                    maximumSeatPriceCents: this.maximum_seat_price_cents,
+                    maximumTripPriceCents: this.maximum_trip_price_cents
+                })
             ) {
                 this.priceError.state = true;
                 this.priceError.message = this.getMaxContributionExceededMessage(
@@ -3476,8 +3488,13 @@ export default {
         validateReturnPrice() {
             const p = parseSeatPriceInput(this.returnPrice);
             if (
-                p !== null &&
-                p > this.maximum_return_seat_price_cents / 100
+                exceedsMaximumSeatPrice({
+                    seatPriceUnits: p,
+                    maximumSeatPriceCents:
+                        this.maximum_return_seat_price_cents,
+                    maximumTripPriceCents:
+                        this.maximum_return_trip_price_cents
+                })
             ) {
                 this.returnPriceError.state = true;
                 this.returnPriceError.message = this.getMaxContributionExceededMessage(

--- a/src/utils/tripMaxPriceValidation.js
+++ b/src/utils/tripMaxPriceValidation.js
@@ -1,0 +1,13 @@
+export function exceedsMaximumSeatPrice({
+    seatPriceUnits,
+    maximumSeatPriceCents,
+    maximumTripPriceCents
+}) {
+    if (maximumTripPriceCents <= 0) {
+        return false;
+    }
+    if (seatPriceUnits === null) {
+        return false;
+    }
+    return seatPriceUnits > maximumSeatPriceCents / 100;
+}

--- a/src/utils/tripMaxPriceValidation.test.js
+++ b/src/utils/tripMaxPriceValidation.test.js
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { exceedsMaximumSeatPrice } from './tripMaxPriceValidation.js';
+
+describe('exceedsMaximumSeatPrice', () => {
+    it('does not flag exceeded max contribution before trip-info loads', () => {
+        expect(
+            exceedsMaximumSeatPrice({
+                seatPriceUnits: 50,
+                maximumSeatPriceCents: 0,
+                maximumTripPriceCents: 0
+            })
+        ).toBe(false);
+    });
+
+    it('flags exceeded max contribution once trip-info cap is available', () => {
+        expect(
+            exceedsMaximumSeatPrice({
+                seatPriceUnits: 50,
+                maximumSeatPriceCents: 4000,
+                maximumTripPriceCents: 20000
+            })
+        ).toBe(true);
+    });
+
+    it('does not flag when seat price is within the cap', () => {
+        expect(
+            exceedsMaximumSeatPrice({
+                seatPriceUnits: 30,
+                maximumSeatPriceCents: 4000,
+                maximumTripPriceCents: 20000
+            })
+        ).toBe(false);
+    });
+
+    it('does not flag when seat price input is empty', () => {
+        expect(
+            exceedsMaximumSeatPrice({
+                seatPriceUnits: null,
+                maximumSeatPriceCents: 4000,
+                maximumTripPriceCents: 20000
+            })
+        ).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
Fixes a false "La contribución máxima ha sido excedida" warning when editing a trip. The max-contribution check now waits for the `trip-info` response before comparing the seat price against the cap.
### Frontend
- **Root cause:** Max price validation ran while `maximum_trip_price_cents` was still `0` (before `/api/trips/trip-info` returned). Any restored seat price looked like it exceeded the cap. A second trigger was calling `recalculateRecommendedPrice()` synchronously right after starting `calcRoute()`, before the async response arrived.
- **Fix:** Added `exceedsMaximumSeatPrice()` in `src/utils/tripMaxPriceValidation.js`, which skips the check until `maximumTripPriceCents > 0`. Wired it into `validatePrice`, `validateReturnPrice`, and form `validate()` in `NewTrip.vue`. Removed the premature `recalculateRecommendedPrice()` call after `calcRoute()` in `getPlace` (the trip-info callback already recalculates when data arrives).
- **Tests:** Unit tests for `exceedsMaximumSeatPrice` plus a view-level regression test in `NewTrip.view.test.js`.
