### PR TITLE
Trip create negative contribution

### DIFF
--- a/src/components/views/NewTrip.view.test.js
+++ b/src/components/views/NewTrip.view.test.js
@@ -5,6 +5,34 @@ import path from 'node:path';
 const viewPath = path.resolve(__dirname, 'NewTrip.vue');
 const viewSource = fs.readFileSync(viewPath, 'utf8');
 
+describe('NewTrip.vue negative contribution validation', () => {
+    it('imports negative seat price helper and blocks negative values on save', () => {
+        expect(viewSource).toMatch(/from '\.\.\/\.\.\/utils\/tripSeatPrice\.js'/);
+        expect(viewSource).toContain('isNegativeSeatPriceInput');
+        expect(viewSource).toContain("$t('contribucionPorPersonaNegativa')");
+        expect(viewSource).toMatch(
+            /if \(this\.trip\.is_passenger == 0 && this\.config\.module_seat_price_enabled\)[\s\S]*?isNegativeSeatPriceInput\(this\.price\)/s
+        );
+        expect(viewSource).toMatch(
+            /isNegativeSeatPriceInput\([\s\S]*?this\.returnPrice[\s\S]*?contribucionPorPersonaNegativa/s
+        );
+    });
+
+    it('validates negative contribution while typing for outbound and return trips', () => {
+        expect(viewSource).toMatch(
+            /validatePrice\(\)[\s\S]*?isNegativeSeatPriceInput\(this\.price\)/s
+        );
+        expect(viewSource).toMatch(
+            /validateReturnPrice\(\)[\s\S]*?isNegativeSeatPriceInput\(this\.returnPrice\)/s
+        );
+    });
+
+    it('sets min zero on contribution inputs', () => {
+        expect(viewSource).toMatch(/id="price"[\s\S]*?min="0"/s);
+        expect(viewSource).toMatch(/id="return-price"[\s\S]*?min="0"/s);
+    });
+});
+
 describe('NewTrip.vue max contribution validation timing', () => {
     it('defers max contribution checks until trip-info cap is available', () => {
         expect(viewSource).toContain("from '../../utils/tripMaxPriceValidation.js'");

--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -2610,6 +2610,11 @@ export default {
                 });
         },
 
+        markNegativeContributionError(errorTarget) {
+            errorTarget.state = true;
+            errorTarget.message = this.$t('contribucionPorPersonaNegativa');
+        },
+
         onOutboundPriceFieldInput() {
             this.validatePrice();
             const p = parseSeatPriceInput(this.price);
@@ -2809,10 +2814,7 @@ export default {
                     );
                 } else if (isNegativeSeatPriceInput(this.price)) {
                     globalError = true;
-                    this.priceError.state = true;
-                    this.priceError.message = this.$t(
-                        'contribucionPorPersonaNegativa'
-                    );
+                    this.markNegativeContributionError(this.priceError);
                 } else if (
                     this.config.module_max_price_enabled &&
                     exceedsMaximumSeatPrice({
@@ -2966,10 +2968,7 @@ export default {
                         );
                     } else if (isNegativeSeatPriceInput(this.returnPrice)) {
                         globalError = true;
-                        this.returnPriceError.state = true;
-                        this.returnPriceError.message = this.$t(
-                            'contribucionPorPersonaNegativa'
-                        );
+                        this.markNegativeContributionError(this.returnPriceError);
                     } else if (
                         this.config.module_trip_creation_payment_enabled &&
                         this.config.module_max_price_enabled &&
@@ -3381,10 +3380,7 @@ export default {
         validatePrice() {
             const p = parseSeatPriceInput(this.price);
             if (isNegativeSeatPriceInput(this.price)) {
-                this.priceError.state = true;
-                this.priceError.message = this.$t(
-                    'contribucionPorPersonaNegativa'
-                );
+                this.markNegativeContributionError(this.priceError);
                 return;
             }
             if (
@@ -3518,10 +3514,7 @@ export default {
         validateReturnPrice() {
             const p = parseSeatPriceInput(this.returnPrice);
             if (isNegativeSeatPriceInput(this.returnPrice)) {
-                this.returnPriceError.state = true;
-                this.returnPriceError.message = this.$t(
-                    'contribucionPorPersonaNegativa'
-                );
+                this.markNegativeContributionError(this.returnPriceError);
                 return;
             }
             if (

--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -633,6 +633,7 @@
                                     v-model="price"
                                     class="form-control form-control-with-icon form-control-price"
                                     id="price"
+                                    min="0"
                                     :class="{ 'has-error': priceError.state }"
                                     :placeholder="price"
                                     @input="onOutboundPriceFieldInput"
@@ -700,6 +701,7 @@
                                     v-model="price"
                                     class="form-control form-control-with-icon form-control-price"
                                     id="price"
+                                    min="0"
                                     :class="{ 'has-error': priceError.state }"
                                     :placeholder="price"
                                     :max="maximum_seat_price_cents / 100"
@@ -1332,6 +1334,7 @@
                                     v-model="returnPrice"
                                     class="form-control form-control-with-icon form-control-price"
                                     id="return-price"
+                                    min="0"
                                     :class="{ 'has-error': returnPriceError.state }"
                                     :placeholder="returnPrice"
                                     @input="onReturnPriceFieldInput"
@@ -1380,6 +1383,7 @@
                                     v-model="returnPrice"
                                     class="form-control form-control-with-icon form-control-price"
                                     id="return-price"
+                                    min="0"
                                     :class="{
                                         'has-error': returnPriceError.state
                                     }"
@@ -2004,6 +2008,7 @@ import bus from '../../services/bus-event.js';
 import { getMaxContributionExceededMessage } from '../../utils/maxContributionExceededMessage.js';
 import { rememberMaxContributionWarning } from '../../utils/maxContributionWarningState.js';
 import {
+    isNegativeSeatPriceInput,
     parseSeatPriceInput,
     priceInputNumberFromStoredSeatPriceCents,
     seatPriceCentsForApi
@@ -2610,8 +2615,11 @@ export default {
             const p = parseSeatPriceInput(this.price);
             if (
                 p !== null &&
-                this.priceError.message ===
-                    this.$t('contribucionPorPersonaRequerida')
+                !isNegativeSeatPriceInput(this.price) &&
+                (this.priceError.message ===
+                    this.$t('contribucionPorPersonaRequerida') ||
+                    this.priceError.message ===
+                        this.$t('contribucionPorPersonaNegativa'))
             ) {
                 this.priceError.state = false;
             }
@@ -2622,8 +2630,11 @@ export default {
             const p = parseSeatPriceInput(this.returnPrice);
             if (
                 p !== null &&
-                this.returnPriceError.message ===
-                    this.$t('contribucionPorPersonaRequerida')
+                !isNegativeSeatPriceInput(this.returnPrice) &&
+                (this.returnPriceError.message ===
+                    this.$t('contribucionPorPersonaRequerida') ||
+                    this.returnPriceError.message ===
+                        this.$t('contribucionPorPersonaNegativa'))
             ) {
                 this.returnPriceError.state = false;
             }
@@ -2796,6 +2807,12 @@ export default {
                     this.priceError.message = this.$t(
                         'contribucionPorPersonaRequerida'
                     );
+                } else if (isNegativeSeatPriceInput(this.price)) {
+                    globalError = true;
+                    this.priceError.state = true;
+                    this.priceError.message = this.$t(
+                        'contribucionPorPersonaNegativa'
+                    );
                 } else if (
                     this.config.module_max_price_enabled &&
                     exceedsMaximumSeatPrice({
@@ -2946,6 +2963,12 @@ export default {
                         this.returnPriceError.state = true;
                         this.returnPriceError.message = this.$t(
                             'contribucionPorPersonaRequerida'
+                        );
+                    } else if (isNegativeSeatPriceInput(this.returnPrice)) {
+                        globalError = true;
+                        this.returnPriceError.state = true;
+                        this.returnPriceError.message = this.$t(
+                            'contribucionPorPersonaNegativa'
                         );
                     } else if (
                         this.config.module_trip_creation_payment_enabled &&
@@ -3357,6 +3380,13 @@ export default {
         },
         validatePrice() {
             const p = parseSeatPriceInput(this.price);
+            if (isNegativeSeatPriceInput(this.price)) {
+                this.priceError.state = true;
+                this.priceError.message = this.$t(
+                    'contribucionPorPersonaNegativa'
+                );
+                return;
+            }
             if (
                 this.config.module_max_price_enabled &&
                 exceedsMaximumSeatPrice({
@@ -3487,6 +3517,13 @@ export default {
         },
         validateReturnPrice() {
             const p = parseSeatPriceInput(this.returnPrice);
+            if (isNegativeSeatPriceInput(this.returnPrice)) {
+                this.returnPriceError.state = true;
+                this.returnPriceError.message = this.$t(
+                    'contribucionPorPersonaNegativa'
+                );
+                return;
+            }
             if (
                 exceedsMaximumSeatPrice({
                     seatPriceUnits: p,

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -1407,6 +1407,8 @@ const messages = {
             'Recuerde que exceder la contribución máxima está fuera de las reglas de Carpoolear, el seguro automotor no lo cubrirá en caso de accidente, y será suspendido de la plataforma',
         contribucionPorPersonaRequerida:
             'Tenés que completar la contribución por persona.',
+        contribucionPorPersonaNegativa:
+            'La contribución por persona no puede ser negativa.',
         unaVez: 'Una vez',
         programaSemanal: 'Semanal',
         faltaFechaOProgramaSemanal:
@@ -3994,6 +3996,8 @@ const messages = {
             'Remember that exceeding the maximum contribution is against Carpoolear rules, auto insurance will not cover it in case of an accident, and you will be suspended from the platform',
         contribucionPorPersonaRequerida:
             'You must enter the per-person contribution.',
+        contribucionPorPersonaNegativa:
+            'The per-person contribution cannot be negative.',
         unaVez: 'Once',
         programaSemanal: 'Weekly',
         faltaFechaOProgramaSemanal:

--- a/src/utils/tripSeatPrice.js
+++ b/src/utils/tripSeatPrice.js
@@ -12,17 +12,17 @@ export function parseSeatPriceInput(value) {
     return Number.isFinite(n) ? n : null;
 }
 
-export function isNegativeSeatPriceInput(value) {
-    const parsed = parseSeatPriceInput(value);
+export function isNegativeSeatPriceUnits(parsed) {
     return parsed !== null && parsed < 0;
+}
+
+export function isNegativeSeatPriceInput(value) {
+    return isNegativeSeatPriceUnits(parseSeatPriceInput(value));
 }
 
 export function seatPriceCentsForApi(raw) {
     const p = parseSeatPriceInput(raw);
-    if (p === null) {
-        return null;
-    }
-    if (p < 0) {
+    if (p === null || isNegativeSeatPriceUnits(p)) {
         return null;
     }
     if (p === 0) {

--- a/src/utils/tripSeatPrice.js
+++ b/src/utils/tripSeatPrice.js
@@ -12,9 +12,17 @@ export function parseSeatPriceInput(value) {
     return Number.isFinite(n) ? n : null;
 }
 
+export function isNegativeSeatPriceInput(value) {
+    const parsed = parseSeatPriceInput(value);
+    return parsed !== null && parsed < 0;
+}
+
 export function seatPriceCentsForApi(raw) {
     const p = parseSeatPriceInput(raw);
     if (p === null) {
+        return null;
+    }
+    if (p < 0) {
         return null;
     }
     if (p === 0) {

--- a/src/utils/tripSeatPrice.test.js
+++ b/src/utils/tripSeatPrice.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
     VOLUNTARY_CONTRIBUTION_SEAT_PRICE_CENTS,
+    isNegativeSeatPriceInput,
     isVoluntaryContributionSeatPrice,
     maxContributionCapFromSeatPriceCents,
     parseSeatPriceInput,
@@ -31,6 +32,21 @@ describe('tripSeatPrice', () => {
         });
     });
 
+    describe('isNegativeSeatPriceInput', () => {
+        it('is true for negative form values', () => {
+            expect(isNegativeSeatPriceInput(-1)).toBe(true);
+            expect(isNegativeSeatPriceInput('-5')).toBe(true);
+        });
+
+        it('is false for zero, positive, and empty values', () => {
+            expect(isNegativeSeatPriceInput(0)).toBe(false);
+            expect(isNegativeSeatPriceInput('0')).toBe(false);
+            expect(isNegativeSeatPriceInput(10)).toBe(false);
+            expect(isNegativeSeatPriceInput('')).toBe(false);
+            expect(isNegativeSeatPriceInput(null)).toBe(false);
+        });
+    });
+
     describe('seatPriceCentsForApi', () => {
         it('maps explicit zero to voluntary sentinel -1', () => {
             expect(seatPriceCentsForApi(0)).toBe(-1);
@@ -45,6 +61,11 @@ describe('tripSeatPrice', () => {
         it('returns null when unset (empty input)', () => {
             expect(seatPriceCentsForApi('')).toBeNull();
             expect(seatPriceCentsForApi(null)).toBeNull();
+        });
+
+        it('returns null for negative form values', () => {
+            expect(seatPriceCentsForApi(-5)).toBeNull();
+            expect(seatPriceCentsForApi('-1')).toBeNull();
         });
     });
 


### PR DESCRIPTION
## Summary

Prevent negative per-person contribution values during trip creation.

- **Frontend:** Block negative contribution input in the trip creation form with validation on input/submit, `min="0"` on price fields, and a dedicated error message. Negative form values no longer map to negative cents in the API payload.
- **Backend:** Reject `seat_price_cents` values below `-1` (the voluntary contribution sentinel) on trip create/update.

## Cause

The contribution field accepted negative numbers. `seatPriceCentsForApi` converted them to negative cents (e.g. `-5` → `-500`), and the backend had no validation rule for `seat_price_cents`.

## Fix

### Frontend (`carpoolear`)
- Added `isNegativeSeatPriceInput` / `isNegativeSeatPriceUnits` in `tripSeatPrice.js`; `seatPriceCentsForApi` returns `null` for negative inputs.
- `NewTrip.vue` validates negative values on input and submit (outbound and return trips), sets `min="0"` on contribution inputs, and shows `contribucionPorPersonaNegativa`.
