### PR TITLE
Migrate warning

### DIFF
--- a/src/components/views/AdminUserMigrationNew.view.test.js
+++ b/src/components/views/AdminUserMigrationNew.view.test.js
@@ -3,7 +3,14 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const viewPath = path.resolve(__dirname, 'AdminUserMigrationNew.vue');
+const i18nPath = path.resolve(__dirname, '../../language/i18n.js');
 const source = fs.readFileSync(viewPath, 'utf8');
+const i18nSource = fs.readFileSync(i18nPath, 'utf8');
+const supportTicketNoticeKey = 'migracionUsuarioAMantenerAvisoTicketSoporte';
+const supportTicketNoticeCopy =
+    'Si el usuario envió ticket de soporte, la cuenta a mantener debe ser la que envió el ticket';
+const supportTicketNoticeEnglishCopy =
+    'If the user submitted a support ticket, the account to keep must be the one that submitted the ticket';
 
 describe('AdminUserMigrationNew view', () => {
     it('uses two UserSearchAutocomplete and confirm before createUserMigration', () => {
@@ -70,5 +77,38 @@ describe('AdminUserMigrationNew view', () => {
     it('highlights the selected field source cell in the comparison table', () => {
         expect(source).toContain('admin-user-migration-new__field-cell--selected');
         expect(source).toContain('isFieldSourceSelected');
+    });
+
+    it('shows the support ticket notice next to Usuario a mantener', () => {
+        const keepLabelIndex = source.indexOf("$t('usuarioAMantener')");
+        const noticeIndex = source.indexOf(`$t('${supportTicketNoticeKey}')`);
+
+        expect(keepLabelIndex).toBeGreaterThan(-1);
+        expect(noticeIndex).toBeGreaterThan(keepLabelIndex);
+        expect(source).toContain('admin-user-migration-new__support-ticket-notice');
+    });
+
+    it('shows the support ticket notice below the keep user preview heading', () => {
+        const keepHeadingIndex = source.indexOf('yLosVasAJuntarConLosDeEsteUsuario');
+        const keepRoleNoticeIndex = source.indexOf("card.role === 'keep'");
+
+        expect(keepHeadingIndex).toBeGreaterThan(-1);
+        expect(keepRoleNoticeIndex).toBeGreaterThan(-1);
+        expect(source).toContain(`$t('${supportTicketNoticeKey}')`);
+    });
+
+    it('styles the support ticket notice as red bold text', () => {
+        expect(source).toMatch(
+            /\.admin-user-migration-new__support-ticket-notice\s*\{[^}]*color:\s*[^;]+/
+        );
+        expect(source).toMatch(
+            /\.admin-user-migration-new__support-ticket-notice\s*\{[^}]*font-weight:\s*(700|bold)/
+        );
+    });
+
+    it('keeps the support ticket notice copy in i18n', () => {
+        expect(i18nSource).toContain(supportTicketNoticeKey);
+        expect(i18nSource).toContain(supportTicketNoticeCopy);
+        expect(i18nSource).toContain(supportTicketNoticeEnglishCopy);
     });
 });

--- a/src/components/views/AdminUserMigrationNew.view.test.js
+++ b/src/components/views/AdminUserMigrationNew.view.test.js
@@ -81,7 +81,7 @@ describe('AdminUserMigrationNew view', () => {
 
     it('shows the support ticket notice next to Usuario a mantener', () => {
         const keepLabelIndex = source.indexOf("$t('usuarioAMantener')");
-        const noticeIndex = source.indexOf(`$t('${supportTicketNoticeKey}')`);
+        const noticeIndex = source.indexOf('supportTicketNoticeText');
 
         expect(keepLabelIndex).toBeGreaterThan(-1);
         expect(noticeIndex).toBeGreaterThan(keepLabelIndex);
@@ -94,7 +94,7 @@ describe('AdminUserMigrationNew view', () => {
 
         expect(keepHeadingIndex).toBeGreaterThan(-1);
         expect(keepRoleNoticeIndex).toBeGreaterThan(-1);
-        expect(source).toContain(`$t('${supportTicketNoticeKey}')`);
+        expect(source).toContain('supportTicketNoticeText');
     });
 
     it('styles the support ticket notice as red bold text', () => {
@@ -104,11 +104,14 @@ describe('AdminUserMigrationNew view', () => {
         expect(source).toMatch(
             /\.admin-user-migration-new__support-ticket-notice\s*\{[^}]*font-weight:\s*(700|bold)/
         );
+        expect(source).toMatch(/label \.admin-user-migration-new__support-ticket-notice\s*\{/);
+        expect(source).toMatch(/p\.admin-user-migration-new__support-ticket-notice\s*\{/);
     });
 
     it('keeps the support ticket notice copy in i18n', () => {
         expect(i18nSource).toContain(supportTicketNoticeKey);
         expect(i18nSource).toContain(supportTicketNoticeCopy);
         expect(i18nSource).toContain(supportTicketNoticeEnglishCopy);
+        expect(source).toContain("this.$t('migracionUsuarioAMantenerAvisoTicketSoporte')");
     });
 });

--- a/src/components/views/AdminUserMigrationNew.vue
+++ b/src/components/views/AdminUserMigrationNew.vue
@@ -428,7 +428,7 @@ export default {
 }
 
 .admin-user-migration-new__support-ticket-notice {
-    color: #c0392b;
+    color: #ff0000;
     font-weight: 700;
 }
 

--- a/src/components/views/AdminUserMigrationNew.vue
+++ b/src/components/views/AdminUserMigrationNew.vue
@@ -25,7 +25,7 @@
                         <label>
                             {{ $t('usuarioAMantener') }}
                             <span class="admin-user-migration-new__support-ticket-notice">
-                                {{ $t('migracionUsuarioAMantenerAvisoTicketSoporte') }}
+                                {{ supportTicketNoticeText }}
                             </span>
                         </label>
                         <UserSearchAutocomplete
@@ -46,7 +46,7 @@
                                     v-if="card.role === 'keep'"
                                     class="admin-user-migration-new__support-ticket-notice"
                                 >
-                                    {{ $t('migracionUsuarioAMantenerAvisoTicketSoporte') }}
+                                    {{ supportTicketNoticeText }}
                                 </p>
                                 <div class="media user-migration-card">
                                     <div
@@ -198,6 +198,9 @@ export default {
                     user: this.userToKeep
                 }
             ];
+        },
+        supportTicketNoticeText() {
+            return this.$t('migracionUsuarioAMantenerAvisoTicketSoporte');
         }
     },
     methods: {
@@ -427,5 +430,14 @@ export default {
 .admin-user-migration-new__support-ticket-notice {
     color: #c0392b;
     font-weight: 700;
+}
+
+label .admin-user-migration-new__support-ticket-notice {
+    margin-left: 0.5em;
+}
+
+p.admin-user-migration-new__support-ticket-notice {
+    margin-top: -6px;
+    margin-bottom: 12px;
 }
 </style>

--- a/src/components/views/AdminUserMigrationNew.vue
+++ b/src/components/views/AdminUserMigrationNew.vue
@@ -22,7 +22,12 @@
                         />
                     </div>
                     <div class="form-group">
-                        <label>{{ $t('usuarioAMantener') }}</label>
+                        <label>
+                            {{ $t('usuarioAMantener') }}
+                            <span class="admin-user-migration-new__support-ticket-notice">
+                                {{ $t('migracionUsuarioAMantenerAvisoTicketSoporte') }}
+                            </span>
+                        </label>
                         <UserSearchAutocomplete
                             v-model="userToKeep"
                             :placeholder="$t('escribeUnNombreYPresionaBuscar')"
@@ -37,6 +42,12 @@
                         <div class="panel-body">
                             <template v-for="card in previewCards" :key="card.role">
                                 <p class="lead">{{ $t(card.headingKey) }}</p>
+                                <p
+                                    v-if="card.role === 'keep'"
+                                    class="admin-user-migration-new__support-ticket-notice"
+                                >
+                                    {{ $t('migracionUsuarioAMantenerAvisoTicketSoporte') }}
+                                </p>
                                 <div class="media user-migration-card">
                                     <div
                                         v-if="hasUserImage(card.user)"
@@ -411,5 +422,10 @@ export default {
 
 .admin-user-migration-new__submit {
     margin-top: 24px;
+}
+
+.admin-user-migration-new__support-ticket-notice {
+    color: #c0392b;
+    font-weight: 700;
 }
 </style>

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -1320,6 +1320,8 @@ const messages = {
         migrarUsuariosVolverAlListado: 'Volver al listado de migraciones',
         nuevaMigracionDeUsuario: 'Nueva migración de usuario',
         usuarioAMantener: 'Usuario a mantener',
+        migracionUsuarioAMantenerAvisoTicketSoporte:
+            'Si el usuario envió ticket de soporte, la cuenta a mantener debe ser la que envió el ticket',
         usuarioABorrar: 'Usuario a borrar',
         vasAMigrarLosDatosDeEsteUsuario:
             'Vas a pasar los datos de este usuario:',
@@ -2640,6 +2642,8 @@ const messages = {
         migrarUsuariosVolverAlListado: 'Volver al listado de migraciones',
         nuevaMigracionDeUsuario: 'Nueva migración de usuario',
         usuarioAMantener: 'Usuario a mantener',
+        migracionUsuarioAMantenerAvisoTicketSoporte:
+            'Si el usuario envió ticket de soporte, la cuenta a mantener debe ser la que envió el ticket',
         usuarioABorrar: 'Usuario a borrar',
         vasAMigrarLosDatosDeEsteUsuario:
             'Vas a pasar los datos de este usuario:',
@@ -4090,6 +4094,8 @@ const messages = {
         migrarUsuariosVolverAlListado: 'Back to migration list',
         nuevaMigracionDeUsuario: 'New user migration',
         usuarioAMantener: 'User to keep',
+        migracionUsuarioAMantenerAvisoTicketSoporte:
+            'If the user submitted a support ticket, the account to keep must be the one that submitted the ticket',
         usuarioABorrar: 'User to remove',
         vasAMigrarLosDatosDeEsteUsuario:
             'You are about to move this user’s data:',


### PR DESCRIPTION
## Summary

Adds a visible support-ticket warning on the admin user migration page so admins choose the correct account to keep when a user has contacted support.

## Cause

When merging duplicate accounts, admins could pick the wrong “Usuario a mantener” if they did not know that the account that opened the support ticket must be the one kept.

## Fix (Frontend)

- Added i18n key `migracionUsuarioAMantenerAvisoTicketSoporte` (ES/EN) with the message: *“Si el usuario envió ticket de soporte, la cuenta a mantener debe ser la que envió el ticket”*
- Show the notice in **red bold** next to the “Usuario a mantener” field label
- Show the same notice below “A este otro usuario:” in the migration preview
- Covered with view tests in `AdminUserMigrationNew.view.test.js` (TDD: red → green → refactor)

## Test plan

- [ ] Open `/admin/user-migrations/new`
- [ ] Confirm red bold notice appears next to “Usuario a mantener”
- [ ] Select two different users and confirm the same notice appears below “A este otro usuario:”
- [ ] Switch locale to English and confirm translated notice text
- [ ] `npm run lint` and `npm run test:unit -- --run src/components/views/AdminUserMigrationNew.view.test.js`