### PR TITLE
Mobile chat: full width

### DIFF
--- a/src/components/views/ConversationList.view.test.js
+++ b/src/components/views/ConversationList.view.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const viewPath = path.resolve(__dirname, 'ConversationList.vue');
+const viewSource = fs.readFileSync(viewPath, 'utf8');
+
+function getMobileChatConversationComponentBlock() {
+    const match = viewSource.match(
+        /\.conversation-list-page--mobile-chat \.conversation-component\.container\s*\{[^}]+\}/s
+    );
+    return match ? match[0] : '';
+}
+
+describe('ConversationList.vue mobile chat layout', () => {
+    it('removes horizontal container padding on mobile chat so conversation uses full width', () => {
+        const block = getMobileChatConversationComponentBlock();
+
+        expect(block).toMatch(/padding-left:\s*0/);
+        expect(block).toMatch(/padding-right:\s*0/);
+        expect(block).toMatch(/width:\s*100%/);
+        expect(block).toMatch(/max-width:\s*100%/);
+    });
+});

--- a/src/components/views/ConversationList.view.test.js
+++ b/src/components/views/ConversationList.view.test.js
@@ -5,20 +5,24 @@ import path from 'node:path';
 const viewPath = path.resolve(__dirname, 'ConversationList.vue');
 const viewSource = fs.readFileSync(viewPath, 'utf8');
 
-function getMobileChatConversationComponentBlock() {
+function getMobileStylesBlock() {
     const match = viewSource.match(
-        /\.conversation-list-page--mobile-chat \.conversation-component\.container\s*\{[^}]+\}/s
+        /@media only screen and \(max-width: 768px\)\s*\{([\s\S]*?)\n\}/m
     );
-    return match ? match[0] : '';
+    return match ? match[1] : '';
 }
 
 describe('ConversationList.vue mobile chat layout', () => {
     it('removes horizontal container padding on mobile chat so conversation uses full width', () => {
-        const block = getMobileChatConversationComponentBlock();
+        const mobileStyles = getMobileStylesBlock();
+        const block = mobileStyles.match(
+            /\.conversation-list-page--mobile-chat \.conversation-component\.container\s*\{[^}]+\}/s
+        );
 
-        expect(block).toMatch(/padding-left:\s*0/);
-        expect(block).toMatch(/padding-right:\s*0/);
-        expect(block).toMatch(/width:\s*100%/);
-        expect(block).toMatch(/max-width:\s*100%/);
+        expect(block).not.toBeNull();
+        expect(block[0]).toMatch(/padding-left:\s*0/);
+        expect(block[0]).toMatch(/padding-right:\s*0/);
+        expect(block[0]).toMatch(/width:\s*100%/);
+        expect(block[0]).toMatch(/max-width:\s*100%/);
     });
 });

--- a/src/components/views/ConversationList.vue
+++ b/src/components/views/ConversationList.vue
@@ -504,6 +504,10 @@ export default {
         overflow: hidden;
         margin-bottom: 0;
         padding-bottom: 0;
+        padding-left: 0;
+        padding-right: 0;
+        width: 100%;
+        max-width: 100%;
     }
     .conversation-list-page--mobile-chat .conversation-component > .row {
         flex: 1 1 auto;

--- a/src/components/views/ConversationList.vue
+++ b/src/components/views/ConversationList.vue
@@ -496,6 +496,7 @@ export default {
         z-index: 8;
         align-self: stretch;
     }
+    /* Bootstrap .container adds 10px side padding; override for edge-to-edge chat */
     .conversation-list-page--mobile-chat .conversation-component.container {
         flex: 1 1 auto;
         min-height: 0;


### PR DESCRIPTION
## Summary
Fix mobile chat not using full viewport width due to Bootstrap `.container` horizontal padding on `.conversation-component`.
### Frontend
- Override Bootstrap container side padding on mobile chat (`.conversation-list-page--mobile-chat .conversation-component.container`) with `padding-left: 0`, `padding-right: 0`, `width: 100%`, and `max-width: 100%`
- Add `ConversationList.view.test.js` to assert full-width rules live inside the `max-width: 768px` media query
- TDD commits: failing test → minimal CSS fix → refactor (comment + tighter test scope)
