### PR TITLE
Skip splash only on /admin routes, not for admin users

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,9 +39,38 @@
    integrity="sha512-Rksm5RenBEKSKFjgI3a41vrjkw4EVPlJ3+OiI65vTjIdo9brlAacEuKOiQ5OFh7cOI1bkDwLqdLw3Zg0cRJAAQ=="
    crossorigin=""/>
    <link rel="stylesheet" href="https://unpkg.com/leaflet-routing-machine@latest/dist/leaflet-routing-machine.css" />
+    <style>
+      .bootstrap-splash-screen {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: #FFFFFF;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        z-index: 9999;
+      }
+
+      .bootstrap-splash-image {
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+        max-width: 100%;
+        max-height: 100%;
+      }
+    </style>
   </head>
   <body>
     <div id="fb-root"></div>
+    <div id="bootstrap-splash" class="bootstrap-splash-screen">
+      <img
+        src="%BASE_URL%img/splash-android-1280x1920.png"
+        alt="Carpoolear"
+        class="bootstrap-splash-image"
+      />
+    </div>
     <div id="app">
 
     </div>

--- a/src/App.splash.test.js
+++ b/src/App.splash.test.js
@@ -4,16 +4,55 @@ import { describe, expect, it } from 'vitest';
 
 const appPath = path.join(__dirname, 'App.vue');
 const appSource = fs.readFileSync(appPath, 'utf8');
+const indexPath = path.join(__dirname, '..', 'index.html');
+const indexSource = fs.readFileSync(indexPath, 'utf8');
+const mainPath = path.join(__dirname, 'main.js');
+const mainSource = fs.readFileSync(mainPath, 'utf8');
 
 describe('App custom splash', () => {
-    it('skips the custom splash overlay for admin users', () => {
+    it('skips the custom splash overlay on admin routes', () => {
         expect(appSource).toContain('v-if="customSplashVisible"');
+        expect(appSource).toContain("from './utils/customSplash'");
         expect(appSource).toMatch(
-            /customSplashVisible\s*\(\)\s*\{[\s\S]*this\.user[\s\S]*is_admin[\s\S]*return false/
+            /customSplashVisible\s*\(\)\s*\{[\s\S]*isCustomSplashVisible\s*\([\s\S]*this\.\$route[\s\S]*this\.showCustomSplash/
         );
+    });
+
+    it('keeps splash enabled by default for the public app', () => {
+        expect(appSource).toMatch(/showCustomSplash:\s*true/);
+        expect(appSource).toContain('class="custom-splash-screen"');
+        expect(appSource).toContain('getRemainingSplashMs');
+        expect(appSource).toMatch(
+            /setTimeout\s*\([\s\S]*showCustomSplash\s*=\s*false[\s\S]*getRemainingSplashMs/
+        );
+    });
+
+    it('only dismisses splash early for admin URLs', () => {
+        expect(appSource).toMatch(/if\s*\(\s*isAdminAppUrl\(this\.\$route\)\s*\)/);
+        expect(appSource).toMatch(
+            /['"]\$route['"]\s*\([\s\S]*isAdminAppUrl\(to\)[\s\S]*showCustomSplash\s*=\s*false/
+        );
+        expect(appSource).not.toContain('isAdminUser');
     });
 
     it('uses custom splash visibility for modal suppression', () => {
         expect(appSource).toContain('return this.customSplashVisible || this.onBoardingVisibility');
+    });
+});
+
+describe('index.html bootstrap splash', () => {
+    it('shows splash immediately on cold page load before Vue mounts', () => {
+        expect(indexSource).toContain('id="bootstrap-splash"');
+        expect(indexSource).toContain('splash-android-1280x1920.png');
+        expect(indexSource).toContain('bootstrap-splash-screen');
+    });
+});
+
+describe('main.js bootstrap splash', () => {
+    it('initializes bootstrap splash before system-ready', () => {
+        expect(mainSource).toContain('initBootstrapSplash');
+        expect(mainSource.indexOf('initBootstrapSplash')).toBeLessThan(
+            mainSource.indexOf("bus.on('system-ready'")
+        );
     });
 });

--- a/src/App.vue
+++ b/src/App.vue
@@ -53,6 +53,12 @@ import { useRootStore } from './stores/root';
 import { Capacitor } from '@capacitor/core';
 import { AppUpdate } from '@capawesome/capacitor-app-update';
 import { compareAndroidVersion, compareSemver } from './utils/versionCompare';
+import {
+    getRemainingSplashMs,
+    hideBootstrapSplash,
+    isAdminAppUrl,
+    isCustomSplashVisible
+} from './utils/customSplash';
 import footerApp from './components/sections/FooterApp.vue';
 import headerApp from './components/sections/HeaderApp.vue';
 import onBoarding from './components/sections/OnBoarding.vue';
@@ -155,14 +161,20 @@ export default {
             window.SplashScreen.hide();
         }
 
-        if (this.user && this.user.is_admin) {
+        if (isAdminAppUrl(this.$route)) {
+            hideBootstrapSplash();
             this.showCustomSplash = false;
             return;
         }
 
+        hideBootstrapSplash();
+
         setTimeout(() => {
             this.showCustomSplash = false;
-        }, 3000);
+        }, getRemainingSplashMs(
+            performance.now(),
+            window.__customSplashStartedAt
+        ));
     },
     computed: {
         // Same version we send in X-App-Version header for all requests (network.js getHeader)
@@ -214,10 +226,10 @@ export default {
             return moduleEnabled && (mustShowMobile || mustShowGeneral);
         },
         customSplashVisible() {
-            if (this.user && this.user.is_admin) {
-                return false;
-            }
-            return this.showCustomSplash;
+            return isCustomSplashVisible({
+                location: this.$route,
+                showCustomSplash: this.showCustomSplash
+            });
         },
         identityPromptSuppress() {
             return this.customSplashVisible || this.onBoardingVisibility;
@@ -274,9 +286,11 @@ export default {
     watch: {
         deviceReady: () => {
         },
-        user(user) {
-            if (user && user.is_admin) {
+        '$route'(to) {
+            if (isAdminAppUrl(to)) {
+                hideBootstrapSplash();
                 this.showCustomSplash = false;
+                window.__customSplashStartedAt = null;
             }
         },
         appConfig(value) {

--- a/src/main.js
+++ b/src/main.js
@@ -36,6 +36,7 @@ import bus from './services/bus-event';
 import { DebugApi } from './services/api';
 import { init as initDebugLogger } from './services/debug';
 import { installPrototypes } from './prototypes';
+import { initBootstrapSplash } from './utils/customSplash';
 
 // Capacitor plugins
 import { StatusBar, Style } from '@capacitor/status-bar';
@@ -49,6 +50,8 @@ const debugApi = new DebugApi();
 
 // Initialize debug logger: clear logs on app init, patch console if debug mode enabled
 initDebugLogger();
+
+initBootstrapSplash();
 
 // Initialize Capacitor plugins
 const initializeCapacitorPlugins = async () => {

--- a/src/utils/customSplash.js
+++ b/src/utils/customSplash.js
@@ -1,0 +1,75 @@
+export const CUSTOM_SPLASH_DISMISS_MS = 3000;
+
+export function isAdminAppUrl(location) {
+    if (!location) {
+        return false;
+    }
+
+    const path = location.path || location.pathname || '';
+    const hash = location.hash || '';
+    const fullPath = location.fullPath || '';
+
+    return (
+        path.includes('/admin') ||
+        hash.includes('/admin') ||
+        fullPath.includes('/admin')
+    );
+}
+
+export function isCustomSplashVisible({ location, showCustomSplash }) {
+    if (isAdminAppUrl(location)) {
+        return false;
+    }
+
+    return Boolean(showCustomSplash);
+}
+
+export function getRemainingSplashMs(
+    now,
+    startedAt,
+    dismissMs = CUSTOM_SPLASH_DISMISS_MS
+) {
+    if (startedAt == null) {
+        return 0;
+    }
+
+    return Math.max(0, dismissMs - (now - startedAt));
+}
+
+export function hideBootstrapSplash(doc = typeof document !== 'undefined' ? document : null) {
+    if (!doc) {
+        return;
+    }
+
+    const bootstrapSplash = doc.getElementById('bootstrap-splash');
+    if (bootstrapSplash) {
+        bootstrapSplash.remove();
+    }
+}
+
+export function initBootstrapSplash({
+    location = typeof window !== 'undefined' ? window.location : null,
+    doc = typeof document !== 'undefined' ? document : null,
+    now = typeof performance !== 'undefined' ? performance.now() : 0,
+    setStartedAt = (value) => {
+        if (typeof window !== 'undefined') {
+            window.__customSplashStartedAt = value;
+        }
+    },
+    scheduleTimeout = (fn, delay) => setTimeout(fn, delay)
+} = {}) {
+    if (isAdminAppUrl(location)) {
+        hideBootstrapSplash(doc);
+        setStartedAt(null);
+        return { skipped: true, startedAt: null };
+    }
+
+    const startedAt = now;
+    setStartedAt(startedAt);
+
+    scheduleTimeout(() => {
+        hideBootstrapSplash(doc);
+    }, getRemainingSplashMs(now, startedAt));
+
+    return { skipped: false, startedAt };
+}

--- a/src/utils/customSplash.test.js
+++ b/src/utils/customSplash.test.js
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    CUSTOM_SPLASH_DISMISS_MS,
+    getRemainingSplashMs,
+    hideBootstrapSplash,
+    initBootstrapSplash,
+    isAdminAppUrl,
+    isCustomSplashVisible
+} from './customSplash.js';
+
+describe('isAdminAppUrl', () => {
+    it('detects admin routes in history and hash mode', () => {
+        expect(isAdminAppUrl({ path: '/admin' })).toBe(true);
+        expect(isAdminAppUrl({ path: '/admin/users' })).toBe(true);
+        expect(isAdminAppUrl({ pathname: '/app/admin/trips' })).toBe(true);
+        expect(isAdminAppUrl({ hash: '#/admin/users' })).toBe(true);
+        expect(isAdminAppUrl({ fullPath: '/admin/support-tickets/new' })).toBe(true);
+    });
+
+    it('does not treat public routes as admin', () => {
+        expect(isAdminAppUrl({ path: '/trips' })).toBe(false);
+        expect(isAdminAppUrl({ path: '/trips', fullPath: '/trips?clearSearch=true' })).toBe(false);
+        expect(isAdminAppUrl({ pathname: '/trips', search: '?clearSearch=true' })).toBe(false);
+        expect(isAdminAppUrl({ path: '/login' })).toBe(false);
+        expect(isAdminAppUrl({ hash: '#/trips' })).toBe(false);
+        expect(isAdminAppUrl(null)).toBe(false);
+    });
+});
+
+describe('isCustomSplashVisible', () => {
+    it('shows splash on public routes including trips with query params', () => {
+        expect(
+            isCustomSplashVisible({
+                location: { path: '/trips' },
+                showCustomSplash: true
+            })
+        ).toBe(true);
+        expect(
+            isCustomSplashVisible({
+                location: { path: '/trips', fullPath: '/trips?clearSearch=true' },
+                showCustomSplash: true
+            })
+        ).toBe(true);
+    });
+
+    it('still shows splash for admin users outside admin routes', () => {
+        expect(
+            isCustomSplashVisible({
+                location: { path: '/trips' },
+                showCustomSplash: true
+            })
+        ).toBe(true);
+    });
+
+    it('hides splash on admin routes', () => {
+        expect(
+            isCustomSplashVisible({
+                location: { path: '/admin/users' },
+                showCustomSplash: true
+            })
+        ).toBe(false);
+    });
+
+    it('hides splash after dismiss timer clears showCustomSplash', () => {
+        expect(
+            isCustomSplashVisible({
+                location: { path: '/trips' },
+                showCustomSplash: false
+            })
+        ).toBe(false);
+    });
+});
+
+describe('getRemainingSplashMs', () => {
+    it('counts down from page load so public users keep the full splash window', () => {
+        expect(getRemainingSplashMs(2500, 0)).toBe(500);
+        expect(getRemainingSplashMs(4000, 0)).toBe(0);
+        expect(getRemainingSplashMs(1000, 500)).toBe(2500);
+    });
+
+    it('returns zero when splash was skipped', () => {
+        expect(getRemainingSplashMs(1000, null)).toBe(0);
+    });
+});
+
+describe('hideBootstrapSplash', () => {
+    it('removes the bootstrap splash element', () => {
+        const bootstrapSplash = { remove: vi.fn() };
+        const doc = {
+            getElementById: vi.fn(() => bootstrapSplash)
+        };
+
+        hideBootstrapSplash(doc);
+
+        expect(doc.getElementById).toHaveBeenCalledWith('bootstrap-splash');
+        expect(bootstrapSplash.remove).toHaveBeenCalled();
+    });
+});
+
+describe('initBootstrapSplash', () => {
+    it('shows bootstrap splash immediately for public routes', () => {
+        const startedAtValues = [];
+        const timeouts = [];
+
+        const result = initBootstrapSplash({
+            location: { pathname: '/trips', hash: '' },
+            doc: { getElementById: () => null },
+            now: 100,
+            setStartedAt: (value) => startedAtValues.push(value),
+            scheduleTimeout: (fn, delay) => {
+                timeouts.push({ fn, delay });
+                return delay;
+            }
+        });
+
+        expect(result.skipped).toBe(false);
+        expect(startedAtValues).toEqual([100]);
+        expect(timeouts).toEqual([
+            expect.objectContaining({ delay: CUSTOM_SPLASH_DISMISS_MS })
+        ]);
+    });
+
+    it('skips bootstrap splash for admin URLs', () => {
+        const bootstrapSplash = { remove: vi.fn() };
+        const startedAtValues = [];
+
+        const result = initBootstrapSplash({
+            location: { pathname: '/admin/users', hash: '' },
+            doc: {
+                getElementById: () => bootstrapSplash
+            },
+            now: 100,
+            setStartedAt: (value) => startedAtValues.push(value),
+            scheduleTimeout: vi.fn()
+        });
+
+        expect(result.skipped).toBe(true);
+        expect(bootstrapSplash.remove).toHaveBeenCalled();
+        expect(startedAtValues).toEqual([null]);
+    });
+
+    it('skips bootstrap splash for hash-mode admin URLs', () => {
+        const bootstrapSplash = { remove: vi.fn() };
+
+        const result = initBootstrapSplash({
+            location: { pathname: '/', hash: '#/admin/users' },
+            doc: { getElementById: () => bootstrapSplash },
+            now: 100,
+            setStartedAt: () => {},
+            scheduleTimeout: vi.fn()
+        });
+
+        expect(result.skipped).toBe(true);
+        expect(bootstrapSplash.remove).toHaveBeenCalled();
+    });
+});
+
+describe('CUSTOM_SPLASH_DISMISS_MS', () => {
+    it('keeps the public splash visible for three seconds', () => {
+        expect(CUSTOM_SPLASH_DISMISS_MS).toBe(3000);
+    });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -161,6 +161,9 @@ export default defineConfig(({ mode }) => {
             'import.meta.env.VITE_HISTORY_MODE': JSON.stringify(historyMode),
             'import.meta.env.VITE_API_URL': JSON.stringify(apiUrl),
             'import.meta.env.VITE_TARGET_APP': JSON.stringify(brandingTarget),
+            'import.meta.env.VITE_SERVE': JSON.stringify(
+                process.env.SERVE === true || process.env.SERVE === 'true'
+            ),
 
             // Keep in sync with `process.env.*` usage under src/ (static replace at build time).
             'process.env': JSON.stringify({


### PR DESCRIPTION
## Summary

Skip the custom splash screen only on `/admin` routes. Public routes (e.g. `/trips`, `/trips?clearSearch=true`) always show the splash, even for logged-in admin users.

## Cause

Splash visibility was tied to `user.is_admin`, so admin users never saw the splash in their normal browser session (cached admin login). That was wrong for the public app: admins using `/trips` and other non-admin URLs should still get the splash. Splash should be skipped only when opening admin URLs.

A second issue made the splash easy to miss on web: Vue mounted only after a boot delay, so the overlay appeared late or not at all during normal browsing.

## Fix (Frontend)

- Added `src/utils/customSplash.js` with route-based helpers:
  - `isAdminAppUrl()` — detects `/admin` in path, hash, or fullPath (history + hash mode)
  - `isCustomSplashVisible()` — shows splash on all non-admin routes
  - `initBootstrapSplash()` / `getRemainingSplashMs()` — bootstrap splash lifecycle
- **`index.html`**: immediate bootstrap splash before Vue mounts
- **`main.js`**: calls `initBootstrapSplash()` on load
- **`App.vue`**: uses `$route` instead of `user.is_admin`; watches `$route` to dismiss splash when navigating to admin
- **`vite.config.js`**: wires `VITE_SERVE` so dev init is not delayed unnecessarily


## Test plan

- [x] Unit tests: `src/utils/customSplash.test.js`, `src/App.splash.test.js` (19 tests)
- [x] Frontend lint passes
- [ ] Hard refresh `http://localhost:8080/trips?clearSearch=true` as admin → splash shows ~3s
- [ ] Hard refresh `http://localhost:8080/admin` → no splash
- [ ] In-app navigation to `/admin` dismisses splash if still visible