### PR TITLE
Admin splash

### DIFF
--- a/src/App.splash.test.js
+++ b/src/App.splash.test.js
@@ -1,0 +1,19 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const appPath = path.join(__dirname, 'App.vue');
+const appSource = fs.readFileSync(appPath, 'utf8');
+
+describe('App custom splash', () => {
+    it('skips the custom splash overlay for admin users', () => {
+        expect(appSource).toContain('v-if="customSplashVisible"');
+        expect(appSource).toMatch(
+            /customSplashVisible\s*\(\)\s*\{[\s\S]*this\.user[\s\S]*is_admin[\s\S]*return false/
+        );
+    });
+
+    it('uses custom splash visibility for modal suppression', () => {
+        expect(appSource).toContain('return this.customSplashVisible || this.onBoardingVisibility');
+    });
+});

--- a/src/App.vue
+++ b/src/App.vue
@@ -13,7 +13,7 @@
             />
             <ChangelogModal :suppress="changelogModalSuppress" />
             <!-- Custom Splash Screen -->
-            <div v-if="showCustomSplash" class="custom-splash-screen">
+            <div v-if="customSplashVisible" class="custom-splash-screen">
                 <img
                     :src="$publicImg('splash-android-1280x1920.png')"
                     alt="Carpoolear"
@@ -208,11 +208,17 @@ export default {
                 !this.isBrowser;
             return moduleEnabled && (mustShowMobile || mustShowGeneral);
         },
+        customSplashVisible() {
+            if (this.user && this.user.is_admin) {
+                return false;
+            }
+            return this.showCustomSplash;
+        },
         identityPromptSuppress() {
-            return this.showCustomSplash || this.onBoardingVisibility;
+            return this.customSplashVisible || this.onBoardingVisibility;
         },
         changelogModalSuppress() {
-            return this.showCustomSplash || this.onBoardingVisibility;
+            return this.customSplashVisible || this.onBoardingVisibility;
         },
         passengerMaintenanceWall() {
             const cfg = this.appConfig && this.appConfig.maintenance;

--- a/src/App.vue
+++ b/src/App.vue
@@ -155,6 +155,11 @@ export default {
             window.SplashScreen.hide();
         }
 
+        if (this.user && this.user.is_admin) {
+            this.showCustomSplash = false;
+            return;
+        }
+
         setTimeout(() => {
             this.showCustomSplash = false;
         }, 3000);
@@ -268,6 +273,11 @@ export default {
     },
     watch: {
         deviceReady: () => {
+        },
+        user(user) {
+            if (user && user.is_admin) {
+                this.showCustomSplash = false;
+            }
         },
         appConfig(value) {
             if (value && value.locale && !localStorage.getItem('app_locale')) {


### PR DESCRIPTION
## Summary

Skip the custom splash overlay for admin users so they can access admin tools immediately on app load.

## Cause

All users saw a 3-second custom splash screen on startup (`showCustomSplash`), including admins who need fast access to admin routes during maintenance or day-to-day operations.

## Fix (Frontend)

- Added `customSplashVisible` computed property that bypasses the splash when `user.is_admin` is true (same pattern as `passengerMaintenanceWall`).
- Updated splash template and modal suppression logic to use `customSplashVisible`.
- Dismiss splash immediately for admins on mount and when the admin session loads (skip unnecessary 3s timer).
