### PR TITLE
Splash version number

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,15 @@
         max-width: 100%;
         max-height: 100%;
       }
+
+      .bootstrap-splash-version {
+        position: absolute;
+        bottom: 20px;
+        left: 20px;
+        color: #999;
+        font-size: 12px;
+        font-family: Arial, sans-serif;
+      }
     </style>
   </head>
   <body>
@@ -70,6 +79,7 @@
         alt="Carpoolear"
         class="bootstrap-splash-image"
       />
+      <div id="bootstrap-splash-version" class="bootstrap-splash-version"></div>
     </div>
     <div id="app">
 

--- a/src/App.splash.test.js
+++ b/src/App.splash.test.js
@@ -66,4 +66,8 @@ describe('main.js bootstrap splash', () => {
             mainSource.indexOf("bus.on('system-ready'")
         );
     });
+
+    it('passes native platform flag when initializing bootstrap splash', () => {
+        expect(mainSource).toContain('isNativePlatform: Capacitor.isNativePlatform()');
+    });
 });

--- a/src/App.splash.test.js
+++ b/src/App.splash.test.js
@@ -38,6 +38,12 @@ describe('App custom splash', () => {
     it('uses custom splash visibility for modal suppression', () => {
         expect(appSource).toContain('return this.customSplashVisible || this.onBoardingVisibility');
     });
+
+    it('shows version and build number on the vue splash overlay', () => {
+        expect(appSource).toContain('class="splash-version"');
+        expect(appSource).toContain('formatSplashVersionText');
+        expect(appSource).toContain('resolveSplashVersion');
+    });
 });
 
 describe('index.html bootstrap splash', () => {
@@ -45,6 +51,11 @@ describe('index.html bootstrap splash', () => {
         expect(indexSource).toContain('id="bootstrap-splash"');
         expect(indexSource).toContain('splash-android-1280x1920.png');
         expect(indexSource).toContain('bootstrap-splash-screen');
+    });
+
+    it('includes a bootstrap version label for the splash overlay', () => {
+        expect(indexSource).toContain('id="bootstrap-splash-version"');
+        expect(indexSource).toContain('bootstrap-splash-version');
     });
 });
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -54,10 +54,12 @@ import { Capacitor } from '@capacitor/core';
 import { AppUpdate } from '@capawesome/capacitor-app-update';
 import { compareAndroidVersion, compareSemver } from './utils/versionCompare';
 import {
+    formatSplashVersionText,
     getRemainingSplashMs,
     hideBootstrapSplash,
     isAdminAppUrl,
-    isCustomSplashVisible
+    isCustomSplashVisible,
+    resolveSplashVersion
 } from './utils/customSplash';
 import footerApp from './components/sections/FooterApp.vue';
 import headerApp from './components/sections/HeaderApp.vue';
@@ -179,10 +181,14 @@ export default {
     computed: {
         // Same version we send in X-App-Version header for all requests (network.js getHeader)
         splashVersionText() {
-            const appVersionInfo = useRootStore().appVersionInfo;
-            const version = (appVersionInfo && appVersionInfo.version) || (typeof window !== 'undefined' && window.appVersion) || '0';
-            const base = 'Version ' + version;
-            return Capacitor.isNativePlatform() ? base : base + ' - build 116';
+            return formatSplashVersionText({
+                version: resolveSplashVersion({
+                    appVersionInfo: useRootStore().appVersionInfo,
+                    windowAppVersion:
+                        typeof window !== 'undefined' ? window.appVersion : null
+                }),
+                isNativePlatform: Capacitor.isNativePlatform()
+            });
         },
         ...mapState(useCordovaStore, {
             deviceReady: 'deviceReady',

--- a/src/main.js
+++ b/src/main.js
@@ -51,7 +51,9 @@ const debugApi = new DebugApi();
 // Initialize debug logger: clear logs on app init, patch console if debug mode enabled
 initDebugLogger();
 
-initBootstrapSplash();
+initBootstrapSplash({
+    isNativePlatform: Capacitor.isNativePlatform()
+});
 
 // Initialize Capacitor plugins
 const initializeCapacitorPlugins = async () => {

--- a/src/utils/customSplash.js
+++ b/src/utils/customSplash.js
@@ -1,4 +1,50 @@
 export const CUSTOM_SPLASH_DISMISS_MS = 3000;
+export const SPLASH_WEB_BUILD_NUMBER = 116;
+export const BOOTSTRAP_SPLASH_VERSION_ID = 'bootstrap-splash-version';
+
+export function formatSplashVersionText({
+    version,
+    isNativePlatform = false,
+    webBuildNumber = SPLASH_WEB_BUILD_NUMBER
+}) {
+    const resolvedVersion =
+        version != null && String(version) !== '' ? String(version) : '0';
+    const base = `Version ${resolvedVersion}`;
+
+    return isNativePlatform ? base : `${base} - build ${webBuildNumber}`;
+}
+
+export function resolveSplashVersion({ appVersionInfo, windowAppVersion }) {
+    if (appVersionInfo && appVersionInfo.version) {
+        return String(appVersionInfo.version);
+    }
+
+    if (windowAppVersion) {
+        return String(windowAppVersion);
+    }
+
+    return '0';
+}
+
+export function updateBootstrapSplashVersion(
+    doc,
+    { version, isNativePlatform = false, webBuildNumber = SPLASH_WEB_BUILD_NUMBER }
+) {
+    if (!doc) {
+        return;
+    }
+
+    const versionEl = doc.getElementById(BOOTSTRAP_SPLASH_VERSION_ID);
+    if (!versionEl) {
+        return;
+    }
+
+    versionEl.textContent = formatSplashVersionText({
+        version,
+        isNativePlatform,
+        webBuildNumber
+    });
+}
 
 export function isAdminAppUrl(location) {
     if (!location) {
@@ -51,6 +97,8 @@ export function initBootstrapSplash({
     location = typeof window !== 'undefined' ? window.location : null,
     doc = typeof document !== 'undefined' ? document : null,
     now = typeof performance !== 'undefined' ? performance.now() : 0,
+    windowAppVersion = typeof window !== 'undefined' ? window.appVersion : null,
+    isNativePlatform = false,
     setStartedAt = (value) => {
         if (typeof window !== 'undefined') {
             window.__customSplashStartedAt = value;
@@ -63,6 +111,11 @@ export function initBootstrapSplash({
         setStartedAt(null);
         return { skipped: true, startedAt: null };
     }
+
+    updateBootstrapSplashVersion(doc, {
+        version: resolveSplashVersion({ windowAppVersion }),
+        isNativePlatform
+    });
 
     const startedAt = now;
     setStartedAt(startedAt);

--- a/src/utils/customSplash.test.js
+++ b/src/utils/customSplash.test.js
@@ -1,12 +1,72 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
     CUSTOM_SPLASH_DISMISS_MS,
+    formatSplashVersionText,
     getRemainingSplashMs,
     hideBootstrapSplash,
     initBootstrapSplash,
     isAdminAppUrl,
-    isCustomSplashVisible
+    isCustomSplashVisible,
+    resolveSplashVersion,
+    SPLASH_WEB_BUILD_NUMBER,
+    updateBootstrapSplashVersion
 } from './customSplash.js';
+
+describe('formatSplashVersionText', () => {
+    it('shows version and build number on web', () => {
+        expect(
+            formatSplashVersionText({ version: '3.2.5', isNativePlatform: false })
+        ).toBe('Version 3.2.5 - build 116');
+    });
+
+    it('shows version only on native platforms', () => {
+        expect(
+            formatSplashVersionText({ version: '123', isNativePlatform: true })
+        ).toBe('Version 123');
+    });
+
+    it('falls back to zero when version is missing', () => {
+        expect(
+            formatSplashVersionText({ version: null, isNativePlatform: false })
+        ).toBe('Version 0 - build 116');
+    });
+});
+
+describe('resolveSplashVersion', () => {
+    it('prefers appVersionInfo over window fallback', () => {
+        expect(
+            resolveSplashVersion({
+                appVersionInfo: { version: '9.9.9' },
+                windowAppVersion: '3.2.5'
+            })
+        ).toBe('9.9.9');
+    });
+
+    it('uses window.appVersion when store info is unavailable', () => {
+        expect(
+            resolveSplashVersion({
+                appVersionInfo: null,
+                windowAppVersion: '3.2.5'
+            })
+        ).toBe('3.2.5');
+    });
+});
+
+describe('updateBootstrapSplashVersion', () => {
+    it('writes version text into the bootstrap splash label', () => {
+        const versionEl = { textContent: '' };
+        const doc = {
+            getElementById: vi.fn((id) => (id === 'bootstrap-splash-version' ? versionEl : null))
+        };
+
+        updateBootstrapSplashVersion(doc, {
+            version: '3.2.5',
+            isNativePlatform: false
+        });
+
+        expect(versionEl.textContent).toBe('Version 3.2.5 - build 116');
+    });
+});
 
 describe('isAdminAppUrl', () => {
     it('detects admin routes in history and hash mode', () => {
@@ -101,11 +161,17 @@ describe('initBootstrapSplash', () => {
     it('shows bootstrap splash immediately for public routes', () => {
         const startedAtValues = [];
         const timeouts = [];
+        const versionEl = { textContent: '' };
+        const doc = {
+            getElementById: vi.fn((id) => (id === 'bootstrap-splash-version' ? versionEl : null))
+        };
 
         const result = initBootstrapSplash({
             location: { pathname: '/trips', hash: '' },
-            doc: { getElementById: () => null },
+            doc,
             now: 100,
+            windowAppVersion: '3.2.5',
+            isNativePlatform: false,
             setStartedAt: (value) => startedAtValues.push(value),
             scheduleTimeout: (fn, delay) => {
                 timeouts.push({ fn, delay });
@@ -115,6 +181,7 @@ describe('initBootstrapSplash', () => {
 
         expect(result.skipped).toBe(false);
         expect(startedAtValues).toEqual([100]);
+        expect(versionEl.textContent).toBe('Version 3.2.5 - build 116');
         expect(timeouts).toEqual([
             expect.objectContaining({ delay: CUSTOM_SPLASH_DISMISS_MS })
         ]);
@@ -158,5 +225,9 @@ describe('initBootstrapSplash', () => {
 describe('CUSTOM_SPLASH_DISMISS_MS', () => {
     it('keeps the public splash visible for three seconds', () => {
         expect(CUSTOM_SPLASH_DISMISS_MS).toBe(3000);
+    });
+
+    it('exposes the web build number used on the splash screen', () => {
+        expect(SPLASH_WEB_BUILD_NUMBER).toBe(116);
     });
 });


### PR DESCRIPTION
## Summary

Restore the version and build number label on the splash screen, including during the bootstrap phase before Vue mounts.

## Cause

The bootstrap splash added in `index.html` only showed the image — no version label. Because the bootstrap overlay is visible for most of the splash window (before Vue mounts), users stopped seeing `Version X - build 116` even though `App.vue` still had `splashVersionText` on the Vue overlay.

## Fix (Frontend)

- Added shared helpers in `src/utils/customSplash.js`:
  - `formatSplashVersionText()` — formats `Version X` on native, `Version X - build 116` on web
  - `resolveSplashVersion()` — resolves version from store or `window.appVersion`
  - `updateBootstrapSplashVersion()` — writes label into `#bootstrap-splash-version`
- **`index.html`**: added `#bootstrap-splash-version` element and matching styles
- **`initBootstrapSplash()`**: populates version text on cold load using `window.appVersion`
- **`App.vue`**: uses shared `formatSplashVersionText` / `resolveSplashVersion` instead of inline logic
- **`main.js`**: passes `Capacitor.isNativePlatform()` to bootstrap init


## Test plan

- [x] Unit tests: `src/utils/customSplash.test.js`, `src/App.splash.test.js` (29 tests)
- [x] Frontend lint passes
- [x] Backend test suite passes (no backend changes)
- [ ] Hard refresh `/trips` → bootstrap splash shows `Version 3.2.5 - build 116` (bottom-left)
- [ ] Vue splash (if visible after mount) shows the same version text