### PR TITLE
Referencias description

### DIFF
--- a/src/components/sections/ProfileRates.view.test.js
+++ b/src/components/sections/ProfileRates.view.test.js
@@ -21,8 +21,30 @@ const referenceTripRatingCopy =
     'Si tuviste un viaje dentro de Carpoolear y querés dejar una calificación, podés hacerlo cuando haya transcurrido el 80% del tiempo estimado del viaje desde Mis Viajes. Vas a recibir una notificación 24 horas después del inicio del viaje.';
 const referenceModalParagraphsRule =
     /<template #body>[\s\S]*<p>[\s\S]*\$t\('confirmarReferenciaUsuarioMensajeReferencia'[\s\S]*<\/p>[\s\S]*<p>[\s\S]*\$t\('confirmarReferenciaUsuarioMensajeCalificacion'\)[\s\S]*<\/p>[\s\S]*<\/template>/;
+const referenciasDescriptionKey = 'referenciasDescripcion';
+const referenciasDescriptionCopy =
+    'Las referencias son recomendaciones de la persona, no por un viaje en particular dentro de Carpoolear';
+const referenciasSectionDescriptionRule =
+    /<h2>\{\{ \$t\('referencias'\) \}\}<\/h2>[\s\S]*<p>[\s\S]*\$t\('referenciasDescripcion'\)[\s\S]*<\/p>/;
 
 describe('ProfileRates reference action', () => {
+    it('shows a description paragraph below the references section header', () => {
+        const referencesHeadingIndex = profileRatesSource.indexOf("$t('referencias')");
+        const descriptionIndex = profileRatesSource.indexOf(
+            `$t('${referenciasDescriptionKey}')`
+        );
+        const actionIndex = profileRatesSource.indexOf("$t('enviarReferencia')");
+
+        expect(profileRatesSource).toMatch(referenciasSectionDescriptionRule);
+        expect(descriptionIndex).toBeGreaterThan(referencesHeadingIndex);
+        expect(descriptionIndex).toBeLessThan(actionIndex);
+    });
+
+    it('keeps the references section description in i18n', () => {
+        expect(i18nSource).toContain(referenciasDescriptionKey);
+        expect(i18nSource).toContain(referenciasDescriptionCopy);
+    });
+
     it('shows the write-reference action in the references section before the list', () => {
         const referencesHeadingIndex = profileRatesSource.indexOf("$t('referencias')");
         const actionIndex = profileRatesSource.indexOf("$t('enviarReferencia')");

--- a/src/components/sections/ProfileRates.view.test.js
+++ b/src/components/sections/ProfileRates.view.test.js
@@ -25,7 +25,7 @@ const referenciasDescriptionKey = 'referenciasDescripcion';
 const referenciasDescriptionCopy =
     'Las referencias son recomendaciones de la persona, no por un viaje en particular dentro de Carpoolear';
 const referenciasSectionDescriptionRule =
-    /<h2>\{\{ \$t\('referencias'\) \}\}<\/h2>[\s\S]*<p>[\s\S]*\$t\('referenciasDescripcion'\)[\s\S]*<\/p>/;
+    /<h2>\{\{ \$t\('referencias'\) \}\}<\/h2>[\s\S]*<p class="referencias-section-description">[\s\S]*\$t\('referenciasDescripcion'\)[\s\S]*<\/p>/;
 
 describe('ProfileRates reference action', () => {
     it('shows a description paragraph below the references section header', () => {

--- a/src/components/sections/ProfileRates.vue
+++ b/src/components/sections/ProfileRates.vue
@@ -64,7 +64,9 @@
         <template v-if="config && config.module_references">
             <div class="clearfix">
                 <h2>{{ $t('referencias') }}</h2>
-                <p>{{ $t('referenciasDescripcion') }}</p>
+                <p class="referencias-section-description">
+                    {{ $t('referenciasDescripcion') }}
+                </p>
                 <div
                     class="edit-action edit-action-reference"
                     v-if="canWriteReference"
@@ -386,6 +388,10 @@ export default {
 }
 
 .edit-action-reference {
+    margin-bottom: 1rem;
+}
+
+.referencias-section-description {
     margin-bottom: 1rem;
 }
 

--- a/src/components/sections/ProfileRates.vue
+++ b/src/components/sections/ProfileRates.vue
@@ -64,6 +64,7 @@
         <template v-if="config && config.module_references">
             <div class="clearfix">
                 <h2>{{ $t('referencias') }}</h2>
+                <p>{{ $t('referenciasDescripcion') }}</p>
                 <div
                     class="edit-action edit-action-reference"
                     v-if="canWriteReference"

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -914,6 +914,8 @@ const messages = {
         comenzar: '¡Comenzar!',
         siguiente: 'Siguiente',
         referencias: 'Referencias',
+        referenciasDescripcion:
+            'Las referencias son recomendaciones de la persona, no por un viaje en particular dentro de Carpoolear',
         buscar: 'Buscar',
         opcional: 'opcional',
         pagoPendiente: 'Pago pendiente',
@@ -3695,6 +3697,8 @@ const messages = {
         comenzar: 'Get started!',
         siguiente: 'Next',
         referencias: 'Reviews',
+        referenciasDescripcion:
+            'References are recommendations about the person, not about a specific trip within Carpoolear',
         buscar: 'Search',
         opcional: 'optional',
         pagoPendiente: 'Payment pending',


### PR DESCRIPTION
## Summary

Add a short explanatory paragraph below the **Referencias** header on the user profile, clarifying that references are recommendations about the person — not tied to a specific Carpoolear trip.

## Cause

Users could confuse **Referencias** (personal recommendations) with **Calificaciones** (trip-based ratings). The profile section had a header but no inline explanation of what references mean.

## Fix (frontend)

- **`ProfileRates.vue`**: Render a paragraph with `$t('referenciasDescripcion')` directly below the Referencias `<h2>`, before the write-reference action and list.
- **`i18n.js`**: Add `referenciasDescripcion` in Spanish (`arg`) and English (`en`):
  - ES: *"Las referencias son recomendaciones de la persona, no por un viaje en particular dentro de Carpoolear"*
  - EN: *"References are recommendations about the person, not about a specific trip within Carpoolear"*
- **`ProfileRates.view.test.js`**: TDD coverage for markup placement, i18n key, and copy.
- **Styling**: `referencias-section-description` class with bottom margin for spacing.
