### PR TITLE
Trip detail seats notice

### DIFF
--- a/src/components/elements/TripSeats.view.test.js
+++ b/src/components/elements/TripSeats.view.test.js
@@ -6,12 +6,15 @@ const viewPath = path.resolve(__dirname, 'TripSeats.vue');
 const viewSource = fs.readFileSync(viewPath, 'utf8');
 
 describe('TripSeats.vue rear seat comfort preference', () => {
-    it('shows rear seat comfort copy alongside available seats when enabled', () => {
+    it('shows rear seat comfort copy for every viewer when the trip enables it', () => {
         expect(viewSource).toContain("$t('atrasViajanSolo2Personas')");
+        expect(viewSource).toContain('shouldShowRearComfortNote');
         expect(viewSource).toMatch(
-            /class="trip-seats__availability"[\s\S]*?trip_seats-available_label[\s\S]*?trip-seats__rear-comfort-note/s
+            /v-if="showRearComfortNote"[\s\S]*?trip-seats__rear-comfort-note--above[\s\S]*?trip-seats__availability/s
         );
-        expect(viewSource).toContain('trip-seats__rear-comfort-note');
+        expect(viewSource).not.toMatch(
+            /v-else class="trip-seats__availability"[\s\S]*?trip_seats-available_label[\s\S]*?trip-seats__rear-comfort-note(?!--above)/s
+        );
     });
 
     it('uses a larger font size for rear comfort copy in trip detail', () => {

--- a/src/components/elements/TripSeats.view.test.js
+++ b/src/components/elements/TripSeats.view.test.js
@@ -46,12 +46,6 @@ describe('TripSeats.vue accepted passenger co-travelers', () => {
         expect(viewSource).toContain('trip-seats__co-passengers');
     });
 
-    it('places rear comfort note above seats for accepted passengers', () => {
-        expect(viewSource).toMatch(
-            /trip-seats__rear-comfort-note--above[\s\S]*?trip-seats__availability/s
-        );
-    });
-
     it('styles co-passenger copy with top margin and a larger font', () => {
         expect(viewSource).toMatch(
             /\.trip-seats__co-passengers\s*\{[\s\S]*?margin-top:\s*0\.75rem[\s\S]*?font-size:\s*1\.15em/

--- a/src/components/elements/TripSeats.vue
+++ b/src/components/elements/TripSeats.vue
@@ -7,10 +7,7 @@
             <div
                 class="trip_seats-available col-xs-offset-2 col-sm-offset-4 col-xs-24"
             >
-                <div
-                    v-if="isAcceptedPassengerView"
-                    class="trip-seats__passenger-detail"
-                >
+                <div class="trip-seats__passenger-detail">
                     <span
                         v-if="showRearComfortNote"
                         class="trip-seats__rear-comfort-note trip-seats__rear-comfort-note--above label-soft"
@@ -46,38 +43,11 @@
                         }}
                     </span>
                 </div>
-                <div v-else class="trip-seats__availability">
-                    <span class="trip_seats-available_value">{{
-                        trip.seats_available
-                    }}</span>
-                    <span
-                        v-if="trip.seats_available == 1"
-                        class="trip_seats-available_label"
-                    >
-                        {{ $t('Lugar') }}
-                        <br />
-                        {{ $t('libre') }}
-                    </span>
-                    <span v-else class="trip_seats-available_label">
-                        {{ $t('Lugares') }}
-                        <br />
-                        {{ $t('libres') }}
-                    </span>
-                    <span
-                        v-if="showRearComfortNote"
-                        class="trip-seats__rear-comfort-note label-soft"
-                    >
-                        {{ $t('atrasViajanSolo2Personas') }}
-                    </span>
-                </div>
             </div>
         </div>
         <template v-else>
             <div class="trip_seats-available" v-if="!trip.is_passenger">
-                <div
-                    v-if="isAcceptedPassengerView"
-                    class="trip-seats__passenger-detail"
-                >
+                <div class="trip-seats__passenger-detail">
                     <span
                         v-if="showRearComfortNote"
                         class="trip-seats__rear-comfort-note trip-seats__rear-comfort-note--above label-soft"
@@ -112,25 +82,6 @@
                         }}
                     </span>
                 </div>
-                <div v-else class="trip-seats__availability">
-                    <template v-for="n in trip.total_seats">
-                        <span
-                            :class="
-                                n < trip.total_seats - trip.seats_available
-                                    ? 'seat-taken'
-                                    : 'seat-free'
-                            "
-                        >
-                            <svg-item :icon="'seat'" :size="18"></svg-item>
-                        </span>
-                    </template>
-                    <span
-                        v-if="showRearComfortNote"
-                        class="trip-seats__rear-comfort-note label-soft"
-                    >
-                        {{ $t('atrasViajanSolo2Personas') }}
-                    </span>
-                </div>
             </div>
         </template>
     </div>
@@ -144,6 +95,7 @@ import {
     buildCoPassengerNamesText,
     isAcceptedPassengerOnTrip
 } from '../../utils/tripCoPassengers.js';
+import { shouldShowRearComfortNote } from '../../utils/tripRearComfortSeats.js';
 
 export default {
     name: 'TripSeats',
@@ -168,7 +120,7 @@ export default {
             );
         },
         showRearComfortNote() {
-            return Number(this.trip?.rear_max_two_passengers) > 0;
+            return shouldShowRearComfortNote(this.trip);
         },
         coPassengerNamesText() {
             if (!this.isAcceptedPassengerView) {

--- a/src/components/elements/TripSeats.vue
+++ b/src/components/elements/TripSeats.vue
@@ -172,7 +172,6 @@ export default {
     line-height: 1.3;
     text-transform: none;
     min-width: 0;
-    margin-left: 1rem;
 }
 
 .trip-seats__rear-comfort-note--above {

--- a/src/utils/tripRearComfortSeats.js
+++ b/src/utils/tripRearComfortSeats.js
@@ -22,5 +22,11 @@ export function shouldBlockSeatSelection(totalSeats, rearMaxTwoPassengers) {
 }
 
 export function shouldShowRearComfortNote(trip) {
-    return Number(trip?.rear_max_two_passengers) > 0;
+    if (!trip) {
+        return false;
+    }
+
+    const { rear_max_two_passengers: rearMaxTwoPassengers } = trip;
+
+    return Number(rearMaxTwoPassengers) > 0;
 }

--- a/src/utils/tripRearComfortSeats.js
+++ b/src/utils/tripRearComfortSeats.js
@@ -20,3 +20,7 @@ export function rearMaxTwoRequiresThreeOrFewerSeats(
 export function shouldBlockSeatSelection(totalSeats, rearMaxTwoPassengers) {
     return rearMaxTwoRequiresThreeOrFewerSeats(totalSeats, rearMaxTwoPassengers);
 }
+
+export function shouldShowRearComfortNote(trip) {
+    return Number(trip?.rear_max_two_passengers) > 0;
+}

--- a/src/utils/tripRearComfortSeats.test.js
+++ b/src/utils/tripRearComfortSeats.test.js
@@ -3,7 +3,8 @@ import {
     MAX_AVAILABLE_SEATS_WITH_REAR_MAX_TWO,
     isRearMaxTwoCompatibleWithSeats,
     rearMaxTwoRequiresThreeOrFewerSeats,
-    shouldBlockSeatSelection
+    shouldBlockSeatSelection,
+    shouldShowRearComfortNote
 } from './tripRearComfortSeats.js';
 
 describe('tripRearComfortSeats', () => {
@@ -47,6 +48,28 @@ describe('tripRearComfortSeats', () => {
 
         it('allows selecting up to 3 seats when rear max two is enabled', () => {
             expect(shouldBlockSeatSelection(3, true)).toBe(false);
+        });
+    });
+
+    describe('shouldShowRearComfortNote', () => {
+        it('is true when rear max two passengers is enabled on the trip', () => {
+            expect(shouldShowRearComfortNote({ rear_max_two_passengers: 1 })).toBe(
+                true
+            );
+            expect(shouldShowRearComfortNote({ rear_max_two_passengers: true })).toBe(
+                true
+            );
+        });
+
+        it('is false when rear max two passengers is disabled or missing', () => {
+            expect(shouldShowRearComfortNote({ rear_max_two_passengers: 0 })).toBe(
+                false
+            );
+            expect(shouldShowRearComfortNote({ rear_max_two_passengers: false })).toBe(
+                false
+            );
+            expect(shouldShowRearComfortNote({})).toBe(false);
+            expect(shouldShowRearComfortNote(null)).toBe(false);
         });
     });
 });


### PR DESCRIPTION
## Summary
Show the rear-seat comfort notice ("Atrás viajan sólo 2 personas") to **every** trip detail viewer when the driver enabled it — not only accepted passengers.
### Frontend
**Cause:** After the accepted-passenger trip detail work, the notice used two layouts: above seats for accepted passengers, but inline next to the seat count for everyone else (owner, guests, pending requesters). The inline placement was easy to miss, especially on mobile.
**Fix:**
- Unified `TripSeats.vue` so all viewers get the same above-seats notice layout.
- Added `shouldShowRearComfortNote()` in `tripRearComfortSeats.js` and wired it into the component.
- View/unit tests assert the notice is not gated by viewer role.
