### PR TITLE
Rate after trip

### DIFF
--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -418,7 +418,7 @@ const messages = {
         confirmarReferenciaUsuarioMensajeReferencia:
             'Estás por escribir una referencia para el usuario {userName}. Las referencias son de la persona, y no de un viaje.',
         confirmarReferenciaUsuarioMensajeCalificacion:
-            'Si tuviste un viaje dentro de Carpoolear y querés dejar una calificación, tenés que esperar a que pasen 24 horas luego de la finalización del viaje, vas a recibir una notificación cuando puedas hacerlo.',
+            'Si tuviste un viaje dentro de Carpoolear y querés dejar una calificación, podés hacerlo cuando haya transcurrido el 80% del tiempo estimado del viaje desde Mis Viajes. Vas a recibir una notificación 24 horas después del inicio del viaje.',
         continuar: 'Continuar',
         referenciaExitosa: 'El comentario fue enviado exitosamente',
         referenciaError: 'Ocurrió un problema al enviar el comentario.',
@@ -961,7 +961,7 @@ const messages = {
         carpoodatosAntesSolicitud:
             'Antes de mandar solicitud de asiento, mandale mensaje a la otra persona para coordinar todo lo vinculado al viaje: punto de encuentro, punto de llegada,tamaño de bolsos, contribución para combustible y peajes, etc.',
         carpoodatosCompromisoViaje:
-            'Si mandaste solicitud de asiento y te aceptan el pedido, se genera el compromiso de viaje. Habilitándose la posibilidad de calificación 24hs después de comenzado el viaje. Tendrán 14 días para calificarse',
+            'Si mandaste solicitud de asiento y te aceptan el pedido, se genera el compromiso de viaje. Habilitándose la posibilidad de calificación cuando transcurra el 80% del tiempo estimado del viaje. Recibirás una notificación 24 horas después del inicio. Tendrán 14 días para calificarse',
         carpoodatosCalificarCancelar:
             'Podrán calificarse aunque el viaje se cancele, te bajen o te bajes del viaje.',
         carpoodatosNoPidasAsiento:
@@ -1293,7 +1293,7 @@ const messages = {
         pendingRequestAntesDeAceptarSolicitud:
             'Antes de aceptar solicitud de asiento, mandale mensaje a la otra persona para coordinar todo lo vinculado al viaje: punto de encuentro, punto de llegada, tamaño de bolsos, contribución para combustible y peajes, etc.',
         pendingRequestSiAceptasUnaSolicitud:
-            'Si aceptás una solicitud de asiento, se genera el compromiso de viajar. Habilitándose la posibilidad de calificación 24hs después de comenzado el viaje. Tendrán 14 días para calificarse',
+            'Si aceptás una solicitud de asiento, se genera el compromiso de viajar. Habilitándose la posibilidad de calificación cuando transcurra el 80% del tiempo estimado del viaje. Recibirás una notificación 24 horas después del inicio. Tendrán 14 días para calificarse',
         pendingRequestPodranCalificarseAunque:
             'Podrán calificarse aunque canceles el viaje o te bajen o te bajes del viaje.',
         pendingRequestNoPidasAsiento:
@@ -2171,7 +2171,7 @@ const messages = {
         carpoodatosAntesSolicitud:
             'Antes de mandar solicitud de asiento, mandale mensaje a la otra persona para coordinar todo lo vinculado al viaje: punto de encuentro, punto de llegada,tamaño de bolsos, contribución para combustible y peajes, etc.',
         carpoodatosCompromisoViaje:
-            'Si mandaste solicitud de asiento y te aceptan el pedido, se genera el compromiso de viaje. Habilitándose la posibilidad de calificación 24hs después de comenzado el viaje. Tendrán 14 días para calificarse',
+            'Si mandaste solicitud de asiento y te aceptan el pedido, se genera el compromiso de viaje. Habilitándose la posibilidad de calificación cuando transcurra el 80% del tiempo estimado del viaje. Recibirás una notificación 24 horas después del inicio. Tendrán 14 días para calificarse',
         carpoodatosCalificarCancelar:
             'Podrán calificarse aunque el viaje se cancele, te bajen o te bajes del viaje.',
         carpoodatosNoPidasAsiento:
@@ -2526,7 +2526,7 @@ const messages = {
         pendingRequestAntesDeAceptarSolicitud:
             'Antes de aceptar solicitud de asiento, mandale mensaje a la otra persona para coordinar todo lo vinculado al viaje: punto de encuentro, punto de llegada, tamaño de bolsos, contribución para combustible y peajes, etc.',
         pendingRequestSiAceptasUnaSolicitud:
-            'Si aceptás una solicitud de asiento, se genera el compromiso de viajar. Habilitándose la posibilidad de calificación 24hs después de comenzado el viaje. Tendrán 14 días para calificarse',
+            'Si aceptás una solicitud de asiento, se genera el compromiso de viajar. Habilitándose la posibilidad de calificación cuando transcurra el 80% del tiempo estimado del viaje. Recibirás una notificación 24 horas después del inicio. Tendrán 14 días para calificarse',
         pendingRequestPodranCalificarseAunque:
             'Podrán calificarse aunque canceles el viaje o te bajen o te bajes del viaje.',
         pendingRequestNoPidasAsiento:
@@ -3030,7 +3030,7 @@ const messages = {
         confirmarReferenciaUsuarioMensajeReferencia:
             'You are about to write a reference for {userName}. References are about the person, not a trip.',
         confirmarReferenciaUsuarioMensajeCalificacion:
-            'If you took a trip within Carpoolear and want to leave a rating, you need to wait 24 hours after the trip ends. You will receive a notification when you can do it.',
+            'If you took a trip within Carpoolear and want to leave a rating, you can do it once 80% of the estimated trip time has passed from My Trips. You will receive a notification 24 hours after the trip starts.',
         continuar: 'Continue',
         referenciaExitosa: 'The comment was sent successfully',
         referenciaError: 'A problem occurred while sending the comment.',
@@ -3563,7 +3563,7 @@ const messages = {
         carpoodatosAntesSolicitud:
             'Before sending a seat request, send a message to the other person to coordinate everything related to the trip: meeting point, arrival point, bag size, contribution for fuel and tolls, etc.',
         carpoodatosCompromisoViaje:
-            'If you sent a seat request and your request is accepted, a trip commitment is generated. Rating will be enabled 24 hours after the trip starts. You will have 14 days to rate each other.',
+            'If you sent a seat request and your request is accepted, a trip commitment is generated. Rating will be enabled once 80% of the estimated trip time has passed. You will receive a notification 24 hours after the trip starts. You will have 14 days to rate each other.',
         carpoodatosCalificarCancelar:
             'You can rate each other even if the trip is canceled, you are removed, or you leave the trip.',
         carpoodatosNoPidasAsiento:
@@ -3888,7 +3888,7 @@ const messages = {
         pendingRequestAntesDeAceptarSolicitud:
             'Before accepting a seat request, send a message to the other person to coordinate everything related to the trip: meeting point, arrival point, bag size, contribution for fuel and tolls, etc.',
         pendingRequestSiAceptasUnaSolicitud:
-            'If you accept a seat request, a commitment to travel is generated. Rating will be enabled 24 hours after the trip starts. You will have 14 days to rate each other.',
+            'If you accept a seat request, a commitment to travel is generated. Rating will be enabled once 80% of the estimated trip time has passed. You will receive a notification 24 hours after the trip starts. You will have 14 days to rate each other.',
         pendingRequestPodranCalificarseAunque:
             'You can rate each other even if you cancel the trip or get removed or leave the trip.',
         pendingRequestNoPidasAsiento:

--- a/src/utils/ongoingTrip.js
+++ b/src/utils/ongoingTrip.js
@@ -2,6 +2,7 @@ import dayjs from '../dayjs';
 
 export const ONGOING_TRIP_LEAD_MINUTES = 60;
 export const ONGOING_TRIP_GRACE_MINUTES = 30;
+export const RATING_AVAILABLE_DURATION_FACTOR = 0.8;
 
 export function estimatedTimeToMinutes(estimatedTime) {
     if (estimatedTime == null || estimatedTime === '') {
@@ -11,6 +12,17 @@ export function estimatedTimeToMinutes(estimatedTime) {
     const hours = Number.parseInt(parts[0], 10) || 0;
     const minutes = Number.parseInt(parts[1], 10) || 0;
     return hours * 60 + minutes;
+}
+
+export function getRatingAvailableAt(tripStart, estimatedTime) {
+    const durationMinutes = estimatedTimeToMinutes(estimatedTime);
+    const availableAfterMinutes = Math.round(durationMinutes * RATING_AVAILABLE_DURATION_FACTOR);
+
+    return tripStart.add(availableAfterMinutes, 'minute');
+}
+
+export function isRatingAvailable(now, tripStart, estimatedTime) {
+    return !now.isBefore(getRatingAvailableAt(tripStart, estimatedTime));
 }
 
 export function isWithinOngoingTripWindow(now, tripStart, estimatedTime) {

--- a/src/utils/ongoingTrip.test.js
+++ b/src/utils/ongoingTrip.test.js
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import dayjs from '../dayjs';
 import {
     estimatedTimeToMinutes,
+    getRatingAvailableAt,
     getTripLocationLabels,
+    isRatingAvailable,
     isWithinOngoingTripWindow,
     canStartSharing,
     isLiveLocationParticipant,
@@ -47,6 +49,27 @@ describe('ongoingTrip isWithinOngoingTripWindow', () => {
     it('is false more than thirty minutes after estimated arrival', () => {
         const now = start.add(81, 'minute');
         expect(isWithinOngoingTripWindow(now, start, '00:50')).toBe(false);
+    });
+});
+
+describe('ongoingTrip rating availability', () => {
+    const tripStart = dayjs('2026-06-01 10:00:00');
+
+    it('computes available time as trip start plus eighty percent of estimated duration', () => {
+        expect(getRatingAvailableAt(tripStart, '02:00').format('YYYY-MM-DD HH:mm:ss')).toBe(
+            '2026-06-01 11:36:00'
+        );
+    });
+
+    it('returns trip start when estimated time is missing', () => {
+        expect(getRatingAvailableAt(tripStart, null).format('YYYY-MM-DD HH:mm:ss')).toBe(
+            '2026-06-01 10:00:00'
+        );
+    });
+
+    it('is available once eighty percent of estimated duration has passed', () => {
+        expect(isRatingAvailable(dayjs('2026-06-01 11:36:00'), tripStart, '02:00')).toBe(true);
+        expect(isRatingAvailable(dayjs('2026-06-01 11:35:00'), tripStart, '02:00')).toBe(false);
     });
 });
 


### PR DESCRIPTION
## Summary

Users can now rate a trip earlier — once 80% of the estimated trip duration has elapsed — while push notifications still go out 24 hours after trip start.

## Cause

Rating eligibility was tied to the same 24-hour cron job that creates rating records and sends notifications. Users had to wait a full day before they could rate, even if the trip had clearly ended much earlier.

## Fix


### Frontend (`carpoolear`)

- Added `getRatingAvailableAt()` / `isRatingAvailable()` in `ongoingTrip.js` (mirrors backend logic).
- Updated i18n copy (ES/EN) to explain that rating is available after trip time, with notification at 24 hours.
