### PR TITLE
Support images: open in a new tab

### DIFF
--- a/src/components/views/AdminSupportTicketDetail.view.test.js
+++ b/src/components/views/AdminSupportTicketDetail.view.test.js
@@ -160,6 +160,12 @@ describe('AdminSupportTicketDetail view', () => {
         expect(viewSource).toContain('fetchSupportTicketAttachmentBlob');
     });
 
+    it('opens reply attachment thumbnails in a new tab when clicked', () => {
+        expect(viewSource).toContain('openBlobImageInNewTab');
+        expect(viewSource).toContain('@click="openBlobImageInNewTab(attachmentBlobUrls[attachment.id])"');
+        expect(viewSource).toContain('ticket-attachment-thumb clickable-img');
+    });
+
     it('shows mark needs review action for open tickets', () => {
         expect(viewSource).toContain('markNeedsReviewTicket');
         expect(viewSource).toContain('adminMarkNeedsReview');

--- a/src/components/views/AdminSupportTicketDetail.view.test.js
+++ b/src/components/views/AdminSupportTicketDetail.view.test.js
@@ -164,6 +164,7 @@ describe('AdminSupportTicketDetail view', () => {
         expect(viewSource).toContain('openBlobImageInNewTab');
         expect(viewSource).toContain('@click="openBlobImageInNewTab(attachmentBlobUrls[attachment.id])"');
         expect(viewSource).toContain('ticket-attachment-thumb clickable-img');
+        expect(viewSource).toContain('.clickable-img {\n    cursor: pointer;\n}');
     });
 
     it('shows mark needs review action for open tickets', () => {

--- a/src/components/views/AdminSupportTicketDetail.vue
+++ b/src/components/views/AdminSupportTicketDetail.vue
@@ -599,6 +599,10 @@ export default {
     max-height: 160px;
 }
 
+.clickable-img {
+    cursor: pointer;
+}
+
 .ticket-meta-row {
     display: flex;
     align-items: center;

--- a/src/components/views/AdminSupportTicketDetail.vue
+++ b/src/components/views/AdminSupportTicketDetail.vue
@@ -58,8 +58,9 @@
                         v-show="attachmentBlobUrls[attachment.id]"
                         :key="attachment.id"
                         :src="attachmentBlobUrls[attachment.id]"
-                        class="img-thumbnail ticket-attachment-thumb"
+                        class="img-thumbnail ticket-attachment-thumb clickable-img"
                         :alt="attachment.original_name"
+                        @click="openBlobImageInNewTab(attachmentBlobUrls[attachment.id])"
                     />
                 </div>
             </div>
@@ -181,7 +182,10 @@ import AdminLayout from '../layouts/AdminLayout.vue';
 import { markdownToHtml } from '../../services/markdown';
 import { interpolateSupportTemplateVariables } from '../../utils/supportTemplateInterpolation';
 import { ticketReplyBodyAlreadyUsed, isDuplicateReplyApiError } from '../../utils/supportTicketReplyDuplicate';
-import { fetchSupportTicketAttachmentBlob } from '../../utils/supportTicketAttachmentImage';
+import {
+    fetchSupportTicketAttachmentBlob,
+    openBlobImageInNewTab
+} from '../../utils/supportTicketAttachmentImage';
 import { useTicketsStore } from '../../stores/tickets';
 import { useReplyTemplatesStore } from '../../stores/replyTemplates';
 import dialogs from '../../services/dialogs.js';
@@ -294,6 +298,7 @@ export default {
         }
     },
     methods: {
+        openBlobImageInNewTab,
         markdownToHtml,
         ...mapActions(useTicketsStore, {
             fetchAdminOne: 'fetchAdminOne',

--- a/src/components/views/TicketDetail.view.test.js
+++ b/src/components/views/TicketDetail.view.test.js
@@ -63,6 +63,7 @@ describe('TicketDetail user view', () => {
         expect(viewSource).toContain('openBlobImageInNewTab');
         expect(viewSource).toContain('@click="openBlobImageInNewTab(attachmentBlobUrls[attachment.id])"');
         expect(viewSource).toContain('ticket-attachment-thumb clickable-img');
+        expect(viewSource).toContain('.clickable-img {\n    cursor: pointer;\n}');
     });
 
     it('shows title above the reply composer', () => {

--- a/src/components/views/TicketDetail.view.test.js
+++ b/src/components/views/TicketDetail.view.test.js
@@ -59,6 +59,12 @@ describe('TicketDetail user view', () => {
         expect(viewSource).toContain('fetchSupportTicketAttachmentBlob');
     });
 
+    it('opens reply attachment thumbnails in a new tab when clicked', () => {
+        expect(viewSource).toContain('openBlobImageInNewTab');
+        expect(viewSource).toContain('@click="openBlobImageInNewTab(attachmentBlobUrls[attachment.id])"');
+        expect(viewSource).toContain('ticket-attachment-thumb clickable-img');
+    });
+
     it('shows title above the reply composer', () => {
         expect(viewSource).toContain("{{ $t('responderAlTicketDeSoporte') }}");
         expect(viewSource).toContain('reply-to-ticket-title');

--- a/src/components/views/TicketDetail.vue
+++ b/src/components/views/TicketDetail.vue
@@ -276,4 +276,8 @@ export default {
     max-width: 160px;
     max-height: 160px;
 }
+
+.clickable-img {
+    cursor: pointer;
+}
 </style>

--- a/src/components/views/TicketDetail.vue
+++ b/src/components/views/TicketDetail.vue
@@ -26,8 +26,9 @@
                         v-show="attachmentBlobUrls[attachment.id]"
                         :key="attachment.id"
                         :src="attachmentBlobUrls[attachment.id]"
-                        class="img-thumbnail ticket-attachment-thumb"
+                        class="img-thumbnail ticket-attachment-thumb clickable-img"
                         :alt="attachment.original_name"
+                        @click="openBlobImageInNewTab(attachmentBlobUrls[attachment.id])"
                     />
                 </div>
             </div>
@@ -70,7 +71,10 @@ import ToastUiEditor from '../elements/ToastUiEditor.vue';
 import { useTicketsStore } from '../../stores/tickets';
 import { ticketReplyBodyAlreadyUsed, isDuplicateReplyApiError } from '../../utils/supportTicketReplyDuplicate';
 import { markdownToHtml } from '../../services/markdown';
-import { fetchSupportTicketAttachmentBlob } from '../../utils/supportTicketAttachmentImage';
+import {
+    fetchSupportTicketAttachmentBlob,
+    openBlobImageInNewTab
+} from '../../utils/supportTicketAttachmentImage';
 import dialogs from '../../services/dialogs';
 import dayjs from '../../dayjs';
 import {
@@ -117,6 +121,7 @@ export default {
         }
     },
     methods: {
+        openBlobImageInNewTab,
         markdownToHtml,
         ...mapActions(useTicketsStore, {
             fetchOne: 'fetchOne',

--- a/src/utils/supportTicketAttachmentImage.js
+++ b/src/utils/supportTicketAttachmentImage.js
@@ -20,6 +20,14 @@ export function supportTicketAttachmentImagePath(ticketId, attachmentId, { admin
     return `${prefix}${ticketId}/attachments/${attachmentId}/image`;
 }
 
+export function openBlobImageInNewTab(blobUrl) {
+    if (!blobUrl) {
+        return;
+    }
+
+    globalThis.open(blobUrl, '_blank', 'noopener,noreferrer');
+}
+
 export function fetchSupportTicketAttachmentBlob(ticketId, attachmentId, { admin = false } = {}) {
     const baseUrl = resolveApiBaseUrl();
     if (!baseUrl) {

--- a/src/utils/supportTicketAttachmentImage.test.js
+++ b/src/utils/supportTicketAttachmentImage.test.js
@@ -1,9 +1,14 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
-    supportTicketAttachmentImagePath
+    supportTicketAttachmentImagePath,
+    openBlobImageInNewTab
 } from './supportTicketAttachmentImage';
 
 describe('supportTicketAttachmentImage', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
     it('builds user and admin attachment image API paths', () => {
         expect(supportTicketAttachmentImagePath(12, 34)).toBe(
             '/api/support/tickets/12/attachments/34/image'
@@ -11,5 +16,29 @@ describe('supportTicketAttachmentImage', () => {
         expect(supportTicketAttachmentImagePath(12, 34, { admin: true })).toBe(
             '/api/admin/support/tickets/12/attachments/34/image'
         );
+    });
+
+    it('opens a blob image URL in a new browser tab', () => {
+        const open = vi.fn();
+        vi.stubGlobal('open', open);
+
+        openBlobImageInNewTab('blob:http://localhost/abc-123');
+
+        expect(open).toHaveBeenCalledWith(
+            'blob:http://localhost/abc-123',
+            '_blank',
+            'noopener,noreferrer'
+        );
+    });
+
+    it('does not open a new tab when blob URL is missing', () => {
+        const open = vi.fn();
+        vi.stubGlobal('open', open);
+
+        openBlobImageInNewTab('');
+        openBlobImageInNewTab(null);
+        openBlobImageInNewTab(undefined);
+
+        expect(open).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Summary
Support ticket attachment images in the user and admin ticket detail views can now be clicked to open full size in a new browser tab.
## Cause
Reply attachment thumbnails were rendered as static `<img>` elements with no click handler. Images loaded correctly via authenticated blob URLs, but there was no way to view them at full size.
## Fix
### Frontend
- Added `openBlobImageInNewTab()` in `supportTicketAttachmentImage.js` to open a blob URL in a new tab (`noopener,noreferrer`).
- Wired `@click` on attachment thumbnails in `TicketDetail.vue` (user) and `AdminSupportTicketDetail.vue` (admin).
- Added `clickable-img` cursor styling so thumbnails look interactive.
- Added unit and view tests covering the new behavior.
