### PR TITLE
Trip checks

### DIFF
--- a/src/components/sections/TripInviteFriends.view.test.js
+++ b/src/components/sections/TripInviteFriends.view.test.js
@@ -82,9 +82,8 @@ describe('TripSeats.vue TripInviteFriends integration', () => {
 });
 
 describe('NewTrip.vue post-create invite friends redirect', () => {
-    it('redirects to trip detail with inviteFriends query after create', () => {
-        expect(newTripViewSource).toMatch(
-            /name:\s*'detail_trip'[\s\S]*?inviteFriends:\s*'1'/s
-        );
+    it('uses tripDetailRouteAfterCreate for post-create navigation', () => {
+        expect(newTripViewSource).toContain('tripDetailRouteAfterCreate');
+        expect(newTripViewSource).toContain('viajeYaPublicado');
     });
 });

--- a/src/components/views/NewTrip.create.view.test.js
+++ b/src/components/views/NewTrip.create.view.test.js
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const newTripViewPath = path.resolve(__dirname, 'NewTrip.vue');
+const newTripViewSource = fs.readFileSync(newTripViewPath, 'utf8');
+
+describe('NewTrip duplicate create handling', () => {
+    it('redirects via tripDetailRouteAfterCreate and notifies when trip already exists', () => {
+        expect(newTripViewSource).toContain('tripDetailRouteAfterCreate');
+        expect(newTripViewSource).toContain('viajeYaPublicado');
+        expect(newTripViewSource).toContain('t.existing');
+    });
+});

--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -2034,6 +2034,7 @@ import WeeklySchedule from '../elements/WeeklySchedule';
 import CompleteCarModal from '../elements/CompleteCarModal.vue';
 import TripCarsModal from '../elements/TripCarsModal.vue';
 import bus from '../../services/bus-event.js';
+import { tripDetailRouteAfterCreate } from '../../utils/tripCreateRedirect.js';
 import { getMaxContributionExceededMessage } from '../../utils/maxContributionExceededMessage.js';
 import { rememberMaxContributionWarning } from '../../utils/maxContributionWarningState.js';
 import {
@@ -3189,15 +3190,12 @@ export default {
                             }
                         }).then((ot) => {
                             this.saving = false;
-                            this.$router.replace({
-                                name: 'detail_trip',
-                                params: {
-                                    id: t.id
-                                },
-                                query: {
-                                    inviteFriends: '1'
-                                }
-                            });
+                            if (t.existing) {
+                                dialogs.message(this.$t('viajeYaPublicado'), {
+                                    estado: 'info'
+                                });
+                            }
+                            this.$router.replace(tripDetailRouteAfterCreate(t));
                         });
                     })
                     .catch((err) => {

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -447,6 +447,8 @@ const messages = {
             'Tienes que ser verificado como conductor para poder cargar viajes.',
         problemaAlCargarElViaje:
             'Ocurrió un problema al cargar el viaje. Por favor vuelva a intentarlo.',
+        viajeYaPublicado:
+            'Ya tenés un viaje publicado con el mismo origen, destino y horario. Te llevamos a ese viaje.',
         routingServiceTemporaryError:
             'El sistema de routeo está teniendo problemas temporalmente, por favor intente más tarde',
         ingresePuntoIntermedio: 'Ingrese punto intermedio (opcional)',
@@ -3232,6 +3234,8 @@ const messages = {
             'You must be verified as a driver to be able to create trips.',
         problemaAlCargarElViaje:
             'A problem occurred while loading the trip. Please try again.',
+        viajeYaPublicado:
+            'You already have a trip with the same origin, destination, and time. Redirecting you to it.',
         routingServiceTemporaryError:
             'The routing system is temporarily unavailable, please try again later.',
         ingresePuntoIntermedio: 'Enter intermediate point (optional)',

--- a/src/stores/trips.create.test.js
+++ b/src/stores/trips.create.test.js
@@ -41,10 +41,12 @@ describe('trips store create', () => {
 
         const store = useTripsStore();
         store.tripsSearchParam = { data: {} };
+        store.tripsSearch = vi.fn().mockResolvedValue(undefined);
         const trip = await store.create({ from_town: 'A', to_town: 'B' });
 
         expect(trip.existing).toBe(true);
         expect(myTripsStoreMock.addTrip).not.toHaveBeenCalled();
+        expect(store.tripsSearch).not.toHaveBeenCalled();
     });
 
     it('adds newly created trips to myTrips', async () => {
@@ -55,6 +57,7 @@ describe('trips store create', () => {
 
         const store = useTripsStore();
         store.tripsSearchParam = { data: {} };
+        store.tripsSearch = vi.fn().mockResolvedValue(undefined);
         const trip = await store.create({ from_town: 'A', to_town: 'B' });
 
         expect(trip.existing).toBe(false);

--- a/src/stores/trips.create.test.js
+++ b/src/stores/trips.create.test.js
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+
+const tripsApiMock = {
+    create: vi.fn(),
+    tag: vi.fn(() => ({
+        search: vi.fn()
+    }))
+};
+
+const myTripsStoreMock = {
+    addTrip: vi.fn()
+};
+
+vi.mock('../services/api', () => ({
+    TripApi: class TripApiMock {
+        constructor() {
+            return tripsApiMock;
+        }
+    }
+}));
+
+vi.mock('./myTrips', () => ({
+    useMyTripsStore: () => myTripsStoreMock
+}));
+
+describe('trips store create', () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        tripsApiMock.create.mockReset();
+        tripsApiMock.tag.mockReset();
+        myTripsStoreMock.addTrip.mockReset();
+        tripsApiMock.tag.mockReturnValue({ search: vi.fn() });
+    });
+
+    it('does not add duplicate trips to myTrips when backend returns existing', async () => {
+        const { useTripsStore } = await import('./trips');
+        tripsApiMock.create.mockResolvedValue({
+            data: { id: 99, from_town: 'A', to_town: 'B', existing: true }
+        });
+
+        const store = useTripsStore();
+        store.tripsSearchParam = { data: {} };
+        const trip = await store.create({ from_town: 'A', to_town: 'B' });
+
+        expect(trip.existing).toBe(true);
+        expect(myTripsStoreMock.addTrip).not.toHaveBeenCalled();
+    });
+
+    it('adds newly created trips to myTrips', async () => {
+        const { useTripsStore } = await import('./trips');
+        tripsApiMock.create.mockResolvedValue({
+            data: { id: 100, from_town: 'A', to_town: 'B', existing: false }
+        });
+
+        const store = useTripsStore();
+        store.tripsSearchParam = { data: {} };
+        const trip = await store.create({ from_town: 'A', to_town: 'B' });
+
+        expect(trip.existing).toBe(false);
+        expect(myTripsStoreMock.addTrip).toHaveBeenCalledWith(trip);
+    });
+});

--- a/src/stores/trips.js
+++ b/src/stores/trips.js
@@ -33,9 +33,12 @@ export const useTripsStore = defineStore('trips', {
             const { useMyTripsStore } = await import('./myTrips');
             const myTripsStore = useMyTripsStore();
             return tripsApi.create(data).then((response) => {
-                myTripsStore.addTrip(response.data);
-                this.tripsSearch(this.tripsSearchParam.data);
-                return Promise.resolve(response.data);
+                const trip = response.data;
+                if (!trip.existing) {
+                    myTripsStore.addTrip(trip);
+                    this.tripsSearch(this.tripsSearchParam.data);
+                }
+                return Promise.resolve(trip);
             });
         },
 

--- a/src/utils/tripCreateRedirect.js
+++ b/src/utils/tripCreateRedirect.js
@@ -1,0 +1,13 @@
+export function shouldInviteFriendsAfterCreate(trip) {
+    return !trip?.existing;
+}
+
+export function tripDetailRouteAfterCreate(trip) {
+    return {
+        name: 'detail_trip',
+        params: { id: trip.id },
+        query: shouldInviteFriendsAfterCreate(trip)
+            ? { inviteFriends: '1' }
+            : {}
+    };
+}

--- a/src/utils/tripCreateRedirect.test.js
+++ b/src/utils/tripCreateRedirect.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+    shouldInviteFriendsAfterCreate,
+    tripDetailRouteAfterCreate
+} from './tripCreateRedirect';
+
+describe('tripCreateRedirect', () => {
+    it('skips invite friends when backend returned an existing trip', () => {
+        expect(shouldInviteFriendsAfterCreate({ id: 5, existing: true })).toBe(
+            false
+        );
+    });
+
+    it('shows invite friends for a newly created trip', () => {
+        expect(shouldInviteFriendsAfterCreate({ id: 5, existing: false })).toBe(
+            true
+        );
+        expect(shouldInviteFriendsAfterCreate({ id: 5 })).toBe(true);
+    });
+
+    it('builds detail route without inviteFriends for existing trips', () => {
+        expect(tripDetailRouteAfterCreate({ id: 42, existing: true })).toEqual({
+            name: 'detail_trip',
+            params: { id: 42 },
+            query: {}
+        });
+    });
+
+    it('builds detail route with inviteFriends for new trips', () => {
+        expect(tripDetailRouteAfterCreate({ id: 42 })).toEqual({
+            name: 'detail_trip',
+            params: { id: 42 },
+            query: { inviteFriends: '1' }
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Fixes a production bug where the passenger “similar trip” limit never ran, and prevents duplicate driver/passenger trips with the same origin, destination, date, and time.

## Cause

### Passenger similar-trip check
`PassengersManager` read `config('carpoolear.module_user_request_limited')` (legacy object key), but production config only defines:
- `module_user_request_limited_enabled`
- `module_user_request_limited_hours_range`

So the block for `user_has_another_similar_trip` was effectively disabled in production.

### Duplicate trip creation
There was no backend or frontend guard against creating the same trip twice. Concurrent or repeated submits could insert multiple identical rows. The API always created a new trip and the frontend always redirected to the new `id`.

## Fix

### Frontend
- **`trips` store:** Skips `myTrips` update and search refresh when `existing: true`.
- **`NewTrip.vue`:** Redirects to the existing trip via `tripDetailRouteAfterCreate()`; shows an info message; skips `inviteFriends` query for duplicates.
- **i18n:** Added `viajeYaPublicado` (ES/EN).

## Test plan

- [ ] Enable `MODULE_USER_REQUEST_LIMITED_ENABLED=true` and verify a passenger with an accepted trip in the time window cannot request another similar trip (`user_has_another_similar_trip`).
- [ ] Create a trip as driver; submit the same origin/destination/date/time again → API returns same `id` with `existing: true`, no second DB row.
- [ ] Frontend redirects to existing trip detail and shows info toast (no invite-friends prompt).
- [ ] Change only trip time or date → new trip is created normally with `existing: false`.
- [ ] Return trip flow (`parent_trip_id`) still creates a separate return trip.