### PR TITLE
Banner verification check

### DIFF
--- a/src/components/views/Trips.view.test.js
+++ b/src/components/views/Trips.view.test.js
@@ -5,6 +5,14 @@ import path from 'node:path';
 const viewPath = path.resolve(__dirname, 'Trips.vue');
 const viewSource = fs.readFileSync(viewPath, 'utf8');
 
+describe('Trips.vue app banner', () => {
+    it('uses shouldShowAppBanner for verification-aware banner visibility', () => {
+        expect(viewSource).toContain('shouldShowAppBanner');
+        expect(viewSource).toContain('showAppBanner');
+        expect(viewSource).toContain('v-if="showAppBanner"');
+    });
+});
+
 describe('Trips.vue persisted search state', () => {
     it('does not run default search when URL already has search params', () => {
         expect(viewSource).toContain('hasRouteSearchParams()');

--- a/src/components/views/Trips.vue
+++ b/src/components/views/Trips.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="trips container" :class="!user ? 'not-logged' : ''"> 
-        <template v-if="appConfig && appConfig.banner && appConfig.banner.url">
+        <template v-if="showAppBanner">
             <a
                 :href="bannerHref"
                 :target="bannerTarget"
@@ -300,6 +300,7 @@ import {
     isIOSCapacitor,
     shouldHideDonationOnIOSCapacitor
 } from '../../services/capacitor.js';
+import { shouldShowAppBanner } from '../../utils/appBanner.js';
 
 export default {
     name: 'trips',
@@ -868,6 +869,10 @@ export default {
         },
         isIOSCapacitor() {
             return Capacitor.isNativePlatform() && Capacitor.getPlatform() === 'ios';
+        },
+        showAppBanner() {
+            const banner = this.appConfig && this.appConfig.banner;
+            return shouldShowAppBanner(banner, this.user);
         },
         bannerHref() {
             const url =

--- a/src/utils/appBanner.js
+++ b/src/utils/appBanner.js
@@ -1,0 +1,17 @@
+export function isAccountVerificationBanner(banner) {
+    const image = banner && banner.image;
+    return typeof image === 'string' && image.toLowerCase().includes('verif');
+}
+
+export function shouldShowAppBanner(banner, user) {
+    if (!banner || !banner.url) {
+        return false;
+    }
+    if (!isAccountVerificationBanner(banner)) {
+        return true;
+    }
+    if (!user) {
+        return true;
+    }
+    return !user.identity_validated;
+}

--- a/src/utils/appBanner.test.js
+++ b/src/utils/appBanner.test.js
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+    isAccountVerificationBanner,
+    shouldShowAppBanner
+} from './appBanner.js';
+
+describe('isAccountVerificationBanner', () => {
+    it('returns true when banner image URL contains "verif"', () => {
+        expect(
+            isAccountVerificationBanner({
+                image: 'https://cdn.example.com/banner-verif-2026.png',
+                url: '/identity-validation'
+            })
+        ).toBe(true);
+    });
+
+    it('returns false when banner image URL does not contain "verif"', () => {
+        expect(
+            isAccountVerificationBanner({
+                image: 'https://cdn.example.com/donation-banner.png',
+                url: '/donate'
+            })
+        ).toBe(false);
+    });
+});
+
+describe('shouldShowAppBanner', () => {
+    const verificationBanner = {
+        image: 'https://cdn.example.com/banner-verif.png',
+        url: '/identity-validation'
+    };
+    const regularBanner = {
+        image: 'https://cdn.example.com/donation.png',
+        url: '/donate'
+    };
+
+    it('returns false when banner has no url', () => {
+        expect(shouldShowAppBanner({ image: 'x', url: '' }, null)).toBe(false);
+    });
+
+    it('shows regular banners regardless of verification status', () => {
+        const verifiedUser = { identity_validated: true };
+        expect(shouldShowAppBanner(regularBanner, verifiedUser)).toBe(true);
+    });
+
+    it('shows verification banner for unverified users', () => {
+        expect(
+            shouldShowAppBanner(verificationBanner, { identity_validated: false })
+        ).toBe(true);
+    });
+
+    it('hides verification banner for verified users', () => {
+        expect(
+            shouldShowAppBanner(verificationBanner, { identity_validated: true })
+        ).toBe(false);
+    });
+
+    it('shows verification banner when user is not logged in', () => {
+        expect(shouldShowAppBanner(verificationBanner, null)).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
Hide the account verification promo banner on the trips list for users who already completed identity verification.
## Cause
The trips page showed any configured `appConfig.banner` whenever it had a URL, including the account verification banner. Verified users still saw a banner prompting them to verify.
## Fix (frontend)
- Added `src/utils/appBanner.js` with:
  - `isAccountVerificationBanner(banner)` — treats banners whose `image` URL contains `"verif"` as account verification banners
  - `shouldShowAppBanner(banner, user)` — shows verification banners only when the user is not logged in or `identity_validated` is false; non-verification banners behave as before
- Updated `Trips.vue` to render the banner via `showAppBanner` instead of only checking `appConfig.banner.url`
- Added unit tests (`appBanner.test.js`) and a view source test (`Trips.view.test.js`)
