### PR TITLE
Profile: show trip amount and created_at

### DIFF
--- a/src/components/sections/ProfileInfo.view.test.js
+++ b/src/components/sections/ProfileInfo.view.test.js
@@ -3,7 +3,33 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const viewPath = path.resolve(__dirname, 'ProfileInfo.vue');
+const i18nPath = path.resolve(__dirname, '../../language/i18n.js');
 const viewSource = fs.readFileSync(viewPath, 'utf8');
+const i18nSource = fs.readFileSync(i18nPath, 'utf8');
+
+describe('ProfileInfo member stats', () => {
+    it('shows member since and participated trips below rating counters', () => {
+        const ratingsIndex = viewSource.indexOf('profile-info--ratings');
+        const memberSinceIndex = viewSource.indexOf("$t('miembroDesde'");
+        const tripsIndex = viewSource.indexOf("$t('perfilViajesParticipados'");
+
+        expect(ratingsIndex).toBeGreaterThan(-1);
+        expect(memberSinceIndex).toBeGreaterThan(ratingsIndex);
+        expect(tripsIndex).toBeGreaterThan(memberSinceIndex);
+        expect(viewSource).toContain('formatMemberSinceMonthYear');
+        expect(viewSource).toContain('normalizeTripsCount');
+        expect(viewSource).toContain('profile-info--member-stats');
+    });
+
+    it('keeps member stats copy in i18n', () => {
+        expect(i18nSource).toContain('miembroDesde');
+        expect(i18nSource).toContain('perfilViajesParticipados');
+        expect(i18nSource).toContain('Miembro desde: {date}');
+        expect(i18nSource).toContain('{count} viajes');
+        expect(i18nSource).toContain('Member since: {date}');
+        expect(i18nSource).toContain('{count} trips');
+    });
+});
 
 describe('ProfileInfo cars display', () => {
     it('lists all active patentes when viewing a profile', () => {

--- a/src/components/sections/ProfileInfo.view.test.js
+++ b/src/components/sections/ProfileInfo.view.test.js
@@ -19,6 +19,10 @@ describe('ProfileInfo member stats', () => {
         expect(viewSource).toContain('formatMemberSinceMonthYear');
         expect(viewSource).toContain('normalizeTripsCount');
         expect(viewSource).toContain('profile-info--member-stats');
+        expect(viewSource).toMatch(/\.profile-info\s*\{[\s\S]*align-items:\s*center/);
+        expect(viewSource).toMatch(
+            /\.profile-info--member-stats\s*\{[\s\S]*text-align:\s*center/
+        );
     });
 
     it('keeps member stats copy in i18n', () => {

--- a/src/components/sections/ProfileInfo.vue
+++ b/src/components/sections/ProfileInfo.vue
@@ -16,6 +16,15 @@
                         <i class="fa fa-thumbs-down" aria-hidden="true"></i>
                         <span>{{ profile.negative_ratings }}</span>
                     </div>
+                    <div
+                        v-if="memberSinceLabel || participatedTripsLabel"
+                        class="profile-info--member-stats"
+                    >
+                        <div v-if="memberSinceLabel">{{ memberSinceLabel }}</div>
+                        <div v-if="participatedTripsLabel">
+                            {{ participatedTripsLabel }}
+                        </div>
+                    </div>
                 </div>
                 <div v-if="badges.length" class="profile-badges">
                     <img
@@ -183,6 +192,10 @@ import router from '../../router';
 import UserNameWithBadge from '../elements/UserNameWithBadge.vue';
 import { formatId } from '../../services/utility';
 import { activeCarsWithPlate } from '../../utils/userCars.js';
+import {
+    formatMemberSinceMonthYear,
+    normalizeTripsCount
+} from '../../utils/profileMemberStats.js';
 
 export default {
     computed: {
@@ -208,6 +221,19 @@ export default {
         },
         visibleCars() {
             return activeCarsWithPlate(this.profile?.cars);
+        },
+        memberSinceLabel() {
+            const date = formatMemberSinceMonthYear(this.profile?.created_at);
+            return date ? this.$t('miembroDesde', { date }) : '';
+        },
+        participatedTripsLabel() {
+            if (!this.profile || this.profile.trips_count == null) {
+                return '';
+            }
+
+            return this.$t('perfilViajesParticipados', {
+                count: normalizeTripsCount(this.profile.trips_count)
+            });
         }
     },
     methods: {

--- a/src/components/sections/ProfileInfo.vue
+++ b/src/components/sections/ProfileInfo.vue
@@ -264,6 +264,12 @@ export default {
 };
 </script>
 <style scoped>
+.profile-info--member-stats {
+    margin-top: 0.5rem;
+    font-size: 0.9rem;
+    line-height: 1.4;
+}
+
 .profile-badges {
     display: flex;
     justify-content: center;

--- a/src/components/sections/ProfileInfo.vue
+++ b/src/components/sections/ProfileInfo.vue
@@ -264,10 +264,25 @@ export default {
 };
 </script>
 <style scoped>
+.profile-info {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+}
+
 .profile-info--member-stats {
     margin-top: 0.5rem;
     font-size: 0.9rem;
     line-height: 1.4;
+    text-align: center;
+    max-width: 230px;
+}
+
+@media only screen and (min-width: 768px) {
+    .profile-info--member-stats {
+        white-space: nowrap;
+    }
 }
 
 .profile-badges {

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -366,6 +366,8 @@ const messages = {
         aportanteMediaNaranja:
             'Aportante en la campaña mi media naranja carpoolera',
         miembroEquipo: 'Miembro del equipo de Carpoolear',
+        miembroDesde: 'Miembro desde: {date}',
+        perfilViajesParticipados: '{count} viajes',
         cambioFacebook:
             'Facebook cambió sus políticas y no podemos llevarte al perfil de esta persona, pero te ayudamos a buscarlo.',
         enviarMensaje: 'Enviar mensaje',
@@ -2125,6 +2127,8 @@ const messages = {
         aportanteMediaNaranja:
             'Aportante en la campaña mi media naranja carpoolera',
         miembroEquipo: 'Miembro del equipo de Carpoolear',
+        miembroDesde: 'Miembro desde: {date}',
+        perfilViajesParticipados: '{count} viajes',
         compartirEnFacebook: 'Compartir en Facebook',
         compartirEnTwitter: 'Compartir en Twitter',
         compartirEnGooglePlus: 'Compartir en Google+',
@@ -2880,6 +2884,8 @@ const messages = {
         aportanteMediaNaranja:
             'Contributor to the "my carpooling soulmate" campaign',
         miembroEquipo: 'Carpoolear team member',
+        miembroDesde: 'Member since: {date}',
+        perfilViajesParticipados: '{count} trips',
         cambioFacebook:
             "Facebook changed its policies and we cannot take you to this person's profile, but we can help you search for them.",
         enviarMensaje: 'Send message',

--- a/src/utils/profileMemberStats.js
+++ b/src/utils/profileMemberStats.js
@@ -1,0 +1,21 @@
+import dayjs from '../dayjs';
+
+export function formatMemberSinceMonthYear(createdAt) {
+    if (!createdAt) {
+        return '';
+    }
+
+    const date = dayjs(createdAt);
+
+    return date.isValid() ? date.format('MMMM YYYY') : '';
+}
+
+export function normalizeTripsCount(value) {
+    const count = Number(value);
+
+    if (!Number.isFinite(count) || count < 0) {
+        return 0;
+    }
+
+    return Math.trunc(count);
+}

--- a/src/utils/profileMemberStats.test.js
+++ b/src/utils/profileMemberStats.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import {
+    formatMemberSinceMonthYear,
+    normalizeTripsCount
+} from './profileMemberStats.js';
+
+describe('profileMemberStats', () => {
+    it('formats created_at as localized month and year', () => {
+        expect(formatMemberSinceMonthYear('2024-03-15 12:34:56')).toBe(
+            'marzo 2024'
+        );
+    });
+
+    it('returns empty string when created_at is missing or invalid', () => {
+        expect(formatMemberSinceMonthYear(null)).toBe('');
+        expect(formatMemberSinceMonthYear('')).toBe('');
+        expect(formatMemberSinceMonthYear('not-a-date')).toBe('');
+    });
+
+    it('normalizes trips_count to a non-negative integer', () => {
+        expect(normalizeTripsCount(5)).toBe(5);
+        expect(normalizeTripsCount('3')).toBe(3);
+        expect(normalizeTripsCount(undefined)).toBe(0);
+        expect(normalizeTripsCount(-2)).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary
Show member join date and participated trip count on user profiles, below the positive/negative rating counters.

## Frontend (`carpoolear`)
### Cause
`ProfileInfo.vue` only showed rating counters; no UI or i18n for member since or trip participation.
### Fix
- Added `profile-info--member-stats` block below ratings in `ProfileInfo.vue`.
- New utility `profileMemberStats.js` formats join date (`MMMM YYYY`) and normalizes trip count.
- i18n keys added for `arg`, `chl`, and `en`:
  - `miembroDesde`: `Miembro desde: {date}` / `Member since: {date}`
  - `perfilViajesParticipados`: `{count} viajes` / `{count} trips`
