### PR TITLE
Live location fix

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.sts.carpoolear"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 3020300
-        versionName "3.2.3"
+        versionCode 3020400
+        versionName "3.2.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,7 +24,6 @@ allprojects {
     }
     
     afterEvaluate { project ->
-        // Force Java 17 for all Android projects
         if (project.hasProperty("android")) {
             project.android {
                 compileOptions {
@@ -33,11 +32,16 @@ allprojects {
                 }
             }
         }
-        
-        // Force Java 17 for all Java projects
+
         if (project.plugins.hasPlugin('java')) {
             project.sourceCompatibility = JavaVersion.VERSION_17
             project.targetCompatibility = JavaVersion.VERSION_17
+        }
+
+        if (project.plugins.hasPlugin('kotlin-android')) {
+            project.kotlin {
+                jvmToolchain(17)
+            }
         }
     }
 }

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -1,5 +1,5 @@
 ext {
-    minSdkVersion = 22
+    minSdkVersion = 23
     compileSdkVersion = 35
     targetSdkVersion = 35
     androidxActivityVersion = '1.8.0'

--- a/scripts/fix-capacitor-cordova-gradle.js
+++ b/scripts/fix-capacitor-cordova-gradle.js
@@ -2,27 +2,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const targetFile = path.resolve(
-  __dirname,
-  '..',
-  'android',
-  'capacitor-cordova-android-plugins',
-  'build.gradle',
-);
-
-if (!fs.existsSync(targetFile)) {
-  console.warn(`[fix-capacitor-cordova-gradle] File not found: ${targetFile}`);
-  process.exit(0);
-}
-
-let content = fs.readFileSync(targetFile, 'utf8');
-let changed = false;
-
-const replacements = [
-  {
-    from: "classpath 'com.android.tools.build:gradle:8.13.0'",
-    to: "classpath 'com.android.tools.build:gradle:8.2.1'",
-  },
+const javaVersionReplacements = [
   {
     from: 'sourceCompatibility JavaVersion.VERSION_21',
     to: 'sourceCompatibility JavaVersion.VERSION_17',
@@ -33,15 +13,54 @@ const replacements = [
   },
 ];
 
-for (const rule of replacements) {
-  if (content.includes(rule.from)) {
-    content = content.replace(rule.from, rule.to);
-    changed = true;
+function patchFile(filePath, extraReplacements = []) {
+  if (!fs.existsSync(filePath)) {
+    console.warn(`[fix-capacitor-cordova-gradle] File not found: ${filePath}`);
+    return false;
   }
+
+  let content = fs.readFileSync(filePath, 'utf8');
+  let changed = false;
+
+  for (const rule of [...extraReplacements, ...javaVersionReplacements]) {
+    if (content.includes(rule.from)) {
+      content = content.replace(rule.from, rule.to);
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    fs.writeFileSync(filePath, content);
+  }
+
+  return changed;
 }
 
+const cordovaPluginsGradle = path.resolve(
+  __dirname,
+  '..',
+  'android',
+  'capacitor-cordova-android-plugins',
+  'build.gradle',
+);
+
+const capacitorBuildGradle = path.resolve(
+  __dirname,
+  '..',
+  'android',
+  'app',
+  'capacitor.build.gradle',
+);
+
+const changed =
+  patchFile(cordovaPluginsGradle, [
+    {
+      from: "classpath 'com.android.tools.build:gradle:8.13.0'",
+      to: "classpath 'com.android.tools.build:gradle:8.2.1'",
+    },
+  ]) || patchFile(capacitorBuildGradle);
+
 if (changed) {
-  fs.writeFileSync(targetFile, content);
   console.log('[fix-capacitor-cordova-gradle] Applied Gradle compatibility patch.');
 } else {
   console.log('[fix-capacitor-cordova-gradle] No changes needed.');

--- a/src/utils/geolocation.js
+++ b/src/utils/geolocation.js
@@ -1,3 +1,4 @@
+import { registerPlugin } from '@capacitor/core';
 import { getLiveLocationGeolocationMessages } from './liveLocationGeolocationMessages.js';
 
 let activeWatchId = null;
@@ -52,16 +53,15 @@ function getWebAdapter() {
     };
 }
 
-async function loadBackgroundGeolocation() {
+function loadBackgroundGeolocation() {
     if (!backgroundGeolocationPlugin) {
-        const { registerPlugin } = await import('@capacitor/core');
         backgroundGeolocationPlugin = registerPlugin('BackgroundGeolocation');
     }
     return backgroundGeolocationPlugin;
 }
 
 async function getBackgroundAdapter(watchOptions = {}) {
-    const BackgroundGeolocation = await loadBackgroundGeolocation();
+    const BackgroundGeolocation = loadBackgroundGeolocation();
     const messages =
         watchOptions.messages ?? getLiveLocationGeolocationMessages();
 


### PR DESCRIPTION
## Summary

Follow-up fixes for **live location sharing** on Android after the feature merged in #517. Unblocks release builds and fixes a runtime crash when starting background location on native Android.

## Cause

After shipping live location with `@capacitor/geolocation` and `@capacitor-community/background-geolocation`:

1. **Release build failed** — `iongeolocation-android` requires `minSdk 23`; project was on 22. Capacitor Geolocation also compiled Kotlin for JVM 21 while the project forced Java 17.
2. **Runtime crash on Android** — starting live share threw:
   `"BackgroundGeolocation.then()" is not implemented on android`
   because we `await`ed the Capacitor plugin proxy (any property access, including `.then`, becomes a native call).

---

## Frontend (`live-location-fix`)

### Fixes in this branch

| Issue | Fix |
|-------|-----|
| `bundleRelease` manifest merge error (`minSdk 22 < 23`) | `android/variables.gradle` → `minSdkVersion = 23` |
| Java 17 vs Kotlin 21 mismatch in `:capacitor-geolocation` | `android/build.gradle` → `kotlin { jvmToolchain(17) }` for Kotlin Android modules |
| `cap sync` regenerates Java 21 in `capacitor.build.gradle` | `scripts/fix-capacitor-cordova-gradle.js` patches it back to 17 after sync |
| `BackgroundGeolocation.then()` crash | `geolocation.js` — register plugin synchronously; **do not `await` the plugin object** |
| Store release | Bump Android to **3.2.4** |

### Already merged (#517) — feature context

- Views: `/trips/:id/live`, `/live/:token`, `/trips/:id/ubicacion`
- Native background sharing: foreground service notification while user shares
- iOS/Android permissions, `CapacitorHttp`, coverage removed from git history
