### PR TITLE
Admin cancel trip

### DIFF
--- a/src/components/elements/AdminUserTripsTable.view.test.js
+++ b/src/components/elements/AdminUserTripsTable.view.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const tablePath = path.resolve(__dirname, 'AdminUserTripsTable.vue');
+const source = fs.readFileSync(tablePath, 'utf8');
+
+describe('AdminUserTripsTable', () => {
+    it('renders trip metadata columns and detail link', () => {
+        expect(source).toContain("{{ $t('id') }}");
+        expect(source).toContain("{{ $t('origen') }}");
+        expect(source).toContain("{{ $t('destino') }}");
+        expect(source).toContain("{{ $t('fecha') }}");
+        expect(source).toContain("{{ $t('hora') }}");
+        expect(source).toContain("{{ $t('asientosTotales') }}");
+        expect(source).toContain("{{ $t('estado') }}");
+        expect(source).toContain("name: 'detail_trip'");
+        expect(source).toContain("{{ $t('verDetalleViaje') }}");
+    });
+
+    it('shows cancel button for active trips and calls cancel handler', () => {
+        expect(source).toContain("{{ $t('cancelarViaje') }}");
+        expect(source).toContain('cancelTrip');
+        expect(source).toContain('!trip.deleted');
+    });
+});

--- a/src/components/elements/AdminUserTripsTable.vue
+++ b/src/components/elements/AdminUserTripsTable.vue
@@ -52,6 +52,13 @@
 </template>
 
 <script>
+import {
+    formatTripDate,
+    formatTripTime,
+    formatOccupiedSeats,
+    formatTripStatus
+} from '../../utils/adminTripTable';
+
 export default {
     name: 'admin-user-trips-table',
     props: {
@@ -71,31 +78,16 @@ export default {
     emits: ['cancel'],
     methods: {
         tripDate(trip) {
-            if (!trip.trip_date) {
-                return '';
-            }
-            return String(trip.trip_date).slice(0, 10);
+            return formatTripDate(trip.trip_date);
         },
         tripTime(trip) {
-            if (!trip.trip_date) {
-                return '';
-            }
-            return String(trip.trip_date).slice(11, 16);
+            return formatTripTime(trip.trip_date);
         },
         occupiedSeats(trip) {
-            if (trip.passengerAccepted_count != null) {
-                return trip.passengerAccepted_count;
-            }
-            return '—';
+            return formatOccupiedSeats(trip);
         },
         tripStatus(trip) {
-            if (trip.hidden) {
-                return this.$t('oculto');
-            }
-            if (trip.deleted) {
-                return this.$t('borrado');
-            }
-            return this.$t('activo');
+            return formatTripStatus(trip, (key) => this.$t(key));
         },
         cancelTrip(trip) {
             this.$emit('cancel', trip);

--- a/src/components/elements/AdminUserTripsTable.vue
+++ b/src/components/elements/AdminUserTripsTable.vue
@@ -1,0 +1,115 @@
+<template>
+    <div class="admin-user-trips-table">
+        <p v-if="!trips.length" class="alert alert-warning" role="alert">
+            {{ emptyMessage }}
+        </p>
+        <table v-else class="table table-dark">
+            <thead>
+                <tr>
+                    <th scope="col">{{ $t('id') }}</th>
+                    <th scope="col">{{ $t('origen') }}</th>
+                    <th scope="col">{{ $t('destino') }}</th>
+                    <th scope="col">{{ $t('fecha') }}</th>
+                    <th scope="col">{{ $t('hora') }}</th>
+                    <th scope="col">{{ $t('asientosTotales') }}</th>
+                    <th scope="col">{{ $t('ocupados') }}</th>
+                    <th scope="col">{{ $t('estado') }}</th>
+                    <th scope="col">{{ $t('acciones') }}</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr v-for="trip in trips" :key="trip.id">
+                    <td>{{ trip.id }}</td>
+                    <td>{{ trip.from_town }}</td>
+                    <td>{{ trip.to_town }}</td>
+                    <td>{{ tripDate(trip) }}</td>
+                    <td>{{ tripTime(trip) }}</td>
+                    <td>{{ trip.total_seats }}</td>
+                    <td>{{ occupiedSeats(trip) }}</td>
+                    <td>{{ tripStatus(trip) }}</td>
+                    <td class="admin-user-trips-table__actions">
+                        <router-link
+                            :to="{ name: 'detail_trip', params: { id: trip.id } }"
+                            class="btn btn-default btn-sm"
+                            target="_blank"
+                        >
+                            {{ $t('verDetalleViaje') }}
+                        </router-link>
+                        <button
+                            v-if="!trip.deleted"
+                            type="button"
+                            class="btn btn-danger btn-sm"
+                            :disabled="cancelingId === trip.id"
+                            v-on:click="cancelTrip(trip)"
+                        >
+                            {{ $t('cancelarViaje') }}
+                        </button>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'admin-user-trips-table',
+    props: {
+        trips: {
+            type: Array,
+            default: () => []
+        },
+        emptyMessage: {
+            type: String,
+            required: true
+        },
+        cancelingId: {
+            type: [Number, String, null],
+            default: null
+        }
+    },
+    emits: ['cancel'],
+    methods: {
+        tripDate(trip) {
+            if (!trip.trip_date) {
+                return '';
+            }
+            return String(trip.trip_date).slice(0, 10);
+        },
+        tripTime(trip) {
+            if (!trip.trip_date) {
+                return '';
+            }
+            return String(trip.trip_date).slice(11, 16);
+        },
+        occupiedSeats(trip) {
+            if (trip.passengerAccepted_count != null) {
+                return trip.passengerAccepted_count;
+            }
+            return '—';
+        },
+        tripStatus(trip) {
+            if (trip.hidden) {
+                return this.$t('oculto');
+            }
+            if (trip.deleted) {
+                return this.$t('borrado');
+            }
+            return this.$t('activo');
+        },
+        cancelTrip(trip) {
+            this.$emit('cancel', trip);
+        }
+    }
+};
+</script>
+
+<style scoped>
+.admin-user-trips-table__actions {
+    white-space: nowrap;
+}
+
+.admin-user-trips-table__actions .btn + .btn {
+    margin-left: 6px;
+}
+</style>

--- a/src/components/views/AdminUserTrips.view.test.js
+++ b/src/components/views/AdminUserTrips.view.test.js
@@ -6,16 +6,25 @@ const viewPath = path.resolve(__dirname, 'AdminUserTrips.vue');
 const source = fs.readFileSync(viewPath, 'utf8');
 
 describe('AdminUserTrips view', () => {
-    it('loads trips for the routed user with admin trip modal', () => {
+    it('loads trips for the routed user in admin tables', () => {
         expect(source).toContain('AdminLayout');
         expect(source).toContain("name: 'admin-users-user'");
         expect(source).toContain('tripAsDriver');
         expect(source).toContain('oldTripsAsPassenger');
-        expect(source).toContain(':clickModal="true"');
+        expect(source).toContain('AdminUserTripsTable');
     });
 
-    it('uses Trip clickModal for admin trip inspection', () => {
-        expect(source).toContain("import Trip from '../sections/Trip.vue'");
-        expect(source).toMatch(/<Trip[\s\S]*:clickModal="true"/);
+    it('uses AdminUserTripsTable for each trip section', () => {
+        expect(source).toContain("import AdminUserTripsTable from '../elements/AdminUserTripsTable.vue'");
+        expect(source).toMatch(/<AdminUserTripsTable[\s\S]*:trips="driverTrips"/);
+        expect(source).toMatch(/<AdminUserTripsTable[\s\S]*:trips="passengerTrips"/);
+        expect(source).toMatch(/<AdminUserTripsTable[\s\S]*:trips="oldDriverTrips"/);
+        expect(source).toMatch(/<AdminUserTripsTable[\s\S]*:trips="oldPassengerTrips"/);
+    });
+
+    it('reloads trips after admin cancels one', () => {
+        expect(source).toContain('onTripCanceled');
+        expect(source).toContain('remove');
+        expect(source).toContain('this.load()');
     });
 });

--- a/src/components/views/AdminUserTrips.view.test.js
+++ b/src/components/views/AdminUserTrips.view.test.js
@@ -25,6 +25,6 @@ describe('AdminUserTrips view', () => {
     it('reloads trips after admin cancels one', () => {
         expect(source).toContain('onTripCanceled');
         expect(source).toContain('remove');
-        expect(source).toContain('this.load()');
+        expect(source).toContain('fetchTripLists');
     });
 });

--- a/src/components/views/AdminUserTrips.vue
+++ b/src/components/views/AdminUserTrips.vue
@@ -27,82 +27,42 @@
                         {{ $t('viajes') }}
                         <strong>{{ $t('creados') }}</strong>
                     </h3>
-                    <Loading :data="driverTrips">
-                        <div class="trips-list">
-                            <Trip
-                                v-for="trip in driverTrips"
-                                :key="trip.id"
-                                :trip="trip"
-                                :user="profileUser"
-                                :clickModal="true"
-                            />
-                        </div>
-                        <template #no-data>
-                            <p class="alert alert-warning" role="alert">
-                                {{ $t('noHayViajes') }}
-                            </p>
-                        </template>
-                    </Loading>
+                    <AdminUserTripsTable
+                        :trips="driverTrips"
+                        :empty-message="$t('noHayViajes')"
+                        :canceling-id="cancelingTripId"
+                        v-on:cancel="onTripCanceled"
+                    />
                 </div>
                 <div class="col-xs-24">
                     <h3>
                         {{ $t('viajes') }}
                         <strong>{{ $t('pasajero') }}</strong>
                     </h3>
-                    <Loading :data="passengerTrips">
-                        <div class="trips-list">
-                            <Trip
-                                v-for="trip in passengerTrips"
-                                :key="trip.id"
-                                :trip="trip"
-                                :user="profileUser"
-                                :clickModal="true"
-                            />
-                        </div>
-                        <template #no-data>
-                            <p class="alert alert-warning" role="alert">
-                                {{ $t('noEstasSubidoViaje') }}
-                            </p>
-                        </template>
-                    </Loading>
+                    <AdminUserTripsTable
+                        :trips="passengerTrips"
+                        :empty-message="$t('noEstasSubidoViaje')"
+                        :canceling-id="cancelingTripId"
+                        v-on:cancel="onTripCanceled"
+                    />
                 </div>
                 <div class="col-xs-24">
                     <h3>{{ $t('misViajesPasados') }}</h3>
-                    <Loading :data="oldDriverTrips">
-                        <div class="trips-list">
-                            <Trip
-                                v-for="trip in oldDriverTrips"
-                                :key="trip.id"
-                                :trip="trip"
-                                :user="profileUser"
-                                :clickModal="true"
-                            />
-                        </div>
-                        <template #no-data>
-                            <p class="alert alert-warning" role="alert">
-                                {{ $t('noHayNingunViajePasado') }}
-                            </p>
-                        </template>
-                    </Loading>
+                    <AdminUserTripsTable
+                        :trips="oldDriverTrips"
+                        :empty-message="$t('noHayNingunViajePasado')"
+                        :canceling-id="cancelingTripId"
+                        v-on:cancel="onTripCanceled"
+                    />
                 </div>
                 <div class="col-xs-24">
                     <h3 v-html="$t('viajesMeSubi')"></h3>
-                    <Loading :data="oldPassengerTrips">
-                        <div class="trips-list">
-                            <Trip
-                                v-for="trip in oldPassengerTrips"
-                                :key="trip.id"
-                                :trip="trip"
-                                :user="profileUser"
-                                :clickModal="true"
-                            />
-                        </div>
-                        <template #no-data>
-                            <p class="alert alert-warning" role="alert">
-                                {{ $t('noTeHasSubidoViaje') }}
-                            </p>
-                        </template>
-                    </Loading>
+                    <AdminUserTripsTable
+                        :trips="oldPassengerTrips"
+                        :empty-message="$t('noTeHasSubidoViaje')"
+                        :canceling-id="cancelingTripId"
+                        v-on:cancel="onTripCanceled"
+                    />
                 </div>
             </div>
         </div>
@@ -111,8 +71,7 @@
 
 <script>
 import AdminLayout from '../layouts/AdminLayout.vue';
-import Trip from '../sections/Trip.vue';
-import Loading from '../Loading.vue';
+import AdminUserTripsTable from '../elements/AdminUserTripsTable.vue';
 import { UserApi } from '../../services/api';
 import { useTripsStore } from '../../stores/trips';
 import { mapActions } from 'pinia';
@@ -122,8 +81,7 @@ export default {
     name: 'admin-user-trips',
     components: {
         AdminLayout,
-        Trip,
-        Loading
+        AdminUserTripsTable
     },
     data() {
         return {
@@ -133,7 +91,8 @@ export default {
             passengerTrips: [],
             oldDriverTrips: [],
             oldPassengerTrips: [],
-            userApi: null
+            userApi: null,
+            cancelingTripId: null
         };
     },
     computed: {
@@ -149,7 +108,8 @@ export default {
             tripAsDriver: 'tripsAsDriver',
             tripAsPassenger: 'tripsAsPassenger',
             oldTripsAsDriver: 'oldTripsAsDriver',
-            oldTripsAsPassenger: 'oldTripsAsPassenger'
+            oldTripsAsPassenger: 'oldTripsAsPassenger',
+            remove: 'remove'
         }),
         load() {
             const userId = this.$route.params.userId;
@@ -179,6 +139,27 @@ export default {
                 })
                 .finally(() => {
                     this.loading = false;
+                });
+        },
+        onTripCanceled(trip) {
+            if (!trip || trip.deleted || !window.confirm(this.$t('seguroCancelar'))) {
+                return;
+            }
+            this.cancelingTripId = trip.id;
+            this.remove(trip.id)
+                .then(() => {
+                    dialogs.message(this.$t('viajeCancelado'), {
+                        estado: 'success'
+                    });
+                    return this.load();
+                })
+                .catch(() => {
+                    dialogs.message(this.$t('errorAlCancelar'), {
+                        estado: 'error'
+                    });
+                })
+                .finally(() => {
+                    this.cancelingTripId = null;
                 });
         }
     },

--- a/src/components/views/AdminUserTrips.vue
+++ b/src/components/views/AdminUserTrips.vue
@@ -111,6 +111,18 @@ export default {
             oldTripsAsPassenger: 'oldTripsAsPassenger',
             remove: 'remove'
         }),
+        async fetchTripLists(userId) {
+            const body = await this.userApi.show(userId);
+            this.profileUser = body.data || null;
+            if (!this.profileUser) {
+                throw new Error('not found');
+            }
+            const id = this.profileUser.id;
+            this.driverTrips = await this.tripAsDriver(id);
+            this.passengerTrips = await this.tripAsPassenger(id);
+            this.oldDriverTrips = await this.oldTripsAsDriver(id);
+            this.oldPassengerTrips = await this.oldTripsAsPassenger(id);
+        },
         load() {
             const userId = this.$route.params.userId;
             if (!userId) {
@@ -118,19 +130,7 @@ export default {
                 return;
             }
             this.loading = true;
-            this.userApi
-                .show(userId)
-                .then(async (body) => {
-                    this.profileUser = body.data || null;
-                    if (!this.profileUser) {
-                        throw new Error('not found');
-                    }
-                    const id = this.profileUser.id;
-                    this.driverTrips = await this.tripAsDriver(id);
-                    this.passengerTrips = await this.tripAsPassenger(id);
-                    this.oldDriverTrips = await this.oldTripsAsDriver(id);
-                    this.oldPassengerTrips = await this.oldTripsAsPassenger(id);
-                })
+            this.fetchTripLists(userId)
                 .catch(() => {
                     dialogs.message(this.$t('noSeEncontroNingunUsuario'), {
                         estado: 'error'
@@ -151,7 +151,7 @@ export default {
                     dialogs.message(this.$t('viajeCancelado'), {
                         estado: 'success'
                     });
-                    return this.load();
+                    return this.fetchTripLists(this.$route.params.userId);
                 })
                 .catch(() => {
                     dialogs.message(this.$t('errorAlCancelar'), {

--- a/src/utils/adminTripTable.js
+++ b/src/utils/adminTripTable.js
@@ -1,0 +1,30 @@
+export function formatTripDate(tripDate) {
+    if (!tripDate) {
+        return '';
+    }
+    return String(tripDate).slice(0, 10);
+}
+
+export function formatTripTime(tripDate) {
+    if (!tripDate) {
+        return '';
+    }
+    return String(tripDate).slice(11, 16);
+}
+
+export function formatOccupiedSeats(trip) {
+    if (trip.passengerAccepted_count != null) {
+        return trip.passengerAccepted_count;
+    }
+    return '—';
+}
+
+export function formatTripStatus(trip, translate) {
+    if (trip.hidden) {
+        return translate('oculto');
+    }
+    if (trip.deleted) {
+        return translate('borrado');
+    }
+    return translate('activo');
+}

--- a/src/utils/adminTripTable.test.js
+++ b/src/utils/adminTripTable.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import {
+    formatTripDate,
+    formatTripTime,
+    formatOccupiedSeats,
+    formatTripStatus
+} from './adminTripTable';
+
+describe('adminTripTable helpers', () => {
+    it('formats trip date and time from trip_date', () => {
+        expect(formatTripDate('2028-05-15 10:30:00')).toBe('2028-05-15');
+        expect(formatTripTime('2028-05-15 10:30:00')).toBe('10:30');
+    });
+
+    it('formats occupied seats and status labels', () => {
+        const translate = (key) => key;
+        expect(formatOccupiedSeats({ passengerAccepted_count: 2 })).toBe(2);
+        expect(formatOccupiedSeats({})).toBe('—');
+        expect(formatTripStatus({ hidden: true }, translate)).toBe('oculto');
+        expect(formatTripStatus({ deleted: true }, translate)).toBe('borrado');
+        expect(formatTripStatus({}, translate)).toBe('activo');
+    });
+});


### PR DESCRIPTION
## Summary

Adds admin trip cancellation and a structured trips table on the admin user trips page (`/app/admin/users/:userId/trips`).

## Cause

Admins viewing a user's trips only saw trip cards with a modal preview. There was no table with key trip metadata, no way to cancel trips from admin, and no clear split between opening the in-app detail popup vs. the public trip URL.

## Fix

### Frontend (`carpoolear`)

- Replaced trip cards on `AdminUserTrips` with `AdminUserTripsTable` for all four sections (created, passenger, past created, past passenger).
- Table columns: ID, origin, destination, date, time, total seats, occupied seats, status, and actions.
- **Trip ID** opens the public trip page in a new tab (`detail_trip` route).
- **Ver detalle del viaje** opens the existing `TripDisplay` popup modal (same behavior as before with `clickModal`).
- **Cancelar viaje** cancels active trips with confirmation, success/error feedback, and a silent list refresh (no full-page loader).
- Extracted shared formatting helpers in `adminTripTable.js` (date, time, seats, status).
- Added/updated view tests for the table, page, and helpers.
