### PR TITLE
Account verification changes

### DIFF
--- a/src/components/sections/IdentityValidation.view.test.js
+++ b/src/components/sections/IdentityValidation.view.test.js
@@ -18,6 +18,11 @@ describe('IdentityValidation rejected manual verification', () => {
         expect(viewSource).toContain("$t('validarConMercadoPago')");
         expect(viewSource).toContain("$t('solicitarVerificacionManual')");
     });
+
+    it('does not render standalone in-flow review note when manual verification was rejected', () => {
+        expect(viewSource).toContain('v-if="!showManualRejectedWithChoiceCards"');
+        expect(viewSource).toContain('in-flow');
+    });
 });
 
 describe('IdentityValidation rejection warnings', () => {

--- a/src/components/sections/IdentityValidation.view.test.js
+++ b/src/components/sections/IdentityValidation.view.test.js
@@ -5,6 +5,21 @@ import path from 'node:path';
 const viewPath = path.resolve(__dirname, 'IdentityValidation.vue');
 const viewSource = fs.readFileSync(viewPath, 'utf8');
 
+describe('IdentityValidation rejected manual verification', () => {
+    it('uses shared success banner helper so rejected manual flow is not hidden', () => {
+        expect(viewSource).toContain('shouldShowIdentityVerificationSuccessBanner');
+    });
+
+    it('shows retry prompt and choice cards when manual verification was rejected', () => {
+        expect(viewSource).toContain('showManualRejectedWithChoiceCards');
+        expect(viewSource).toContain('identity-validation-rejected-flow');
+        expect(viewSource).toContain("$t('identityValidationRetryPrompt')");
+        expect(viewSource).toContain('identity-validation-cards');
+        expect(viewSource).toContain("$t('validarConMercadoPago')");
+        expect(viewSource).toContain("$t('solicitarVerificacionManual')");
+    });
+});
+
 describe('IdentityValidation rejection warnings', () => {
     it('shows mismatch support warning with warning icon in MP mismatch alert', () => {
         expect(viewSource).toContain('<div class="alert alert-warning" v-if="mismatchDetails">');

--- a/src/components/sections/IdentityValidation.vue
+++ b/src/components/sections/IdentityValidation.vue
@@ -34,6 +34,7 @@
 
         <div v-else>
         <IdentityValidationAdminReviewNote
+            v-if="!showManualRejectedWithChoiceCards"
             :note="displayableManualReviewNote"
             :label-key="manualAdminReviewNoteLabelKey"
             in-flow

--- a/src/components/sections/IdentityValidation.vue
+++ b/src/components/sections/IdentityValidation.vue
@@ -242,6 +242,10 @@
                     <p class="identity-validation-rejection-notice__text">
                         {{ $t('identityValidationRejectionNoticeBody') }}
                     </p>
+                    <IdentityValidationAdminReviewNote
+                        :note="displayableManualReviewNote"
+                        :label-key="manualAdminReviewNoteLabelKey"
+                    />
                     <p
                         v-if="manualRejectionSupportWarningKey"
                         class="identity-validation-rejection-notice__support-warning"
@@ -253,6 +257,9 @@
                         <strong class="identity-validation-rejection-notice__emphasis-strong">{{ $t('identityValidationRejectionNoticeContactLead') }}</strong><router-link class="identity-validation-rejection-notice__mesa-link" :to="{ name: 'tickets' }">{{ $t('mesaAyuda') }}</router-link>{{ $t('identityValidationRejectionNoticeContactTail') }}
                     </p>
                 </div>
+                <p class="identity-validation-retry-prompt">
+                    {{ $t('identityValidationRetryPrompt') }}
+                </p>
                 <div
                     v-if="isIdentityValidationBlockedByMissingDni"
                     class="identity-validation-dni-warning"
@@ -415,6 +422,8 @@ import {
     getDisplayableManualReviewNote,
     getManualReviewNoteLabelKey
 } from '../../utils/manualIdentityValidationReviewNote';
+import { shouldShowIdentityVerificationSuccessBanner } from '../../utils/identityValidationSuccessBanner';
+import { isManualRejectedWithChoiceCards } from '../../utils/manualIdentityValidationStatus';
 import IdentityValidationAdminReviewNote from '../IdentityValidationAdminReviewNote.vue';
 
 const EMPTY_WARNING_PARTS = { leadKey: null, tailKey: null };
@@ -514,15 +523,9 @@ export default {
         },
         /** Manual docs rejected: show red banner + MP / manual choice cards. */
         showManualRejectedWithChoiceCards() {
-            if (!this.identityValidationManualEnabled) return false;
-            const m = this.manualStatus;
-            return !!(
-                m &&
-                m.has_submission &&
-                m.paid &&
-                m.submitted_at &&
-                m.review_status === 'rejected'
-            );
+            return isManualRejectedWithChoiceCards(this.manualStatus, {
+                manualEnabled: this.identityValidationManualEnabled
+            });
         },
         manualRejectionSupportWarningKey() {
             if (!this.showManualRejectedWithChoiceCards) return null;
@@ -535,20 +538,11 @@ export default {
             return getManualReviewNoteLabelKey(this.manualStatus?.review_status);
         },
         showVerificationSuccessBanner() {
-            if (this.manualDocsPendingAdminReview) {
-                return false;
-            }
-            if (this.resultMessage === 'success') {
-                return true;
-            }
-            if (
-                this.user &&
-                this.user.identity_validated &&
-                this.user.identity_validated_at
-            ) {
-                return true;
-            }
-            return false;
+            return shouldShowIdentityVerificationSuccessBanner({
+                user: this.user,
+                manualStatus: this.manualStatus,
+                resultMessage: this.resultMessage
+            });
         },
         checkCircleIconSrc() {
             const base = process.env.ROUTE_BASE || '/';

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -661,6 +661,7 @@ const messages = {
         identityVerificationPendingReviewNoticeEmphasis:
             'Te notificaremos cuando la verificación esté completa.',
         identityValidationRejectionNoticeTitle: 'Verificación rechazada',
+        identityValidationRetryPrompt: '¿Querés solicitar una nueva verificación de cuenta?',
         identityValidationRejectionNoticeBody:
             'No pudimos verificar tu cuenta con la información enviada.',
         identityValidationRejectionNoticeContactLead:
@@ -2127,6 +2128,7 @@ const messages = {
         identityVerificationPendingReviewNoticeEmphasis:
             'Te notificaremos cuando la verificación esté completa.',
         identityValidationRejectionNoticeTitle: 'Verificación rechazada',
+        identityValidationRetryPrompt: '¿Querés solicitar una nueva verificación de cuenta?',
         identityValidationRejectionNoticeBody:
             'No pudimos verificar tu cuenta con la información enviada.',
         identityValidationRejectionNoticeContactLead:
@@ -3427,6 +3429,7 @@ const messages = {
         identityVerificationPendingReviewNoticeEmphasis:
             'We will notify you when verification is complete.',
         identityValidationRejectionNoticeTitle: 'Verification rejected',
+        identityValidationRetryPrompt: 'Would you like to request a new account verification?',
         identityValidationRejectionNoticeBody:
             "We couldn't verify your account with the information you sent.",
         identityValidationRejectionNoticeContactLead:

--- a/src/utils/adminUserIdentityVerification.js
+++ b/src/utils/adminUserIdentityVerification.js
@@ -71,7 +71,20 @@ export function buildAdminUserIdentityVerificationSection(user, { translate }) {
 }
 
 export function canClearAdminUserIdentityVerification(user) {
-    return !!user?.['identity_validated_at'];
+    if (!user) {
+        return false;
+    }
+
+    if (Number(user.manual_identity_validations_count) > 0) {
+        return true;
+    }
+
+    return !!(
+        user.identity_validated_at ||
+        user.identity_validation_rejected_at ||
+        user.identity_validation_reject_reason ||
+        user.identity_validation_type
+    );
 }
 
 export function applyClearedIdentityValidationFields(user) {

--- a/src/utils/adminUserIdentityVerification.test.js
+++ b/src/utils/adminUserIdentityVerification.test.js
@@ -112,11 +112,36 @@ describe('canClearAdminUserIdentityVerification', () => {
         ).toBe(true);
     });
 
-    it('returns false when user has no verification timestamp', () => {
+    it('returns true when user has manual identity validation in progress', () => {
         expect(
             canClearAdminUserIdentityVerification({
                 identity_validated: false,
-                identity_validated_at: null
+                identity_validated_at: null,
+                manual_identity_validations_count: 1
+            })
+        ).toBe(true);
+    });
+
+    it('returns true when user only has rejection metadata', () => {
+        expect(
+            canClearAdminUserIdentityVerification({
+                identity_validated: false,
+                identity_validated_at: null,
+                identity_validation_rejected_at: '2026-06-02 11:00:00',
+                identity_validation_reject_reason: 'name_mismatch'
+            })
+        ).toBe(true);
+    });
+
+    it('returns false when user has no verification data', () => {
+        expect(
+            canClearAdminUserIdentityVerification({
+                identity_validated: false,
+                identity_validated_at: null,
+                identity_validation_rejected_at: null,
+                identity_validation_reject_reason: null,
+                identity_validation_type: null,
+                manual_identity_validations_count: 0
             })
         ).toBe(false);
     });

--- a/src/utils/identityValidationSuccessBanner.js
+++ b/src/utils/identityValidationSuccessBanner.js
@@ -1,0 +1,29 @@
+import { isManualIdentityValidationRejected } from './manualIdentityValidationStatus.js';
+
+function isManualDocsPendingAdminReview(manualStatus) {
+    if (!manualStatus || !manualStatus.has_submission || !manualStatus.paid || !manualStatus.submitted_at) {
+        return false;
+    }
+    const reviewStatus = manualStatus.review_status;
+    return reviewStatus !== 'approved' && reviewStatus !== 'rejected';
+}
+
+export function shouldShowIdentityVerificationSuccessBanner({
+    user,
+    manualStatus,
+    resultMessage
+}) {
+    if (isManualDocsPendingAdminReview(manualStatus)) {
+        return false;
+    }
+    if (isManualIdentityValidationRejected(manualStatus)) {
+        return false;
+    }
+    if (resultMessage === 'success') {
+        return true;
+    }
+    if (user && user.identity_validated && user.identity_validated_at) {
+        return true;
+    }
+    return false;
+}

--- a/src/utils/identityValidationSuccessBanner.test.js
+++ b/src/utils/identityValidationSuccessBanner.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { shouldShowIdentityVerificationSuccessBanner } from './identityValidationSuccessBanner';
+
+describe('shouldShowIdentityVerificationSuccessBanner', () => {
+    const verifiedUser = {
+        identity_validated: true,
+        identity_validated_at: '2026-06-01 10:00:00'
+    };
+
+    it('returns false when manual verification was rejected even if user still looks verified', () => {
+        expect(
+            shouldShowIdentityVerificationSuccessBanner({
+                user: verifiedUser,
+                manualStatus: {
+                    has_submission: true,
+                    paid: true,
+                    submitted_at: '2026-06-02 12:00:00',
+                    review_status: 'rejected',
+                    review_note: 'Prueba'
+                },
+                resultMessage: null
+            })
+        ).toBe(false);
+    });
+
+    it('returns false while manual docs are pending admin review', () => {
+        expect(
+            shouldShowIdentityVerificationSuccessBanner({
+                user: verifiedUser,
+                manualStatus: {
+                    has_submission: true,
+                    paid: true,
+                    submitted_at: '2026-06-02 12:00:00',
+                    review_status: 'pending'
+                },
+                resultMessage: null
+            })
+        ).toBe(false);
+    });
+
+    it('returns true for a verified user without blocking manual state', () => {
+        expect(
+            shouldShowIdentityVerificationSuccessBanner({
+                user: verifiedUser,
+                manualStatus: {
+                    has_submission: false,
+                    paid: null,
+                    submitted_at: null,
+                    review_status: null
+                },
+                resultMessage: null
+            })
+        ).toBe(true);
+    });
+
+    it('returns true when oauth callback reports success', () => {
+        expect(
+            shouldShowIdentityVerificationSuccessBanner({
+                user: { identity_validated: false, identity_validated_at: null },
+                manualStatus: null,
+                resultMessage: 'success'
+            })
+        ).toBe(true);
+    });
+});

--- a/src/utils/manualIdentityValidationStatus.js
+++ b/src/utils/manualIdentityValidationStatus.js
@@ -1,0 +1,13 @@
+export function isManualIdentityValidationRejected(manualStatus) {
+    if (!manualStatus || !manualStatus.has_submission || !manualStatus.paid || !manualStatus.submitted_at) {
+        return false;
+    }
+    return manualStatus.review_status === 'rejected';
+}
+
+export function isManualRejectedWithChoiceCards(manualStatus, { manualEnabled = true } = {}) {
+    if (!manualEnabled) {
+        return false;
+    }
+    return isManualIdentityValidationRejected(manualStatus);
+}

--- a/src/utils/manualIdentityValidationStatus.test.js
+++ b/src/utils/manualIdentityValidationStatus.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import {
+    isManualIdentityValidationRejected,
+    isManualRejectedWithChoiceCards
+} from './manualIdentityValidationStatus';
+
+describe('isManualIdentityValidationRejected', () => {
+    it('returns true when paid submission was rejected', () => {
+        expect(
+            isManualIdentityValidationRejected({
+                has_submission: true,
+                paid: true,
+                submitted_at: '2026-06-02 12:00:00',
+                review_status: 'rejected'
+            })
+        ).toBe(true);
+    });
+
+    it('returns false when review is still pending', () => {
+        expect(
+            isManualIdentityValidationRejected({
+                has_submission: true,
+                paid: true,
+                submitted_at: '2026-06-02 12:00:00',
+                review_status: 'pending'
+            })
+        ).toBe(false);
+    });
+});
+
+describe('isManualRejectedWithChoiceCards', () => {
+    it('returns false when manual verification is disabled', () => {
+        expect(
+            isManualRejectedWithChoiceCards(
+                {
+                    has_submission: true,
+                    paid: true,
+                    submitted_at: '2026-06-02 12:00:00',
+                    review_status: 'rejected'
+                },
+                { manualEnabled: false }
+            )
+        ).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes manual identity verification rejections incorrectly showing the green "Verificación exitosa" banner, adds a retry prompt with Mercado Pago / manual options on rejection, and makes admin "Remover verificación de cuenta" fully reset all verification state (MP + manual).

## Frontend

### Cause
`showVerificationSuccessBanner` returned `true` whenever `user.identity_validated && user.identity_validated_at`, without checking manual verification status. Rejected manual submissions (with admin review notes like "Razón de rechazo") were hidden behind the success banner.

### Fix
- Extracted `shouldShowIdentityVerificationSuccessBanner` and `manualIdentityValidationStatus` helpers.
- Success banner is suppressed when manual verification is **rejected** or **pending admin review**.
- Rejected flow now shows:
  - Red rejection notice with admin review note
  - **"¿Querés solicitar una nueva verificación de cuenta?"**
  - Mercado Pago and manual verification choice cards (same as initial screen)
- Admin user detail: clear button is available when there is any verification activity (verified, rejected, or in-progress manual), not only when `identity_validated_at` is set.


## Test plan
- [ ] Reject a manual verification in admin → user sees red "Verificación rechazada", retry prompt, and both verification options (not green success).
- [ ] Approve a manual verification → user still sees green success banner.
- [ ] Admin user detail with unpaid/paid manual submission (no `identity_validated_at`) → "Remover verificación de cuenta" button visible.
- [ ] Click remove → user identity fields cleared, manual rows/photos gone, MP rejection records gone; user can start verification again.