### PR TITLE
fix: restore trip detail popup and open public URL from trip id

### DIFF
--- a/src/components/elements/AdminUserTripsTable.view.test.js
+++ b/src/components/elements/AdminUserTripsTable.view.test.js
@@ -6,7 +6,7 @@ const tablePath = path.resolve(__dirname, 'AdminUserTripsTable.vue');
 const source = fs.readFileSync(tablePath, 'utf8');
 
 describe('AdminUserTripsTable', () => {
-    it('renders trip metadata columns and detail link', () => {
+    it('renders trip metadata columns with public id link', () => {
         expect(source).toContain("{{ $t('id') }}");
         expect(source).toContain("{{ $t('origen') }}");
         expect(source).toContain("{{ $t('destino') }}");
@@ -14,8 +14,15 @@ describe('AdminUserTripsTable', () => {
         expect(source).toContain("{{ $t('hora') }}");
         expect(source).toContain("{{ $t('asientosTotales') }}");
         expect(source).toContain("{{ $t('estado') }}");
-        expect(source).toContain("name: 'detail_trip'");
+        expect(source).toMatch(
+            /<router-link[\s\S]*name: 'detail_trip'[\s\S]*target="_blank"[\s\S]*\{\{ trip\.id \}\}/
+        );
+    });
+
+    it('opens trip detail popup from ver detalle action', () => {
         expect(source).toContain("{{ $t('verDetalleViaje') }}");
+        expect(source).toContain('openDetail');
+        expect(source).toContain("'open-detail'");
     });
 
     it('shows cancel button for active trips and calls cancel handler', () => {

--- a/src/components/elements/AdminUserTripsTable.vue
+++ b/src/components/elements/AdminUserTripsTable.vue
@@ -19,7 +19,15 @@
             </thead>
             <tbody>
                 <tr v-for="trip in trips" :key="trip.id">
-                    <td>{{ trip.id }}</td>
+                    <td>
+                        <router-link
+                            :to="{ name: 'detail_trip', params: { id: trip.id } }"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            {{ trip.id }}
+                        </router-link>
+                    </td>
                     <td>{{ trip.from_town }}</td>
                     <td>{{ trip.to_town }}</td>
                     <td>{{ tripDate(trip) }}</td>
@@ -28,13 +36,13 @@
                     <td>{{ occupiedSeats(trip) }}</td>
                     <td>{{ tripStatus(trip) }}</td>
                     <td class="admin-user-trips-table__actions">
-                        <router-link
-                            :to="{ name: 'detail_trip', params: { id: trip.id } }"
+                        <button
+                            type="button"
                             class="btn btn-default btn-sm"
-                            target="_blank"
+                            v-on:click="openDetail(trip)"
                         >
                             {{ $t('verDetalleViaje') }}
-                        </router-link>
+                        </button>
                         <button
                             v-if="!trip.deleted"
                             type="button"
@@ -75,8 +83,11 @@ export default {
             default: null
         }
     },
-    emits: ['cancel'],
+    emits: ['cancel', 'open-detail'],
     methods: {
+        openDetail(trip) {
+            this.$emit('open-detail', trip);
+        },
         tripDate(trip) {
             return formatTripDate(trip.trip_date);
         },

--- a/src/components/views/AdminUserTrips.view.test.js
+++ b/src/components/views/AdminUserTrips.view.test.js
@@ -27,4 +27,12 @@ describe('AdminUserTrips view', () => {
         expect(source).toContain('remove');
         expect(source).toContain('fetchTripLists');
     });
+
+    it('opens trip detail in admin popup modal', () => {
+        expect(source).toContain("import tripDisplay from '../sections/TripDisplay'");
+        expect(source).toContain('<tripDisplay');
+        expect(source).toContain('openTripDetail');
+        expect(source).toContain('closeTripDetail');
+        expect(source).toContain('v-on:open-detail="openTripDetail"');
+    });
 });

--- a/src/components/views/AdminUserTrips.vue
+++ b/src/components/views/AdminUserTrips.vue
@@ -31,6 +31,7 @@
                         :trips="driverTrips"
                         :empty-message="$t('noHayViajes')"
                         :canceling-id="cancelingTripId"
+                        v-on:open-detail="openTripDetail"
                         v-on:cancel="onTripCanceled"
                     />
                 </div>
@@ -43,6 +44,7 @@
                         :trips="passengerTrips"
                         :empty-message="$t('noEstasSubidoViaje')"
                         :canceling-id="cancelingTripId"
+                        v-on:open-detail="openTripDetail"
                         v-on:cancel="onTripCanceled"
                     />
                 </div>
@@ -52,6 +54,7 @@
                         :trips="oldDriverTrips"
                         :empty-message="$t('noHayNingunViajePasado')"
                         :canceling-id="cancelingTripId"
+                        v-on:open-detail="openTripDetail"
                         v-on:cancel="onTripCanceled"
                     />
                 </div>
@@ -61,10 +64,16 @@
                         :trips="oldPassengerTrips"
                         :empty-message="$t('noTeHasSubidoViaje')"
                         :canceling-id="cancelingTripId"
+                        v-on:open-detail="openTripDetail"
                         v-on:cancel="onTripCanceled"
                     />
                 </div>
             </div>
+            <tripDisplay
+                v-if="showTrip"
+                :trip="currentViaje"
+                :clickOutside="closeTripDetail.bind(this)"
+            ></tripDisplay>
         </div>
     </AdminLayout>
 </template>
@@ -72,6 +81,7 @@
 <script>
 import AdminLayout from '../layouts/AdminLayout.vue';
 import AdminUserTripsTable from '../elements/AdminUserTripsTable.vue';
+import tripDisplay from '../sections/TripDisplay';
 import { UserApi } from '../../services/api';
 import { useTripsStore } from '../../stores/trips';
 import { mapActions } from 'pinia';
@@ -81,7 +91,8 @@ export default {
     name: 'admin-user-trips',
     components: {
         AdminLayout,
-        AdminUserTripsTable
+        AdminUserTripsTable,
+        tripDisplay
     },
     data() {
         return {
@@ -92,7 +103,9 @@ export default {
             oldDriverTrips: [],
             oldPassengerTrips: [],
             userApi: null,
-            cancelingTripId: null
+            cancelingTripId: null,
+            showTrip: false,
+            currentViaje: {}
         };
     },
     computed: {
@@ -140,6 +153,14 @@ export default {
                 .finally(() => {
                     this.loading = false;
                 });
+        },
+        openTripDetail(trip) {
+            this.currentViaje = trip;
+            this.showTrip = true;
+        },
+        closeTripDetail() {
+            this.showTrip = false;
+            this.currentViaje = {};
         },
         onTripCanceled(trip) {
             if (!trip || trip.deleted || !window.confirm(this.$t('seguroCancelar'))) {


### PR DESCRIPTION
Ver detalle del viaje opens the TripDisplay modal again; clicking the trip ID opens the public trip page in a new tab.