### PR TITLE
Chat show user ratings

### DIFF
--- a/e2e-frontend/conversations.spec.js
+++ b/e2e-frontend/conversations.spec.js
@@ -93,6 +93,17 @@ test.describe('Conversations', () => {
     await expect(page).toHaveURL(/\/conversations\/1/);
   });
 
+  test('displays other participant ratings in conversation chat header on desktop', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto('/conversations/1');
+    await waitForPageReady(page);
+
+    const ratings = page.locator('.conversation_user_header_title_row .user-ratings-counts');
+    await expect(ratings).toBeVisible({ timeout: 10000 });
+    await expect(ratings).toContainText('8');
+    await expect(ratings).toContainText('2');
+  });
+
   test('displays messages in conversation chat', async ({ page }) => {
     await page.goto('/conversations/1');
     await waitForPageReady(page);

--- a/e2e-frontend/shared/mocks.js
+++ b/e2e-frontend/shared/mocks.js
@@ -173,8 +173,14 @@ const MOCK_CONVERSATIONS = [
     last_message: { id: 10, text: 'Hola, ¿a qué hora salís?', created_at: '2025-06-10T10:30:00.000Z' },
     unread: true,
     users: [
-      { id: 1, name: 'Juan Pérez' },
-      { id: 2, name: 'María García' },
+      { id: 1, name: 'Juan Pérez', positive_ratings: 10, negative_ratings: 1 },
+      {
+        id: 2,
+        name: 'María García',
+        positive_ratings: 8,
+        negative_ratings: 2,
+        last_connection: '2025-06-10T09:00:00.000Z',
+      },
     ],
   },
   {
@@ -434,8 +440,13 @@ function makeMockConversation(id, overrides = {}) {
     last_message: { id: id * 10, text: `Message from conv ${id}`, created_at: '2025-06-10T10:30:00.000Z' },
     unread: false,
     users: [
-      { id: 1, name: 'Juan Pérez' },
-      { id: id + 100, name: `User ${id}` },
+      { id: 1, name: 'Juan Pérez', positive_ratings: 10, negative_ratings: 1 },
+      {
+        id: id + 100,
+        name: `User ${id}`,
+        positive_ratings: 5,
+        negative_ratings: 0,
+      },
     ],
     ...overrides,
   };

--- a/src/App.vue
+++ b/src/App.vue
@@ -25,7 +25,10 @@
             <MaintenanceAdminBanner v-if="maintenanceAdminStickyVisible" />
             <headerApp></headerApp>
             <main id="main">
-                <div class="view-container clearfix">
+                <div
+                    class="view-container clearfix"
+                    :class="{ 'view-container--tall-header': headerRatings }"
+                >
                     <router-view></router-view>
                 </div>
             </main>
@@ -41,6 +44,7 @@
 <script>
 import { mapState, mapActions } from 'pinia';
 import { useAuthStore } from './stores/auth';
+import { useActionbarsStore } from './stores/actionbars';
 import { useCordovaStore } from './stores/cordova';
 import { useDeviceStore } from './stores/device';
 import { useBackgroundStore } from './stores/background';
@@ -163,6 +167,9 @@ export default {
         }),
         ...mapState(useBackgroundStore, {
             backgroundStyle: 'backgroundStyle'
+        }),
+        ...mapState(useActionbarsStore, {
+            headerRatings: 'headerRatings'
         }),
         ...mapState(useAuthStore, {
             logged: 'checkLogin',

--- a/src/components/elements/UserRatingsCounts.view.test.js
+++ b/src/components/elements/UserRatingsCounts.view.test.js
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const viewPath = path.resolve(__dirname, 'UserRatingsCounts.vue');
+const viewSource = fs.readFileSync(viewPath, 'utf8');
+
+describe('UserRatingsCounts.vue', () => {
+    it('renders thumbs-up and thumbs-down icons with positive and negative counts', () => {
+        expect(viewSource).toContain('fa-thumbs-up');
+        expect(viewSource).toContain('fa-thumbs-down');
+        expect(viewSource).toContain('ratings.positive');
+        expect(viewSource).toContain('ratings.negative');
+        expect(viewSource).toContain('user-ratings-counts');
+    });
+
+    it('does not render when ratings prop is null', () => {
+        expect(viewSource).toMatch(/v-if="visible"/);
+        expect(viewSource).toContain('ratings == null');
+    });
+});

--- a/src/components/elements/UserRatingsCounts.view.test.js
+++ b/src/components/elements/UserRatingsCounts.view.test.js
@@ -16,6 +16,6 @@ describe('UserRatingsCounts.vue', () => {
 
     it('does not render when ratings prop is null', () => {
         expect(viewSource).toMatch(/v-if="visible"/);
-        expect(viewSource).toContain('ratings == null');
+        expect(viewSource).toMatch(/ratings\s*!=\s*null/);
     });
 });

--- a/src/components/elements/UserRatingsCounts.view.test.js
+++ b/src/components/elements/UserRatingsCounts.view.test.js
@@ -14,6 +14,20 @@ describe('UserRatingsCounts.vue', () => {
         expect(viewSource).toContain('user-ratings-counts');
     });
 
+    it('uses profile-matching green and red icon colors with spaced icon-number pairs', () => {
+        expect(viewSource).toContain('user-ratings-counts__icon--positive');
+        expect(viewSource).toContain('user-ratings-counts__icon--negative');
+        expect(viewSource).toContain('color: #59b200');
+        expect(viewSource).toContain('color: red');
+        expect(viewSource).toContain('user-ratings-counts__pair');
+        expect(viewSource).toMatch(
+            /max-width:\s*768px[\s\S]*\.user-ratings-counts\s*\{[\s\S]*gap:\s*1\.25em/s
+        );
+        expect(viewSource).toMatch(
+            /max-width:\s*768px[\s\S]*user-ratings-counts__pair[\s\S]*gap:\s*0\.35em/s
+        );
+    });
+
     it('does not render when ratings prop is null', () => {
         expect(viewSource).toMatch(/v-if="visible"/);
         expect(viewSource).toMatch(/ratings\s*!=\s*null/);

--- a/src/components/elements/UserRatingsCounts.vue
+++ b/src/components/elements/UserRatingsCounts.vue
@@ -1,9 +1,19 @@
 <template>
     <span class="user-ratings-counts" v-if="visible">
-        <i class="fa fa-thumbs-up" aria-hidden="true"></i>
-        <span>{{ ratings.positive }}</span>
-        <i class="fa fa-thumbs-down" aria-hidden="true"></i>
-        <span>{{ ratings.negative }}</span>
+        <span class="user-ratings-counts__pair">
+            <i
+                class="fa fa-thumbs-up user-ratings-counts__icon--positive"
+                aria-hidden="true"
+            ></i>
+            <span>{{ ratings.positive }}</span>
+        </span>
+        <span class="user-ratings-counts__pair">
+            <i
+                class="fa fa-thumbs-down user-ratings-counts__icon--negative"
+                aria-hidden="true"
+            ></i>
+            <span>{{ ratings.negative }}</span>
+        </span>
     </span>
 </template>
 
@@ -28,14 +38,29 @@ export default {
 .user-ratings-counts {
     display: inline-flex;
     align-items: center;
-    gap: 0.2em;
+    gap: 0.8em;
     font-size: 13px;
     white-space: nowrap;
 }
-.user-ratings-counts i {
+.user-ratings-counts__pair {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25em;
+}
+.user-ratings-counts__icon--positive {
+    color: #59b200;
     font-size: 0.95em;
 }
-.user-ratings-counts span:first-of-type {
-    margin-right: 0.35em;
+.user-ratings-counts__icon--negative {
+    color: red;
+    font-size: 0.95em;
+}
+@media only screen and (max-width: 768px) {
+    .user-ratings-counts {
+        gap: 1.25em;
+    }
+    .user-ratings-counts__pair {
+        gap: 0.35em;
+    }
 }
 </style>

--- a/src/components/elements/UserRatingsCounts.vue
+++ b/src/components/elements/UserRatingsCounts.vue
@@ -1,0 +1,41 @@
+<template>
+    <span class="user-ratings-counts" v-if="visible">
+        <i class="fa fa-thumbs-up" aria-hidden="true"></i>
+        <span>{{ ratings.positive }}</span>
+        <i class="fa fa-thumbs-down" aria-hidden="true"></i>
+        <span>{{ ratings.negative }}</span>
+    </span>
+</template>
+
+<script>
+export default {
+    name: 'UserRatingsCounts',
+    props: {
+        ratings: {
+            type: Object,
+            default: null
+        }
+    },
+    computed: {
+        visible() {
+            return this.ratings != null;
+        }
+    }
+};
+</script>
+
+<style scoped>
+.user-ratings-counts {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.2em;
+    font-size: 13px;
+    white-space: nowrap;
+}
+.user-ratings-counts i {
+    font-size: 0.95em;
+}
+.user-ratings-counts span:first-of-type {
+    margin-right: 0.35em;
+}
+</style>

--- a/src/components/sections/HeaderApp.view.test.js
+++ b/src/components/sections/HeaderApp.view.test.js
@@ -1,44 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 
 const viewPath = path.resolve(__dirname, 'HeaderApp.vue');
 const viewSource = fs.readFileSync(viewPath, 'utf8');
 
-describe('HeaderApp mesa de ayuda link', () => {
-    it('includes soporte i18n with router-link to tickets for desktop and mobile dropdowns', () => {
-        expect(viewSource).toContain("$t('soporte')");
-        const ticketRouteMatches = viewSource.match(/name:\s*'tickets'/g);
-        expect(ticketRouteMatches).not.toBeNull();
-        expect(ticketRouteMatches.length).toBeGreaterThanOrEqual(2);
-    });
-
-    it('lists soporte link after perfil in the desktop profile dropdown', () => {
-        const marker = '<div class="header_profile" v-if="user">';
-        const start = viewSource.indexOf(marker);
-        expect(start).toBeGreaterThan(-1);
-        const rest = viewSource.slice(start);
-        const closeDropdown = '</dropdown>';
-        const endRel = rest.indexOf(closeDropdown);
-        expect(endRel).toBeGreaterThan(-1);
-        const desktopMenu = rest.slice(0, endRel);
-        const perfilPos = desktopMenu.indexOf("$t('perfil')");
-        const ticketsPos = desktopMenu.indexOf("name: 'tickets'");
-        expect(perfilPos).toBeGreaterThan(-1);
-        expect(ticketsPos).toBeGreaterThan(perfilPos);
-    });
-
-    it('lists soporte link after perfil in the mobile ellipsis dropdown', () => {
-        const marker = '<div class="dropdown-right" v-if="showMenu || isMobile">';
-        const start = viewSource.indexOf(marker);
-        expect(start).toBeGreaterThan(-1);
-        const rest = viewSource.slice(start);
-        const endRel = rest.indexOf('</dropdown>');
-        expect(endRel).toBeGreaterThan(-1);
-        const mobileMenu = rest.slice(0, endRel);
-        const perfilPos = mobileMenu.indexOf("$t('perfil')");
-        const ticketsPos = mobileMenu.indexOf("name: 'tickets'");
-        expect(perfilPos).toBeGreaterThan(-1);
-        expect(ticketsPos).toBeGreaterThan(perfilPos);
+describe('HeaderApp.vue chat user ratings', () => {
+    it('renders ratings below the subtitle in the mobile action bar', () => {
+        expect(viewSource).toContain('UserRatingsCounts');
+        expect(viewSource).toContain('headerRatings');
+        expect(viewSource).toContain('header--with-ratings');
+        expect(viewSource).toMatch(
+            /header--subtitle[\s\S]*UserRatingsCounts/s
+        );
     });
 });

--- a/src/components/sections/HeaderApp.vue
+++ b/src/components/sections/HeaderApp.vue
@@ -1,7 +1,10 @@
 <template>
     <header class="header header-component">
         <IdentityValidationCountdownBanner />
-        <div class="actionbar actionbar-top visible-xs">
+        <div
+            class="actionbar actionbar-top visible-xs"
+            :class="{ 'actionbar-top--with-ratings': headerRatings }"
+        >
             <div class="actionbar_section actionbar_icon">
                 <span v-if="showLogo">
                     <router-link
@@ -25,6 +28,7 @@
                 class="actionbar_section actionbar_title"
                 :class="[
                     subTitle !== '' ? 'header--with-subtitle' : '',
+                    headerRatings ? 'header--with-ratings' : '',
                     actionbarTitleWidthClass
                 ]"
             >
@@ -44,6 +48,11 @@
                     <span>{{ title }}</span>
                 </router-link>
                 <span class="header--subtitle">{{ subTitle }}</span>
+                <UserRatingsCounts
+                    v-if="headerRatings"
+                    :ratings="headerRatings"
+                    class="header--ratings"
+                />
             </div>
             <div class="actionbar_section actionbar_icon pull-right">
                 <template v-for="item in rightHeaderButton" :key="item.id">
@@ -310,6 +319,7 @@ import dropdown from '../Dropdown';
 import router from '../../router';
 import bus from '../../services/bus-event.js';
 import IdentityValidationCountdownBanner from '../IdentityValidationCountdownBanner.vue';
+import UserRatingsCounts from '../elements/UserRatingsCounts.vue';
 import { shouldHideDonationOnIOSCapacitor } from '../../services/capacitor.js';
 
 export default {
@@ -354,6 +364,7 @@ export default {
             title: 'title',
             titleLink: 'titleLink',
             subTitle: 'subTitle',
+            headerRatings: 'headerRatings',
             imgTitle: 'imgTitle',
             showMenu: 'showMenu',
             leftHeaderButton: 'leftHeaderButton',
@@ -429,7 +440,8 @@ export default {
     },
     components: {
         dropdown,
-        IdentityValidationCountdownBanner
+        IdentityValidationCountdownBanner,
+        UserRatingsCounts
     }
 };
 </script>

--- a/src/components/views/ConversationChat.view.test.js
+++ b/src/components/views/ConversationChat.view.test.js
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const viewPath = path.resolve(__dirname, 'ConversationChat.vue');
+const viewSource = fs.readFileSync(viewPath, 'utf8');
+
+describe('ConversationChat.vue user ratings', () => {
+    it('shows other participant ratings to the right of the user name on desktop', () => {
+        expect(viewSource).toContain('UserRatingsCounts');
+        expect(viewSource).toContain('conversation_user_header_title_row');
+        expect(viewSource).toContain('otherUserRatings');
+        expect(viewSource).toMatch(
+            /conversation_user_header_title_row[\s\S]*UserRatingsCounts/s
+        );
+    });
+
+    it('resolves other participant ratings from conversation users via shared helper', () => {
+        expect(viewSource).toContain('getOtherParticipantRatings');
+        expect(viewSource).toContain('setHeaderRatings');
+    });
+});

--- a/src/components/views/ConversationChat.vue
+++ b/src/components/views/ConversationChat.vue
@@ -12,12 +12,17 @@
                         v-imgSrc="conversation.image"
                     ></div>
                 </router-link>
-                <router-link
+                <div
                     v-if="conversation.users.length === 2"
-                    :to="{ name: 'profile', params: userProfile() }"
+                    class="conversation_user_header_title_row"
                 >
-                    <h2>{{ conversation.title }}</h2>
-                </router-link>
+                    <router-link
+                        :to="{ name: 'profile', params: userProfile() }"
+                    >
+                        <h2>{{ conversation.title }}</h2>
+                    </router-link>
+                    <UserRatingsCounts :ratings="otherUserRatings" />
+                </div>
                 <h2 v-else>{{ conversation.title }}</h2>
                 <CoordinateTrip></CoordinateTrip>
                 <p
@@ -98,6 +103,11 @@ import dayjs from '../../dayjs';
 import bus from '../../services/bus-event.js';
 import dialogs from '../../services/dialogs.js';
 import CoordinateTrip from '../elements/CoordinateTrip';
+import UserRatingsCounts from '../elements/UserRatingsCounts.vue';
+import {
+    getOtherParticipant,
+    getOtherParticipantRatings
+} from '../../utils/conversationOtherUserRatings.js';
 
 export default {
     name: 'conversation-chat',
@@ -148,16 +158,17 @@ export default {
          * In group-style conversations (more than one other user) there is no single value; returns null.
          */
         lastConnectionRaw() {
-            if (!this.conversation || !this.conversation.users) {
-                return null;
-            }
-            const others = this.conversation.users.filter(
-                (item) => item.id !== this.user.id
+            const other = getOtherParticipant(
+                this.conversation?.users,
+                this.user?.id
             );
-            if (others.length !== 1) {
-                return null;
-            }
-            return others[0].last_connection;
+            return other?.last_connection ?? null;
+        },
+        otherUserRatings() {
+            return getOtherParticipantRatings(
+                this.conversation?.users,
+                this.user?.id
+            );
         },
         lastConnectionFormatted() {
             const raw = this.lastConnectionRaw;
@@ -183,6 +194,7 @@ export default {
             setTitle: 'setTitle',
             setTitleLink: 'setTitleLink',
             setSubTitle: 'setSubTitle',
+            setHeaderRatings: 'setHeaderRatings',
             setImgTitle: 'setImgTitle'
         }),
 
@@ -250,29 +262,36 @@ export default {
             this.findMessage({ more: true });
         },
 
+        syncChatHeader() {
+            if (!this.conversation) {
+                return;
+            }
+            this.setTitle(this.conversation.title);
+            const otherUser = getOtherParticipant(
+                this.conversation.users,
+                this.user.id
+            );
+            if (otherUser) {
+                this.setTitleLink({
+                    name: 'profile',
+                    params: { id: otherUser.id }
+                });
+            } else {
+                this.setTitleLink({});
+            }
+            this.setSubTitle(
+                this.lastConnectionFormatted
+                    ? `${this.$t('ultimaConexion')} ${this.lastConnectionFormatted}`
+                    : ''
+            );
+            this.setHeaderRatings(this.otherUserRatings);
+            this.setImgTitle(this.conversation.image);
+        },
+
         refresh() {
             this.select(this.id).then(() => {
                 bus.on('back-click', this.onBackClick);
-                if (this.conversation) {
-                    this.setTitle(this.conversation.title);
-                    const otherUser = this.conversation.users.find(
-                        (u) => u.id !== this.user.id
-                    );
-                    if (otherUser) {
-                        this.setTitleLink({
-                            name: 'profile',
-                            params: { id: otherUser.id }
-                        });
-                    } else {
-                        this.setTitleLink({});
-                    }
-                    this.setSubTitle(
-                        this.lastConnectionFormatted
-                            ? `${this.$t('ultimaConexion')} ${this.lastConnectionFormatted}`
-                            : ''
-                    );
-                    this.setImgTitle(this.conversation.image);
-                }
+                this.syncChatHeader();
                 this.jumpEndOfConversation();
             });
         }
@@ -289,25 +308,7 @@ export default {
             this.mustJump = false;
         }
         if (this.conversation) {
-            this.setTitle(this.conversation.title);
-            const otherUser = this.conversation.users.find(
-                (u) => u.id !== this.user.id
-            );
-            if (otherUser) {
-                this.setTitleLink({
-                    name: 'profile',
-                    params: { id: otherUser.id }
-                });
-            } else {
-                this.setTitleLink({});
-            }
-            this.setSubTitle(
-                this.lastConnectionFormatted
-                    ? `${this.$t('ultimaConexion')} ${this.lastConnectionFormatted}`
-                    : ''
-            );
-            this.setImgTitle(this.conversation.image);
-
+            this.syncChatHeader();
             bus.emit('header-title-change');
         }
     },
@@ -328,12 +329,22 @@ export default {
     components: {
         editor: ToastUiEditor,
         MessageView,
-        CoordinateTrip
+        CoordinateTrip,
+        UserRatingsCounts
     }
 };
 </script>
 
 <style scoped>
+.conversation_user_header_title_row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+.conversation_user_header_title_row h2 {
+    margin: 0;
+}
 #btn-more {
     padding: 1em 0;
     margin-top: 1.5rem;

--- a/src/components/views/ConversationList.view.test.js
+++ b/src/components/views/ConversationList.view.test.js
@@ -12,6 +12,18 @@ function getMobileStylesBlock() {
     return match ? match[1] : '';
 }
 
+describe('ConversationList.vue mobile chat ratings header', () => {
+    it('uses a taller mobile chat column when the header shows participant ratings', () => {
+        expect(viewSource).toContain(
+            'conversation-list-page--mobile-chat--tall-header'
+        );
+        expect(viewSource).toContain('headerRatings');
+        expect(viewSource).toMatch(
+            /conversation-list-page--mobile-chat--tall-header[\s\S]*64px/s
+        );
+    });
+});
+
 describe('ConversationList.vue mobile chat layout', () => {
     it('removes horizontal container padding on mobile chat so conversation uses full width', () => {
         const mobileStyles = getMobileStylesBlock();

--- a/src/components/views/ConversationList.vue
+++ b/src/components/views/ConversationList.vue
@@ -5,7 +5,11 @@
             config.module_coordinate_by_message
                 ? 'module--coordinate-by-message'
                 : '',
-            { 'conversation-list-page--mobile-chat': hide && isMobile }
+            {
+                'conversation-list-page--mobile-chat': hide && isMobile,
+                'conversation-list-page--mobile-chat--tall-header':
+                    hide && isMobile && headerRatings
+            }
         ]"
     >
         <CoordinateTrip v-show="isMobile"></CoordinateTrip>
@@ -215,6 +219,7 @@ import { mapState, mapActions } from 'pinia';
 import { useConversationsStore } from '../../stores/conversations';
 import { useDeviceStore } from '../../stores/device';
 import { useAuthStore } from '../../stores/auth';
+import { useActionbarsStore } from '../../stores/actionbars';
 import { Thread } from '../../classes/Threads.js';
 import Loading from '../Loading.vue';
 import UserNameWithBadge from '../elements/UserNameWithBadge.vue';
@@ -242,6 +247,9 @@ export default {
         }),
         ...mapState(useAuthStore, {
             config: 'appConfig'
+        }),
+        ...mapState(useActionbarsStore, {
+            headerRatings: 'headerRatings'
         }),
 
         hide() {
@@ -559,6 +567,12 @@ export default {
         z-index: 9;
         background: #fff;
         box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.08);
+    }
+    .conversation-list-page--mobile-chat--tall-header {
+        height: calc(100dvh - 64px - constant(safe-area-inset-top, 0px) - constant(safe-area-inset-bottom, 0px));
+        height: calc(100dvh - 64px - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px));
+        max-height: calc(100dvh - 64px - constant(safe-area-inset-top, 0px) - constant(safe-area-inset-bottom, 0px));
+        max-height: calc(100dvh - 64px - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px));
     }
 }
 .media-right {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -51,6 +51,7 @@ router.beforeEach((to, from, next) => {
     }
     if (actionbar.header) {
         actionbarsStore.setSubTitle('');
+        actionbarsStore.setHeaderRatings(null);
         actionbarsStore.setTitleLink({});
         actionbarsStore.setImgTitle('');
         if (actionbar.header.titleKey) {

--- a/src/stores/actionbars.headerRatings.test.js
+++ b/src/stores/actionbars.headerRatings.test.js
@@ -1,0 +1,19 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+
+describe('actionbars store headerRatings', () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+    });
+
+    it('stores and clears header ratings for the mobile chat header', async () => {
+        const { useActionbarsStore } = await import('./actionbars.js');
+        const store = useActionbarsStore();
+
+        store.setHeaderRatings({ positive: 4, negative: 1 });
+        expect(store.headerRatings).toEqual({ positive: 4, negative: 1 });
+
+        store.setHeaderRatings(null);
+        expect(store.headerRatings).toBeNull();
+    });
+});

--- a/src/stores/actionbars.js
+++ b/src/stores/actionbars.js
@@ -11,6 +11,7 @@ export const useActionbarsStore = defineStore('actionbars', {
         title: appName,
         titleLink: {},
         subTitle: '',
+        headerRatings: null,
         imgTitle: '',
         showMenu: false,
         header_buttons: [
@@ -111,6 +112,10 @@ export const useActionbarsStore = defineStore('actionbars', {
 
         setSubTitle(newSubTitle = '') {
             this.subTitle = newSubTitle;
+        },
+
+        setHeaderRatings(ratings = null) {
+            this.headerRatings = ratings;
         },
 
         setImgTitle(newImgTitle = '') {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -666,6 +666,23 @@
       /* position: absolute;
       bottom: 8px; */
   }
+  .actionbar-top--with-ratings {
+      height: auto;
+      min-height: 64px;
+  }
+  .header--with-ratings .header--ratings {
+      display: block;
+      font-size: 10px;
+      line-height: 1.4em;
+  }
+  .view-container--tall-header {
+      padding-top: calc(63px + constant(safe-area-inset-top));
+      padding-top: calc(63px + env(safe-area-inset-top));
+  }
+  .ios .view-container--tall-header {
+      padding-top: calc(89px + constant(safe-area-inset-top));
+      padding-top: calc(89px + env(safe-area-inset-top));
+  }
   .header--image {
       width: 32px;
       height: 32px;

--- a/src/utils/conversationOtherUserRatings.js
+++ b/src/utils/conversationOtherUserRatings.js
@@ -1,0 +1,21 @@
+export function getOtherParticipant(users, currentUserId) {
+    if (!Array.isArray(users) || currentUserId == null) {
+        return null;
+    }
+    const others = users.filter((user) => user && user.id !== currentUserId);
+    if (others.length !== 1) {
+        return null;
+    }
+    return others[0];
+}
+
+export function getOtherParticipantRatings(users, currentUserId) {
+    const other = getOtherParticipant(users, currentUserId);
+    if (!other) {
+        return null;
+    }
+    return {
+        positive: Number(other.positive_ratings) || 0,
+        negative: Number(other.negative_ratings) || 0
+    };
+}

--- a/src/utils/conversationOtherUserRatings.test.js
+++ b/src/utils/conversationOtherUserRatings.test.js
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+    getOtherParticipant,
+    getOtherParticipantRatings
+} from './conversationOtherUserRatings.js';
+
+describe('conversationOtherUserRatings', () => {
+    const currentUserId = 1;
+    const users = [
+        { id: 1, name: 'Me' },
+        {
+            id: 2,
+            name: 'Other',
+            positive_ratings: 5,
+            negative_ratings: 2
+        }
+    ];
+
+    it('returns the single other participant in a 1:1 conversation', () => {
+        expect(getOtherParticipant(users, currentUserId)).toEqual(users[1]);
+    });
+
+    it('returns null when there is not exactly one other participant', () => {
+        expect(getOtherParticipant(users, currentUserId)).not.toBeNull();
+        expect(
+            getOtherParticipant(
+                [
+                    { id: 1, name: 'Me' },
+                    { id: 2, name: 'A' },
+                    { id: 3, name: 'B' }
+                ],
+                currentUserId
+            )
+        ).toBeNull();
+        expect(getOtherParticipant(null, currentUserId)).toBeNull();
+    });
+
+    it('returns positive and negative rating counts for the other participant', () => {
+        expect(getOtherParticipantRatings(users, currentUserId)).toEqual({
+            positive: 5,
+            negative: 2
+        });
+    });
+
+    it('defaults missing rating counts to zero', () => {
+        expect(
+            getOtherParticipantRatings(
+                [{ id: 1, name: 'Me' }, { id: 2, name: 'Other' }],
+                currentUserId
+            )
+        ).toEqual({
+            positive: 0,
+            negative: 0
+        });
+    });
+
+    it('returns null when ratings are not applicable', () => {
+        expect(getOtherParticipantRatings(null, currentUserId)).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
Show the other participant's positive and negative ratings in the chat header using thumbs-up/thumbs-down icons and counts.
- **Desktop:** ratings appear to the right of the user name in the conversation header.
- **Mobile:** ratings appear below the last-connection line in the action bar; header height is increased slightly (52px → 64px) when ratings are shown.

## Frontend
**Cause:** Chat only showed the participant name and last connection; ratings existed elsewhere (profile, trips) but were not wired into the conversation header on desktop or mobile.
**Fix:**
- Added `getOtherParticipantRatings` helper and reusable `UserRatingsCounts` component (thumbs icons + counts, matching profile style).
- **Desktop:** ratings inline next to the name in `ConversationChat` via `conversation_user_header_title_row`.
- **Mobile:** ratings in `HeaderApp` below the subtitle via new `headerRatings` state in the actionbars store; `ConversationChat` syncs ratings when the conversation loads.
- Mobile layout: taller action bar (`actionbar-top--with-ratings`), adjusted `view-container` padding, and taller mobile chat column when ratings are present.
