### PR TITLE
chore: ignore local git worktree directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ playwright/.cache/
 
 # Vitest / Istanbul coverage output
 coverage/
+
+# Git worktrees (local isolated checkouts)
+.worktrees/
+worktrees/


### PR DESCRIPTION
Prevent project-local worktrees from appearing as untracked files.