### PR TITLE
DNI format

### DIFF
--- a/src/components/sections/IdentityValidation.vue
+++ b/src/components/sections/IdentityValidation.vue
@@ -463,7 +463,9 @@ export default {
             return this.$route.query.result || null;
         },
         mismatchDetails() {
-            return getIdentityValidationMismatchDetails(this.$route.query || {});
+            return getIdentityValidationMismatchDetails(this.$route.query || {}, {
+                profileIdFormat: this.config && this.config.profile_id_format
+            });
         },
         mismatchSupportWarningKey() {
             return getMismatchSupportWarningKey(this.resultMessage);

--- a/src/components/views/AdminManualIdentityValidationReview.vue
+++ b/src/components/views/AdminManualIdentityValidationReview.vue
@@ -19,7 +19,7 @@
                             :user-id="item.user_id"
                             :user-name="item.user_name"
                         />
-                        <p><strong>{{ $t('doc') }} (DNI):</strong> {{ item.user_nro_doc || '-' }}</p>
+                        <p><strong>{{ $t('doc') }} (DNI):</strong> {{ displayDniOrDash(item.user_nro_doc) }}</p>
                         <p><strong>{{ $t('fechaPago') }}:</strong> {{ item.paid_at ? formatDate(item.paid_at) : '-' }}</p>
                         <p><strong>{{ $t('fechaEnvio') }}:</strong> {{ item.submitted_at ? formatDate(item.submitted_at) : '-' }}</p>
                         <p><strong>{{ $t('pagado') }}:</strong> {{ item.paid ? $t('si') : $t('no') }}</p>
@@ -182,8 +182,10 @@ import AdminLayout from '../layouts/AdminLayout.vue';
 import AdminReviewSubjectUserLine from '../AdminReviewSubjectUserLine.vue';
 import AdminUserSupportTicketsWarning from '../AdminUserSupportTicketsWarning.vue';
 import { AdminApi } from '../../services/api';
+import { mapState } from 'pinia';
 import { useAuthStore } from '../../stores/auth';
 import dialogs from '../../services/dialogs.js';
+import { displayDniOrDash as formatDisplayDniOrDash } from '../../utils/formatDisplayDni';
 
 export default {
     name: 'AdminManualIdentityValidationReview',
@@ -208,11 +210,21 @@ export default {
         };
     },
     computed: {
+        ...mapState(useAuthStore, {
+            config: 'appConfig'
+        }),
         hasComment() {
             return this.reviewNote && this.reviewNote.trim() !== '';
         }
     },
     methods: {
+        displayDniOrDash(value) {
+            return formatDisplayDniOrDash(
+                value,
+                this.config && this.config.profile_id_format,
+                '-'
+            );
+        },
         formatDate(value) {
             if (!value) return '-';
             return new Date(value).toLocaleString();

--- a/src/components/views/AdminMpRejectedValidationDetail.vue
+++ b/src/components/views/AdminMpRejectedValidationDetail.vue
@@ -37,7 +37,7 @@
                             :user-id="item.user_id"
                             :user-name="item.user_name"
                         />
-                        <p><strong>{{ $t('doc') }}:</strong> {{ item.user_nro_doc || '-' }}</p>
+                        <p><strong>{{ $t('doc') }}:</strong> {{ displayDniOrDash(item.user_nro_doc) }}</p>
                         <p><strong>{{ $t('email') }}:</strong> {{ item.user_email || '-' }}</p>
                         <AdminUserSupportTicketsWarning
                             v-if="item.user_id"
@@ -121,11 +121,14 @@
 </template>
 
 <script>
+import { mapState } from 'pinia';
 import AdminLayout from '../layouts/AdminLayout.vue';
 import AdminReviewSubjectUserLine from '../AdminReviewSubjectUserLine.vue';
 import AdminUserSupportTicketsWarning from '../AdminUserSupportTicketsWarning.vue';
+import { useAuthStore } from '../../stores/auth';
 import { AdminApi } from '../../services/api';
 import dialogs from '../../services/dialogs.js';
+import { displayDniOrDash as formatDisplayDniOrDash } from '../../utils/formatDisplayDni';
 
 export default {
     name: 'AdminMpRejectedValidationDetail',
@@ -147,6 +150,9 @@ export default {
         };
     },
     computed: {
+        ...mapState(useAuthStore, {
+            config: 'appConfig'
+        }),
         hasComment() {
             return this.reviewNote && this.reviewNote.trim() !== '';
         },
@@ -160,6 +166,13 @@ export default {
         }
     },
     methods: {
+        displayDniOrDash(value) {
+            return formatDisplayDniOrDash(
+                value,
+                this.config && this.config.profile_id_format,
+                '-'
+            );
+        },
         formatDate(value) {
             if (!value) return '-';
             return new Date(value).toLocaleString();

--- a/src/components/views/AdminMpRejectedValidations.vue
+++ b/src/components/views/AdminMpRejectedValidations.vue
@@ -22,7 +22,7 @@
                                 <th scope="row">{{ item.id }}</th>
                                 <td>{{ item.user_id }}</td>
                                 <td>{{ item.user_name || $t('na') }}</td>
-                                <td>{{ item.user_nro_doc || '-' }}</td>
+                                <td>{{ displayDniOrDash(item.user_nro_doc) }}</td>
                                 <td>
                                     <span :class="item.user_identity_validated ? 'label label-success' : 'label label-default'">
                                         {{ item.user_identity_validated ? $t('identidadValidada') : $t('identidadNoValidada') }}
@@ -62,19 +62,34 @@
 </template>
 
 <script>
+import { mapState } from 'pinia';
 import AdminLayout from '../layouts/AdminLayout.vue';
 import Loading from '../Loading';
+import { useAuthStore } from '../../stores/auth';
 import { AdminApi } from '../../services/api';
 import { getAdminUserProfileRoute } from '../../utils/adminProfileRoute';
+import { displayDniOrDash as formatDisplayDniOrDash } from '../../utils/formatDisplayDni';
 
 export default {
     name: 'AdminMpRejectedValidations',
+    computed: {
+        ...mapState(useAuthStore, {
+            config: 'appConfig'
+        })
+    },
     data() {
         return {
             list: null
         };
     },
     methods: {
+        displayDniOrDash(value) {
+            return formatDisplayDniOrDash(
+                value,
+                this.config && this.config.profile_id_format,
+                '-'
+            );
+        },
         getAdminUserProfileRoute,
         formatDate(value) {
             if (!value) return '-';

--- a/src/components/views/AdminUserDetail.view.test.js
+++ b/src/components/views/AdminUserDetail.view.test.js
@@ -54,6 +54,10 @@ describe('AdminUserDetail view', () => {
         expect(source).toContain("'alert-' + bannedBanner.modifier");
     });
 
+    it('passes profile_id_format when building admin user property rows', () => {
+        expect(source).toContain('profileIdFormat: this.config && this.config.profile_id_format');
+    });
+
     it('renders all user properties from the admin profile payload', () => {
         expect(source).toContain('buildAdminUserPropertyRows');
         expect(source).toContain('admin-user-detail__properties');

--- a/src/components/views/AdminUserDetail.vue
+++ b/src/components/views/AdminUserDetail.vue
@@ -171,6 +171,7 @@ export default {
         propertyRows() {
             return buildAdminUserPropertyRows(this.user, {
                 translate: this.$t.bind(this),
+                profileIdFormat: this.config && this.config.profile_id_format,
                 showFacebookProfileUrl: !!(
                     this.config && this.config.module_facebook_profile_url_enabled
                 )

--- a/src/components/views/AdminUserMigrationNew.view.test.js
+++ b/src/components/views/AdminUserMigrationNew.view.test.js
@@ -27,6 +27,11 @@ describe('AdminUserMigrationNew view', () => {
         expect(source).toMatch(/\.user-migration-card__avatar\s*\{[^}]*height:\s*100px/);
     });
 
+    it('formats DNI in the migration field comparison table', () => {
+        expect(source).toContain('formatMigrationFieldValue');
+        expect(source).toContain('profile_id_format');
+    });
+
     it('renders the user email and a friendly join date in the field comparison table', () => {
         expect(source).toContain('field.labelKey');
         expect(source).toContain('formatJoinDate');

--- a/src/components/views/AdminUserMigrationNew.vue
+++ b/src/components/views/AdminUserMigrationNew.vue
@@ -143,9 +143,12 @@ import UserSearchAutocomplete from '../UserSearchAutocomplete.vue';
 import { AdminApi } from '../../services/api';
 import dialogs from '../../services/dialogs.js';
 import dayjs from '../../dayjs';
+import { mapState } from 'pinia';
+import { useAuthStore } from '../../stores/auth';
 import {
     DEFAULT_FIELD_SOURCES,
     createDefaultFieldSources,
+    formatMigrationFieldValue,
     migrationFields
 } from '../../utils/userMigrationFields.js';
 
@@ -162,6 +165,9 @@ export default {
         };
     },
     computed: {
+        ...mapState(useAuthStore, {
+            config: 'appConfig'
+        }),
         previewReady() {
             return (
                 this.userToRemove &&
@@ -243,6 +249,11 @@ export default {
             }
             if (fieldKey === 'created_at') {
                 return this.formatJoinDate(user.created_at);
+            }
+            if (fieldKey === 'nro_doc') {
+                return formatMigrationFieldValue(fieldKey, user, {
+                    profileIdFormat: this.config && this.config.profile_id_format
+                });
             }
             const value = user[fieldKey];
             return value ? String(value) : '—';

--- a/src/components/views/AdminUsersList.view.test.js
+++ b/src/components/views/AdminUsersList.view.test.js
@@ -11,10 +11,11 @@ describe('AdminUsersList view', () => {
         expect(viewSource).toContain("{{ $t('numeroDeTelefono') }}");
     });
 
-    it('renders DNI and phone values for each user row', () => {
-        expect(viewSource).toContain('{{ displayOrDash(u.nro_doc) }}');
+    it('renders formatted DNI and phone values for each user row', () => {
+        expect(viewSource).toContain('{{ displayDniOrDash(u.nro_doc) }}');
         expect(viewSource).toContain('{{ displayOrDash(u.mobile_phone) }}');
-        expect(viewSource).toContain('displayOrDash(value)');
+        expect(viewSource).toContain('displayDniOrDash(value)');
+        expect(viewSource).toContain('profile_id_format');
     });
 
     it('syncs search, page and sorting in route query for back navigation persistence', () => {

--- a/src/components/views/AdminUsersList.vue
+++ b/src/components/views/AdminUsersList.vue
@@ -94,7 +94,7 @@
                                         </router-link>
                                     </td>
                                     <td>{{ displayOrDash(u.email) }}</td>
-                                    <td>{{ displayOrDash(u.nro_doc) }}</td>
+                                    <td>{{ displayDniOrDash(u.nro_doc) }}</td>
                                     <td>{{ displayOrDash(u.mobile_phone) }}</td>
                                     <td>{{ displayOrDash(u.last_connection) }}</td>
                                 </tr>
@@ -143,14 +143,22 @@
 </template>
 
 <script>
+import { mapState } from 'pinia';
 import AdminLayout from '../layouts/AdminLayout.vue';
+import { useAuthStore } from '../../stores/auth';
 import { AdminApi } from '../../services/api';
 import dialogs from '../../services/dialogs.js';
+import { displayDniOrDash as formatDisplayDniOrDash } from '../../utils/formatDisplayDni';
 
 const DEFAULT_SORT = { key: 'id', dir: 'desc' };
 
 export default {
     name: 'admin-users-list',
+    computed: {
+        ...mapState(useAuthStore, {
+            config: 'appConfig'
+        })
+    },
     data() {
         return {
             textSearch: '',
@@ -167,6 +175,12 @@ export default {
     methods: {
         displayOrDash(value) {
             return value === null || value === undefined || value === '' ? '—' : value;
+        },
+        displayDniOrDash(value) {
+            return formatDisplayDniOrDash(
+                value,
+                this.config && this.config.profile_id_format
+            );
         },
         normalizedSearchQuery() {
             return (this.textSearch && this.textSearch.trim()) || '';

--- a/src/components/views/BannedUsersList.vue
+++ b/src/components/views/BannedUsersList.vue
@@ -23,7 +23,7 @@
                             >
                                 <th scope="row">{{ item.id }}</th>
                                 <td>{{ item.user ? item.user.name : $t('usuarioAnonimo') }}</td>
-                                <td>{{ item.nro_doc || '-' }}</td>
+                                <td>{{ displayDniOrDash(item.nro_doc) }}</td>
                                 <td>{{ formatDate(item.banned_at) }}</td>
                                 <td>{{ getBannedByLabel(item.banned_by) }}</td>
                                 <td>{{ item.note || '-' }}</td>
@@ -49,14 +49,22 @@
     </AdminLayout>
 </template>
 <script>
+import { mapState } from 'pinia';
 import AdminLayout from '../layouts/AdminLayout.vue';
 import Loading from '../Loading.vue';
+import { useAuthStore } from '../../stores/auth';
 import { AdminApi } from '../../services/api';
 import dialogs from '../../services/dialogs.js';
 import dayjs from '../../dayjs';
+import { displayDniOrDash as formatDisplayDniOrDash } from '../../utils/formatDisplayDni';
 
 export default {
     name: 'admin-banned-users-list',
+    computed: {
+        ...mapState(useAuthStore, {
+            config: 'appConfig'
+        })
+    },
     data() {
         return {
             bannedUsers: null,
@@ -65,6 +73,13 @@ export default {
         };
     },
     methods: {
+        displayDniOrDash(value) {
+            return formatDisplayDniOrDash(
+                value,
+                this.config && this.config.profile_id_format,
+                '-'
+            );
+        },
         formatDate(dateString) {
             if (!dateString) return '-';
             return dayjs(dateString).format('DD/MM/YYYY HH:mm');

--- a/src/utils/adminUserDetailProperties.js
+++ b/src/utils/adminUserDetailProperties.js
@@ -1,3 +1,5 @@
+import { formatDisplayDni } from './formatDisplayDni';
+
 const EMPTY_VALUE = '—';
 
 const ADMIN_USER_PROPERTY_DEFINITIONS = [
@@ -9,7 +11,7 @@ const ADMIN_USER_PROPERTY_DEFINITIONS = [
     { key: 'mobile_phone', labelKey: 'numeroDeTelefono' },
     { key: 'phone_verified', labelKey: 'phone_verified', type: 'boolean' },
     { key: 'phone_verified_at', labelKey: 'phone_verified_at' },
-    { key: 'nro_doc', labelKey: 'doc' },
+    { key: 'nro_doc', labelKey: 'doc', type: 'dni' },
     { key: 'is_admin', labelKey: 'is_admin', type: 'boolean' },
     { key: 'is_member', labelKey: 'is_member', type: 'boolean' },
     { key: 'has_pin', labelKey: 'has_pin', type: 'boolean' },
@@ -82,7 +84,12 @@ function isUserBanned(user) {
     return isTruthyFlag(user?.banned);
 }
 
-export function formatAdminUserPropertyValue(value, type = 'text') {
+export function formatAdminUserPropertyValue(value, type = 'text', options = {}) {
+    if (type === 'dni') {
+        const formatted = formatDisplayDni(value, options.profileIdFormat);
+        return formatted === null ? EMPTY_VALUE : formatted;
+    }
+
     if (type === 'boolean') {
         if (value === null || value === undefined || value === '') {
             return EMPTY_VALUE;
@@ -130,7 +137,7 @@ export function getAdminUserBannedBanner(user, translate) {
 
 export function buildAdminUserPropertyRows(
     user,
-    { translate, showFacebookProfileUrl = true }
+    { translate, showFacebookProfileUrl = true, profileIdFormat = null }
 ) {
     if (!user) {
         return [];
@@ -141,7 +148,8 @@ export function buildAdminUserPropertyRows(
         label: resolvePropertyLabel(definition, translate),
         value: formatAdminUserPropertyValue(
             user[definition.key],
-            definition.type || 'text'
+            definition.type || 'text',
+            { profileIdFormat }
         )
     }));
 

--- a/src/utils/adminUserDetailProperties.test.js
+++ b/src/utils/adminUserDetailProperties.test.js
@@ -51,7 +51,10 @@ describe('buildAdminUserPropertyRows', () => {
     };
 
     it('returns ordered rows with labels and formatted values', () => {
-        const rows = buildAdminUserPropertyRows(sampleUser, { translate });
+        const rows = buildAdminUserPropertyRows(sampleUser, {
+            translate,
+            profileIdFormat: '##.###.###'
+        });
 
         expect(rows.length).toBeGreaterThan(10);
         expect(rows[0]).toEqual({ key: 'id', label: 'ID', value: '42' });
@@ -59,6 +62,11 @@ describe('buildAdminUserPropertyRows', () => {
             key: 'email',
             label: 'Email',
             value: 'jane@example.test'
+        });
+        expect(rows.find((row) => row.key === 'nro_doc')).toEqual({
+            key: 'nro_doc',
+            label: 'DNI',
+            value: '30.123.456'
         });
         expect(rows.find((row) => row.key === 'banned')).toEqual({
             key: 'banned',
@@ -93,7 +101,10 @@ describe('buildAdminUserPropertyRows', () => {
     });
 
     it('places banned before other properties in row order', () => {
-        const rows = buildAdminUserPropertyRows(sampleUser, { translate });
+        const rows = buildAdminUserPropertyRows(sampleUser, {
+            translate,
+            profileIdFormat: '##.###.###'
+        });
         const bannedIndex = rows.findIndex((row) => row.key === 'banned');
         const emailIndex = rows.findIndex((row) => row.key === 'email');
 

--- a/src/utils/formatDisplayDni.js
+++ b/src/utils/formatDisplayDni.js
@@ -1,0 +1,18 @@
+import { formatId } from '../services/utility';
+
+export function formatDisplayDni(value, profileIdFormat) {
+    if (value === null || value === undefined || String(value).trim() === '') {
+        return null;
+    }
+
+    if (!profileIdFormat) {
+        return String(value);
+    }
+
+    return formatId(value, profileIdFormat);
+}
+
+export function displayDniOrDash(value, profileIdFormat, dash = '—') {
+    const formatted = formatDisplayDni(value, profileIdFormat);
+    return formatted === null ? dash : formatted;
+}

--- a/src/utils/formatDisplayDni.test.js
+++ b/src/utils/formatDisplayDni.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { displayDniOrDash, formatDisplayDni } from './formatDisplayDni';
+
+const DNI_FORMAT = '##.###.###';
+
+describe('formatDisplayDni', () => {
+    it('formats raw DNI using profile_id_format pattern', () => {
+        expect(formatDisplayDni('30123456', DNI_FORMAT)).toBe('30.123.456');
+    });
+
+    it('returns null for empty values', () => {
+        expect(formatDisplayDni(null, DNI_FORMAT)).toBeNull();
+        expect(formatDisplayDni('', DNI_FORMAT)).toBeNull();
+        expect(formatDisplayDni('   ', DNI_FORMAT)).toBeNull();
+    });
+
+    it('returns value as string when pattern is missing', () => {
+        expect(formatDisplayDni('30123456', null)).toBe('30123456');
+    });
+});
+
+describe('displayDniOrDash', () => {
+    it('returns formatted DNI for display', () => {
+        expect(displayDniOrDash('30123456', DNI_FORMAT)).toBe('30.123.456');
+    });
+
+    it('returns em dash for empty values', () => {
+        expect(displayDniOrDash(null, DNI_FORMAT)).toBe('—');
+        expect(displayDniOrDash('', DNI_FORMAT)).toBe('—');
+    });
+});

--- a/src/utils/identityValidationMismatchDetails.js
+++ b/src/utils/identityValidationMismatchDetails.js
@@ -1,8 +1,20 @@
+import { formatDisplayDni } from './formatDisplayDni';
+
 export const MISMATCH_RESULT_DNI = 'dni_mismatch';
 export const MISMATCH_RESULT_NAME = 'name_mismatch';
 export const MISMATCH_RESULT_BOTH = 'both_mismatch';
 
-export function getIdentityValidationMismatchDetails(query) {
+function formatMismatchDni(value, profileIdFormat) {
+    if (!value) {
+        return '-';
+    }
+
+    const formatted = formatDisplayDni(value, profileIdFormat);
+    return formatted === null ? '-' : formatted;
+}
+
+export function getIdentityValidationMismatchDetails(query, options = {}) {
+    const { profileIdFormat = null } = options;
     const result = query && query.result;
     if (
         result !== MISMATCH_RESULT_DNI &&
@@ -27,8 +39,8 @@ export function getIdentityValidationMismatchDetails(query) {
         showDni,
         userName: showName ? (query.user_name || '-') : null,
         mpName: showName ? (query.mp_name || '-') : null,
-        userDni: showDni ? (query.user_dni || '-') : null,
-        mpDni: showDni ? (query.mp_dni || '-') : null
+        userDni: showDni ? formatMismatchDni(query.user_dni, profileIdFormat) : null,
+        mpDni: showDni ? formatMismatchDni(query.mp_dni, profileIdFormat) : null
     };
 }
 

--- a/src/utils/identityValidationMismatchDetails.test.js
+++ b/src/utils/identityValidationMismatchDetails.test.js
@@ -8,21 +8,24 @@ import {
 
 describe('getIdentityValidationMismatchDetails', () => {
     it('returns both name and dni comparison details for both_mismatch', () => {
-        const details = getIdentityValidationMismatchDetails({
-            result: 'both_mismatch',
-            user_name: 'Jane Doe',
-            mp_name: 'Other Person',
-            user_dni: '30123456',
-            mp_dni: '30999999'
-        });
+        const details = getIdentityValidationMismatchDetails(
+            {
+                result: 'both_mismatch',
+                user_name: 'Jane Doe',
+                mp_name: 'Other Person',
+                user_dni: '30123456',
+                mp_dni: '30999999'
+            },
+            { profileIdFormat: '##.###.###' }
+        );
 
         expect(details.reasonKey).toBe('resultBothMismatch');
         expect(details.showName).toBe(true);
         expect(details.showDni).toBe(true);
         expect(details.userName).toBe('Jane Doe');
         expect(details.mpName).toBe('Other Person');
-        expect(details.userDni).toBe('30123456');
-        expect(details.mpDni).toBe('30999999');
+        expect(details.userDni).toBe('30.123.456');
+        expect(details.mpDni).toBe('30.999.999');
     });
 
     it('exports both mismatch result constant', () => {

--- a/src/utils/userMigrationFields.js
+++ b/src/utils/userMigrationFields.js
@@ -1,3 +1,7 @@
+import { displayDniOrDash } from './formatDisplayDni';
+
+const EMPTY_VALUE = '—';
+
 export const DEFAULT_FIELD_SOURCES = {
     email: 'removed',
     password: 'kept',
@@ -16,4 +20,17 @@ export const migrationFields = [
 
 export function createDefaultFieldSources() {
     return { ...DEFAULT_FIELD_SOURCES };
+}
+
+export function formatMigrationFieldValue(fieldKey, user, options = {}) {
+    if (!user) {
+        return EMPTY_VALUE;
+    }
+
+    if (fieldKey === 'nro_doc') {
+        return displayDniOrDash(user.nro_doc, options.profileIdFormat, EMPTY_VALUE);
+    }
+
+    const value = user[fieldKey];
+    return value ? String(value) : EMPTY_VALUE;
 }

--- a/src/utils/userMigrationFields.test.js
+++ b/src/utils/userMigrationFields.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
     DEFAULT_FIELD_SOURCES,
     createDefaultFieldSources,
+    formatMigrationFieldValue,
     migrationFields
 } from './userMigrationFields.js';
 
@@ -28,5 +29,20 @@ describe('userMigrationFields', () => {
         const first = createDefaultFieldSources();
         first.email = 'kept';
         expect(createDefaultFieldSources().email).toBe('removed');
+    });
+});
+
+describe('formatMigrationFieldValue', () => {
+    it('formats nro_doc using profile_id_format for display', () => {
+        expect(
+            formatMigrationFieldValue('nro_doc', { nro_doc: '30123456' }, {
+                profileIdFormat: '##.###.###'
+            })
+        ).toBe('30.123.456');
+    });
+
+    it('returns em dash when user or value is missing', () => {
+        expect(formatMigrationFieldValue('nro_doc', null, {})).toBe('—');
+        expect(formatMigrationFieldValue('email', { email: '' }, {})).toBe('—');
     });
 });


### PR DESCRIPTION
## Summary

Format DNI with dots everywhere it is shown read-only, using `profile_id_format` from config (`##.###.###`).

### Cause
DNI was stored and transmitted without separators (e.g. `30123456`). Admin screens and some public views rendered the raw value, while profile edit and public profile already used `formatId` for display.

### Frontend fix
- Added `formatDisplayDni` / `displayDniOrDash` utilities for read-only DNI display.
- Wired formatting into admin user detail, users list, banned users list, MP rejected validations, manual identity validation review, user migration comparison, and identity validation mismatch UI.
- Identity validation mismatch details now format both Carpoolear and Mercado Pago DNIs when shown after OAuth rejection.

## Test plan
- [x] Frontend unit tests (785)
- [x] Frontend ESLint
- [x] Backend PHPUnit (3204, unchanged)
- [x] Manual: open admin user detail / users list — DNI shows as `30.123.456`
- [x] Manual: trigger identity validation DNI mismatch — both DNIs show with dots
- [x] Manual: public profile still shows formatted DNI