### PR TITLE
Count request fix

### DIFF
--- a/src/classes/Threads.js
+++ b/src/classes/Threads.js
@@ -59,7 +59,7 @@ export function stopThreads(tags) {
         const list = taggedList.get(tag);
         if (list) {
             list.forEach((thread) => {
-                clearTimeout(thread.id);
+                clearInterval(thread.id);
             });
         }
     });

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -24,7 +24,7 @@ router.beforeEach((to, from, next) => {
     const backgroundStore = useBackgroundStore();
     const notificationsStore = useNotificationsStore();
 
-    refreshNotificationsCountOnRouteChange(authStore, notificationsStore);
+    refreshNotificationsCountOnRouteChange(authStore, notificationsStore, to, from);
 
     const actionbar = to.meta.actionbar || {};
     const background = to.meta.background || {};

--- a/src/router/refreshNotificationsCountOnRouteChange.js
+++ b/src/router/refreshNotificationsCountOnRouteChange.js
@@ -1,5 +1,15 @@
-export function refreshNotificationsCountOnRouteChange(authStore, notificationsStore) {
-    if (authStore.checkLogin) {
+import { shouldRefreshNotificationsCountOnRoute } from './shouldRefreshNotificationsCountOnRoute.js';
+
+export function refreshNotificationsCountOnRouteChange(
+    authStore,
+    notificationsStore,
+    to,
+    from
+) {
+    if (
+        authStore.checkLogin &&
+        shouldRefreshNotificationsCountOnRoute(to, from)
+    ) {
         notificationsStore.countAction();
     }
 }

--- a/src/router/refreshNotificationsCountOnRouteChange.test.js
+++ b/src/router/refreshNotificationsCountOnRouteChange.test.js
@@ -1,15 +1,18 @@
 import { describe, expect, it, vi } from 'vitest';
-import fs from 'node:fs';
-import path from 'node:path';
 import { refreshNotificationsCountOnRouteChange } from './refreshNotificationsCountOnRouteChange.js';
 
 describe('refreshNotificationsCountOnRouteChange', () => {
-    it('refreshes notification count when user is logged in', () => {
+    it('refreshes notification count when user is logged in and route name changes', () => {
         const countAction = vi.fn();
         const authStore = { checkLogin: true };
         const notificationsStore = { countAction };
 
-        refreshNotificationsCountOnRouteChange(authStore, notificationsStore);
+        refreshNotificationsCountOnRouteChange(
+            authStore,
+            notificationsStore,
+            { name: 'notifications', params: {}, query: {} },
+            { name: 'trips', params: {}, query: {} }
+        );
 
         expect(countAction).toHaveBeenCalledTimes(1);
     });
@@ -19,7 +22,27 @@ describe('refreshNotificationsCountOnRouteChange', () => {
         const authStore = { checkLogin: false };
         const notificationsStore = { countAction };
 
-        refreshNotificationsCountOnRouteChange(authStore, notificationsStore);
+        refreshNotificationsCountOnRouteChange(
+            authStore,
+            notificationsStore,
+            { name: 'notifications', params: {}, query: {} },
+            { name: 'trips', params: {}, query: {} }
+        );
+
+        expect(countAction).not.toHaveBeenCalled();
+    });
+
+    it('skips refresh when only query params change on the same route', () => {
+        const countAction = vi.fn();
+        const authStore = { checkLogin: true };
+        const notificationsStore = { countAction };
+
+        refreshNotificationsCountOnRouteChange(
+            authStore,
+            notificationsStore,
+            { name: 'trips', params: {}, query: { scroll: '120' } },
+            { name: 'trips', params: {}, query: { scroll: '0' } }
+        );
 
         expect(countAction).not.toHaveBeenCalled();
     });
@@ -27,13 +50,15 @@ describe('refreshNotificationsCountOnRouteChange', () => {
 
 describe('router beforeEach integration', () => {
     it('refreshes notifications count on every route change', () => {
+        const fs = require('node:fs');
+        const path = require('node:path');
         const routerSource = fs.readFileSync(
             path.resolve(__dirname, 'index.js'),
             'utf8'
         );
 
         expect(routerSource).toContain(
-            'refreshNotificationsCountOnRouteChange(authStore, notificationsStore)'
+            'refreshNotificationsCountOnRouteChange(authStore, notificationsStore, to, from)'
         );
     });
 });

--- a/src/router/refreshNotificationsCountOnRouteChange.test.js
+++ b/src/router/refreshNotificationsCountOnRouteChange.test.js
@@ -1,4 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
 import { refreshNotificationsCountOnRouteChange } from './refreshNotificationsCountOnRouteChange.js';
 
 describe('refreshNotificationsCountOnRouteChange', () => {
@@ -49,9 +51,7 @@ describe('refreshNotificationsCountOnRouteChange', () => {
 });
 
 describe('router beforeEach integration', () => {
-    it('refreshes notifications count on every route change', () => {
-        const fs = require('node:fs');
-        const path = require('node:path');
+    it('passes route locations into refreshNotificationsCountOnRouteChange', () => {
         const routerSource = fs.readFileSync(
             path.resolve(__dirname, 'index.js'),
             'utf8'

--- a/src/router/shouldRefreshNotificationsCountOnRoute.js
+++ b/src/router/shouldRefreshNotificationsCountOnRoute.js
@@ -1,3 +1,7 @@
+function routeParamsChanged(to, from) {
+    return JSON.stringify(to.params || {}) !== JSON.stringify(from.params || {});
+}
+
 export function shouldRefreshNotificationsCountOnRoute(to, from) {
     if (!from || !from.name) {
         return true;
@@ -5,5 +9,5 @@ export function shouldRefreshNotificationsCountOnRoute(to, from) {
     if (to.name !== from.name) {
         return true;
     }
-    return JSON.stringify(to.params || {}) !== JSON.stringify(from.params || {});
+    return routeParamsChanged(to, from);
 }

--- a/src/router/shouldRefreshNotificationsCountOnRoute.js
+++ b/src/router/shouldRefreshNotificationsCountOnRoute.js
@@ -1,0 +1,9 @@
+export function shouldRefreshNotificationsCountOnRoute(to, from) {
+    if (!from || !from.name) {
+        return true;
+    }
+    if (to.name !== from.name) {
+        return true;
+    }
+    return JSON.stringify(to.params || {}) !== JSON.stringify(from.params || {});
+}

--- a/src/router/shouldRefreshNotificationsCountOnRoute.test.js
+++ b/src/router/shouldRefreshNotificationsCountOnRoute.test.js
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { shouldRefreshNotificationsCountOnRoute } from './shouldRefreshNotificationsCountOnRoute.js';
+
+describe('shouldRefreshNotificationsCountOnRoute', () => {
+    it('refreshes on initial navigation when from route has no name', () => {
+        expect(
+            shouldRefreshNotificationsCountOnRoute(
+                { name: 'trips', params: {}, query: {} },
+                { name: undefined, params: {}, query: {} }
+            )
+        ).toBe(true);
+    });
+
+    it('refreshes when route name changes', () => {
+        expect(
+            shouldRefreshNotificationsCountOnRoute(
+                { name: 'notifications', params: {}, query: {} },
+                { name: 'trips', params: {}, query: {} }
+            )
+        ).toBe(true);
+    });
+
+    it('skips when only query params change on the same route', () => {
+        expect(
+            shouldRefreshNotificationsCountOnRoute(
+                { name: 'trips', params: {}, query: { scroll: '120' } },
+                { name: 'trips', params: {}, query: { scroll: '0' } }
+            )
+        ).toBe(false);
+    });
+
+    it('refreshes when route params change on the same route name', () => {
+        expect(
+            shouldRefreshNotificationsCountOnRoute(
+                { name: 'trip', params: { id: '2' }, query: {} },
+                { name: 'trip', params: { id: '1' }, query: {} }
+            )
+        ).toBe(true);
+    });
+});

--- a/src/stores/notifications.js
+++ b/src/stores/notifications.js
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 import { NotificationApi } from '../services/api';
 
 const notificationApi = new NotificationApi();
+let countInFlight = null;
 
 export const useNotificationsStore = defineStore('notifications', {
     state: () => ({
@@ -29,7 +30,11 @@ export const useNotificationsStore = defineStore('notifications', {
         },
 
         countAction() {
-            return notificationApi
+            if (this._countInFlight) {
+                return this._countInFlight;
+            }
+
+            this._countInFlight = notificationApi
                 .count()
                 .then((response) => {
                     this.count = response.data;
@@ -37,7 +42,12 @@ export const useNotificationsStore = defineStore('notifications', {
                 })
                 .catch(() => {
                     return Promise.reject(new Error());
+                })
+                .finally(() => {
+                    this._countInFlight = null;
                 });
+
+            return this._countInFlight;
         },
 
         add() {

--- a/src/stores/notifications.js
+++ b/src/stores/notifications.js
@@ -30,11 +30,11 @@ export const useNotificationsStore = defineStore('notifications', {
         },
 
         countAction() {
-            if (this._countInFlight) {
-                return this._countInFlight;
+            if (countInFlight) {
+                return countInFlight;
             }
 
-            this._countInFlight = notificationApi
+            countInFlight = notificationApi
                 .count()
                 .then((response) => {
                     this.count = response.data;
@@ -44,10 +44,10 @@ export const useNotificationsStore = defineStore('notifications', {
                     return Promise.reject(new Error());
                 })
                 .finally(() => {
-                    this._countInFlight = null;
+                    countInFlight = null;
                 });
 
-            return this._countInFlight;
+            return countInFlight;
         },
 
         add() {

--- a/src/stores/notifications.test.js
+++ b/src/stores/notifications.test.js
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+
+const countMock = vi.fn();
+
+vi.mock('../services/api', () => ({
+    NotificationApi: class NotificationApiMock {
+        count = countMock;
+    }
+}));
+
+describe('notifications store countAction', () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        countMock.mockReset();
+    });
+
+    it('deduplicates concurrent count requests into a single API call', async () => {
+        let resolveCount;
+        countMock.mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    resolveCount = () => resolve({ data: 3 });
+                })
+        );
+
+        const { useNotificationsStore } = await import('./notifications');
+        const store = useNotificationsStore();
+
+        const first = store.countAction();
+        const second = store.countAction();
+
+        expect(countMock).toHaveBeenCalledTimes(1);
+
+        resolveCount();
+        await Promise.all([first, second]);
+
+        expect(store.count).toBe(3);
+    });
+});

--- a/src/stores/root.init.test.js
+++ b/src/stores/root.init.test.js
@@ -94,9 +94,11 @@ describe('root store init', () => {
         const startAppSpy = vi.spyOn(rootStore, 'startApp');
 
         await Promise.all([rootStore.init(), rootStore.init()]);
+        await vi.waitFor(() => {
+            expect(bus.emit).toHaveBeenCalledWith('system-ready');
+        });
 
         expect(startAppSpy).toHaveBeenCalledTimes(1);
         expect(bus.emit).toHaveBeenCalledTimes(1);
-        expect(bus.emit).toHaveBeenCalledWith('system-ready');
     });
 });

--- a/src/stores/root.init.test.js
+++ b/src/stores/root.init.test.js
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+
+const systemReadyHandlers = [];
+
+vi.mock('../services/bus-event', () => ({
+    default: {
+        on: vi.fn((event, handler) => {
+            if (event === 'system-ready') {
+                systemReadyHandlers.push(handler);
+            }
+        }),
+        emit: vi.fn((event) => {
+            if (event === 'system-ready') {
+                systemReadyHandlers.forEach((handler) => handler());
+            }
+        })
+    }
+}));
+
+vi.mock('../services/cache', () => ({
+    default: {
+        getItem: vi.fn(() => Promise.resolve(null))
+    },
+    keys: {
+        TOKEN_KEY: 'token',
+        USER_KEY: 'user',
+        DEVICE_KEY: 'device',
+        FIRST_TIME_APP_KEY: 'first_time'
+    }
+}));
+
+vi.mock('./auth', () => ({
+    useAuthStore: vi.fn()
+}));
+
+vi.mock('./device', () => ({
+    useDeviceStore: vi.fn()
+}));
+
+vi.mock('./trips', () => ({
+    useTripsStore: vi.fn(() => ({
+        tripsSearch: vi.fn()
+    }))
+}));
+
+vi.mock('./myTrips', () => ({
+    useMyTripsStore: vi.fn(() => ({
+        tripAsDriver: vi.fn(),
+        tripAsPassenger: vi.fn()
+    }))
+}));
+
+vi.mock('./passenger', () => ({
+    usePassengerStore: vi.fn(() => ({
+        getPendingRequest: vi.fn()
+    }))
+}));
+
+vi.mock('./cordova', () => ({
+    useCordovaStore: vi.fn(() => ({
+        device: null
+    }))
+}));
+
+describe('root store init', () => {
+    beforeEach(async () => {
+        vi.resetModules();
+        setActivePinia(createPinia());
+        systemReadyHandlers.length = 0;
+
+        const { useAuthStore } = await import('./auth');
+        const { useDeviceStore } = await import('./device');
+
+        useAuthStore.mockReturnValue({
+            token: null,
+            auth: false,
+            retoken: vi.fn(() => Promise.resolve()),
+            setToken: vi.fn(),
+            setUser: vi.fn(),
+            fetchUser: vi.fn()
+        });
+        useDeviceStore.mockReturnValue({
+            setCurrentDevice: vi.fn(),
+            setFirstTimeAppOpen: vi.fn(),
+            resize: vi.fn()
+        });
+    });
+
+    it('runs startup only once when init is called concurrently', async () => {
+        const bus = (await import('../services/bus-event')).default;
+        const { useRootStore } = await import('./root');
+        const rootStore = useRootStore();
+        const startAppSpy = vi.spyOn(rootStore, 'startApp');
+
+        await Promise.all([rootStore.init(), rootStore.init()]);
+
+        expect(startAppSpy).toHaveBeenCalledTimes(1);
+        expect(bus.emit).toHaveBeenCalledTimes(1);
+        expect(bus.emit).toHaveBeenCalledWith('system-ready');
+    });
+});

--- a/src/stores/root.init.test.js
+++ b/src/stores/root.init.test.js
@@ -94,11 +94,9 @@ describe('root store init', () => {
         const startAppSpy = vi.spyOn(rootStore, 'startApp');
 
         await Promise.all([rootStore.init(), rootStore.init()]);
-        await vi.waitFor(() => {
-            expect(bus.emit).toHaveBeenCalledWith('system-ready');
-        });
 
         expect(startAppSpy).toHaveBeenCalledTimes(1);
         expect(bus.emit).toHaveBeenCalledTimes(1);
+        expect(bus.emit).toHaveBeenCalledWith('system-ready');
     });
 });

--- a/src/stores/root.js
+++ b/src/stores/root.js
@@ -4,6 +4,8 @@ import bus from '../services/bus-event';
 import { Thread, stopThreads } from '../classes/Threads';
 import { shouldPollNotificationCount } from '../utils/notificationPolling';
 
+let initPromise = null;
+
 export const useRootStore = defineStore('root', {
     state: () => ({
         appVersion: 3,
@@ -17,6 +19,15 @@ export const useRootStore = defineStore('root', {
         },
 
         async init() {
+            if (initPromise) {
+                return initPromise;
+            }
+
+            initPromise = this._init();
+            return initPromise;
+        },
+
+        async _init() {
             console.log('Starting app.');
 
             const { useAuthStore } = await import('./auth');

--- a/src/stores/root.js
+++ b/src/stores/root.js
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 import cache, { keys } from '../services/cache';
 import bus from '../services/bus-event';
 import { Thread, stopThreads } from '../classes/Threads';
+import { shouldPollNotificationCount } from '../utils/notificationPolling';
 
 export const useRootStore = defineStore('root', {
     state: () => ({
@@ -172,13 +173,7 @@ export const useRootStore = defineStore('root', {
             const notificationsStore = useNotificationsStore();
 
             const config = authStore.appConfig;
-            if (
-                config &&
-                config.web_push_notification &&
-                typeof window !== 'undefined' &&
-                window.Notification &&
-                window.Notification.permission === 'granted'
-            ) {
+            if (!shouldPollNotificationCount(config)) {
                 return;
             }
 

--- a/src/stores/root.js
+++ b/src/stores/root.js
@@ -70,11 +70,12 @@ export const useRootStore = defineStore('root', {
                 promises.push(p);
             });
 
-            return Promise.all(promises).then(() => {
+            return Promise.all(promises).then(async () => {
                 if (authStore.token) {
-                    authStore.retoken().then(() => this.startApp());
+                    await authStore.retoken();
+                    await this.startApp();
                 } else {
-                    this.startApp();
+                    await this.startApp();
                 }
             });
         },

--- a/src/stores/root.js
+++ b/src/stores/root.js
@@ -164,6 +164,8 @@ export const useRootStore = defineStore('root', {
         },
 
         async startThread() {
+            this.stopThread();
+
             const { useAuthStore } = await import('./auth');
             const { useNotificationsStore } = await import('./notifications');
             const authStore = useAuthStore();
@@ -171,7 +173,10 @@ export const useRootStore = defineStore('root', {
 
             const config = authStore.appConfig;
             if (
+                config &&
                 config.web_push_notification &&
+                typeof window !== 'undefined' &&
+                window.Notification &&
                 window.Notification.permission === 'granted'
             ) {
                 return;

--- a/src/stores/root.startThread.test.js
+++ b/src/stores/root.startThread.test.js
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+
+const stopThreadsMock = vi.fn();
+const threadRunMock = vi.fn();
+
+vi.mock('../classes/Threads', () => ({
+    stopThreads: (...args) => stopThreadsMock(...args),
+    Thread: class ThreadMock {
+        constructor(fn, tags) {
+            this.fn = fn;
+            this.tags = tags;
+        }
+
+        run(interval, runFirst) {
+            threadRunMock(interval, runFirst);
+        }
+    }
+}));
+
+vi.mock('./auth', () => ({
+    useAuthStore: vi.fn()
+}));
+
+vi.mock('./notifications', () => ({
+    useNotificationsStore: vi.fn()
+}));
+
+describe('root store startThread', () => {
+    beforeEach(async () => {
+        vi.unstubAllGlobals();
+        setActivePinia(createPinia());
+        stopThreadsMock.mockClear();
+        threadRunMock.mockClear();
+
+        const { useAuthStore } = await import('./auth');
+        const { useNotificationsStore } = await import('./notifications');
+
+        useAuthStore.mockReturnValue({
+            appConfig: { web_push_notification: false }
+        });
+        vi.stubGlobal('window', { Notification: { permission: 'default' } });
+        useNotificationsStore.mockReturnValue({
+            countAction: vi.fn()
+        });
+    });
+
+    it('stops existing notification threads before starting polling', async () => {
+        const { useRootStore } = await import('./root');
+        const rootStore = useRootStore();
+
+        await rootStore.startThread();
+
+        expect(stopThreadsMock).toHaveBeenCalledWith('NOTIFICATIONS');
+        expect(threadRunMock).toHaveBeenCalledWith(30000, true);
+    });
+
+    it('stops polling when web push is already granted', async () => {
+        vi.stubGlobal('window', { Notification: { permission: 'granted' } });
+
+        const { useAuthStore } = await import('./auth');
+        useAuthStore.mockReturnValue({
+            appConfig: { web_push_notification: true }
+        });
+
+        const { useRootStore } = await import('./root');
+        const rootStore = useRootStore();
+
+        await rootStore.startThread();
+
+        expect(stopThreadsMock).toHaveBeenCalledWith('NOTIFICATIONS');
+        expect(threadRunMock).not.toHaveBeenCalled();
+    });
+});

--- a/src/utils/notificationPolling.js
+++ b/src/utils/notificationPolling.js
@@ -1,0 +1,13 @@
+export function isWebPushActive(config) {
+    return (
+        config &&
+        config.web_push_notification &&
+        typeof window !== 'undefined' &&
+        window.Notification &&
+        window.Notification.permission === 'granted'
+    );
+}
+
+export function shouldPollNotificationCount(config) {
+    return !isWebPushActive(config);
+}

--- a/src/utils/notificationPolling.test.js
+++ b/src/utils/notificationPolling.test.js
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest';
+import { isWebPushActive, shouldPollNotificationCount } from './notificationPolling.js';
+
+describe('notificationPolling utils', () => {
+    it('polls when web push is disabled in config', () => {
+        expect(shouldPollNotificationCount({ web_push_notification: false })).toBe(true);
+    });
+
+    it('does not poll when web push is granted', () => {
+        vi.stubGlobal('window', { Notification: { permission: 'granted' } });
+
+        expect(
+            isWebPushActive({ web_push_notification: true })
+        ).toBe(true);
+        expect(
+            shouldPollNotificationCount({ web_push_notification: true })
+        ).toBe(false);
+
+        vi.unstubAllGlobals();
+    });
+});


### PR DESCRIPTION
## Summary

Reduces excessive `/api/notifications/count` requests caused by overlapping polling threads, redundant route refreshes, and concurrent API calls.

### Cause

- A global `router.beforeEach` hook refreshed the badge on **every** navigation, including same-route query-only updates (e.g. trips scroll/search URL sync).
- `startThread()` created a new 30s polling interval without stopping the previous one, so double `init()` (cordova + main.js) or login could stack multiple timers.
- `root.init()` had no guard against concurrent calls, so startup could run twice.
- `countAction()` had no in-flight deduplication, so overlapping triggers could fire parallel requests.

### Fix (frontend)

- **Route refresh:** only fetch count when route name or params change; skip same-route query-only updates (`shouldRefreshNotificationsCountOnRoute`).
- **Polling lifecycle:** call `stopThread()` before starting a new notification thread; use `clearInterval` in `stopThreads`.
- **Init guard:** deduplicate concurrent `root.init()` calls via a shared promise.
- **Request dedup:** reuse a single in-flight promise in `countAction()` for concurrent callers.
- **Push vs poll:** extract `shouldPollNotificationCount()` so web push with granted permission stops polling instead of starting it.


## Test plan

- [x] Frontend unit tests (`npm run test:unit -- --run`) — 787 passing
- [x] Frontend lint (`npm run lint`)
- [x] Backend tests (`php artisan test`)
- [ ] Manual: logged-in user on `/trips` — updating query params should not spam `/count`
- [ ] Manual: reload app — network tab should show one polling interval (~30s), not stacked ~1s bursts
- [ ] Manual: navigate between pages — count refreshes on route change, not on query-only replace