### PR TITLE
Solicitar asiento message

### DIFF
--- a/src/components/views/Trip.view.test.js
+++ b/src/components/views/Trip.view.test.js
@@ -5,6 +5,23 @@ import path from 'node:path';
 const viewPath = path.resolve(__dirname, 'Trip.vue');
 const viewSource = fs.readFileSync(viewPath, 'utf8');
 
+describe('Trip.vue passenger message carpoodatos flow', () => {
+    it('closes the request-seat modal before showing the pricing hint', () => {
+        expect(viewSource).toContain('resolveRequestSeatModalConfirm');
+        expect(viewSource).toContain('shouldShowPricingHint');
+        expect(viewSource).toMatch(
+            /shouldShowPricingHint\([\s\S]*?\)[\s\S]*?this\.showModalRequestSeat = false;[\s\S]*?this\.showModalPricing = true;/
+        );
+    });
+
+    it('closes carpoodatos modals before opening the trip conversation', () => {
+        expect(viewSource).toContain('resolveOpenConversationModalState');
+        expect(viewSource).toMatch(
+            /resolveOpenConversationModalState\(\)[\s\S]*?this\.toUserMessages\(this\.trip\.user\);/
+        );
+    });
+});
+
 describe('Trip.vue driver seat requests warning', () => {
     it('shows a warning link to my-trips when the driver has pending seat requests', () => {
         expect(viewSource).toContain('shouldShowTripSeatRequestsWarning');

--- a/src/components/views/Trip.view.test.js
+++ b/src/components/views/Trip.view.test.js
@@ -16,8 +16,16 @@ describe('Trip.vue passenger message carpoodatos flow', () => {
 
     it('closes carpoodatos modals before opening the trip conversation', () => {
         expect(viewSource).toContain('resolveOpenConversationModalState');
+        expect(viewSource).toContain('closeCarpoodatosModals');
         expect(viewSource).toMatch(
-            /resolveOpenConversationModalState\(\)[\s\S]*?this\.toUserMessages\(this\.trip\.user\);/
+            /closeCarpoodatosModals\(\)[\s\S]*?this\.toUserMessages\(this\.trip\.user\);/
+        );
+    });
+
+    it('uses the pricing modal confirm flow when forcing message navigation', () => {
+        expect(viewSource).toContain('resolvePricingModalConfirm');
+        expect(viewSource).toMatch(
+            /toMessageForce\(\)[\s\S]*?resolvePricingModalConfirm\(\)[\s\S]*?this\.toMessages\(true\);/
         );
     });
 });

--- a/src/components/views/Trip.vue
+++ b/src/components/views/Trip.vue
@@ -384,6 +384,7 @@ import dialogs from '../../services/dialogs.js';
 import { shouldShowTripSeatRequestsWarning } from '../../utils/tripSeatRequestsWarning.js';
 import {
     resolveOpenConversationModalState,
+    resolvePricingModalConfirm,
     resolveRequestSeatModalConfirm,
     shouldShowPricingHint
 } from '../../utils/tripPassengerMessageFlow.js';
@@ -578,7 +579,19 @@ export default {
                     }
                 });
         },
+        closeCarpoodatosModals() {
+            const modalState = resolveOpenConversationModalState();
+            this.showModalRequestSeat = modalState.showRequestSeatModal;
+            this.showModalPricing = modalState.showPricingModal;
+        },
         toMessageForce() {
+            const flow = resolvePricingModalConfirm();
+            if (flow.closeRequestSeatModal) {
+                this.showModalRequestSeat = false;
+            }
+            if (flow.closePricingModal) {
+                this.showModalPricing = false;
+            }
             this.toMessages(true);
         },
 
@@ -615,9 +628,7 @@ export default {
             }
 
             if (this.profileComplete()) {
-                const modalState = resolveOpenConversationModalState();
-                this.showModalRequestSeat = modalState.showRequestSeatModal;
-                this.showModalPricing = modalState.showPricingModal;
+                this.closeCarpoodatosModals();
                 this.toUserMessages(this.trip.user);
             }
         },

--- a/src/components/views/Trip.vue
+++ b/src/components/views/Trip.vue
@@ -382,6 +382,11 @@ import modal from '../Modal';
 import dayjs from '../../dayjs';
 import dialogs from '../../services/dialogs.js';
 import { shouldShowTripSeatRequestsWarning } from '../../utils/tripSeatRequestsWarning.js';
+import {
+    resolveOpenConversationModalState,
+    resolveRequestSeatModalConfirm,
+    shouldShowPricingHint
+} from '../../utils/tripPassengerMessageFlow.js';
 import TripLocation from '../elements/TripLocation';
 import TripDriver from '../elements/TripDriver';
 import TripDate from '../elements/TripDate';
@@ -588,25 +593,32 @@ export default {
                 });
             }
             if (
-                this.user.do_not_alert_pricing ||
-                this.config.disable_user_hints ||
-                force
+                shouldShowPricingHint({
+                    user: this.user,
+                    config: this.config,
+                    force
+                })
             ) {
-                if (this.acceptPassengerValue) {
-                    let data = {
-                        property: 'do_not_alert_request_seat',
-                        value: 1
-                    };
-                    this.changeProperty(data).then(() => {
-                        console.log('do not alert success');
-                    });
-                }
-
-                if (this.profileComplete()) {
-                    this.toUserMessages(this.trip.user);
-                }
-            } else {
+                this.showModalRequestSeat = false;
                 this.showModalPricing = true;
+                return;
+            }
+
+            if (this.acceptPassengerValue) {
+                let data = {
+                    property: 'do_not_alert_request_seat',
+                    value: 1
+                };
+                this.changeProperty(data).then(() => {
+                    console.log('do not alert success');
+                });
+            }
+
+            if (this.profileComplete()) {
+                const modalState = resolveOpenConversationModalState();
+                this.showModalRequestSeat = modalState.showRequestSeatModal;
+                this.showModalPricing = modalState.showPricingModal;
+                this.toUserMessages(this.trip.user);
             }
         },
 
@@ -686,7 +698,19 @@ export default {
             }
             if (this.profileComplete()) {
                 if (this.config.module_coordinate_by_message) {
-                    this.toMessages();
+                    const flow = resolveRequestSeatModalConfirm({
+                        moduleCoordinateByMessage: true,
+                        user: this.user,
+                        config: this.config
+                    });
+                    if (flow.closeRequestSeatModal) {
+                        this.showModalRequestSeat = false;
+                    }
+                    if (flow.showPricingModal) {
+                        this.showModalPricing = true;
+                    } else if (flow.openConversation) {
+                        this.toMessages(true);
+                    }
                     return;
                 }
                 this.sending.requestAction = true;

--- a/src/utils/tripPassengerMessageFlow.js
+++ b/src/utils/tripPassengerMessageFlow.js
@@ -2,10 +2,10 @@ export function shouldShowPricingHint({ user, config, force = false }) {
     if (force) {
         return false;
     }
-    if (config?.disable_user_hints) {
+    if (config?.['disable_user_hints']) {
         return false;
     }
-    if (user?.do_not_alert_pricing) {
+    if (user?.['do_not_alert_pricing']) {
         return false;
     }
     return true;

--- a/src/utils/tripPassengerMessageFlow.js
+++ b/src/utils/tripPassengerMessageFlow.js
@@ -1,0 +1,51 @@
+export function shouldShowPricingHint({ user, config, force = false }) {
+    if (force) {
+        return false;
+    }
+    if (config?.disable_user_hints) {
+        return false;
+    }
+    if (user?.do_not_alert_pricing) {
+        return false;
+    }
+    return true;
+}
+
+export function resolveRequestSeatModalConfirm({
+    moduleCoordinateByMessage,
+    user,
+    config
+}) {
+    if (!moduleCoordinateByMessage) {
+        return {
+            closeRequestSeatModal: true,
+            showPricingModal: false,
+            openConversation: false,
+            makeSeatRequest: true
+        };
+    }
+
+    const showPricingModal = shouldShowPricingHint({ user, config });
+
+    return {
+        closeRequestSeatModal: true,
+        showPricingModal,
+        openConversation: !showPricingModal,
+        makeSeatRequest: false
+    };
+}
+
+export function resolvePricingModalConfirm() {
+    return {
+        closeRequestSeatModal: true,
+        closePricingModal: true,
+        openConversation: true
+    };
+}
+
+export function resolveOpenConversationModalState() {
+    return {
+        showRequestSeatModal: false,
+        showPricingModal: false
+    };
+}

--- a/src/utils/tripPassengerMessageFlow.test.js
+++ b/src/utils/tripPassengerMessageFlow.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import {
+    resolveOpenConversationModalState,
+    resolvePricingModalConfirm,
+    resolveRequestSeatModalConfirm,
+    shouldShowPricingHint
+} from './tripPassengerMessageFlow.js';
+
+describe('tripPassengerMessageFlow', () => {
+    it('shows the pricing hint after confirming the request-seat carpoodatos modal', () => {
+        const result = resolveRequestSeatModalConfirm({
+            moduleCoordinateByMessage: true,
+            user: { do_not_alert_pricing: false },
+            config: { disable_user_hints: false }
+        });
+
+        expect(result.closeRequestSeatModal).toBe(true);
+        expect(result.showPricingModal).toBe(true);
+        expect(result.openConversation).toBe(false);
+    });
+
+    it('opens the conversation after confirming the pricing carpoodatos modal', () => {
+        const result = resolvePricingModalConfirm();
+
+        expect(result.closeRequestSeatModal).toBe(true);
+        expect(result.closePricingModal).toBe(true);
+        expect(result.openConversation).toBe(true);
+    });
+
+    it('skips the pricing hint and opens the conversation when hints were dismissed', () => {
+        const result = resolveRequestSeatModalConfirm({
+            moduleCoordinateByMessage: true,
+            user: { do_not_alert_pricing: true },
+            config: { disable_user_hints: false }
+        });
+
+        expect(result.closeRequestSeatModal).toBe(true);
+        expect(result.showPricingModal).toBe(false);
+        expect(result.openConversation).toBe(true);
+    });
+
+    it('closes all carpoodatos modals before opening the conversation', () => {
+        expect(resolveOpenConversationModalState()).toEqual({
+            showRequestSeatModal: false,
+            showPricingModal: false
+        });
+    });
+
+    it('does not show the pricing hint when force is true', () => {
+        expect(
+            shouldShowPricingHint({
+                user: { do_not_alert_pricing: false },
+                config: { disable_user_hints: false },
+                force: true
+            })
+        ).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes the trip detail flow where a passenger clicks **Enviar mensaje**, sees two Carpoodatos modals, and the second **Enviar mensaje** does nothing instead of opening the conversation with the driver (where they can **Solicitar asiento**).

## Cause

When `module_coordinate_by_message` is enabled, confirming the first Carpoodatos modal (`showModalRequestSeat`) called `toMessages()` without closing it. That left both modals open at once. Neither modal was closed before navigating to the conversation, so the second confirm action appeared broken.

## Fix (frontend)

- Extract `tripPassengerMessageFlow.js` with unit tests for the modal sequence
- Close the request-seat modal before showing the pricing hint
- Close all Carpoodatos modals before calling `toUserMessages()` / navigating to `conversation-chat`
- Refactor `Trip.vue` to use `closeCarpoodatosModals()` and `resolvePricingModalConfirm()` in `toMessageForce()`

## Test plan

- [x] Unit tests: `tripPassengerMessageFlow.test.js`, `Trip.view.test.js`
- [x] Frontend lint (`npm run lint`)
- [x] Full frontend unit suite (`npm run test:unit -- --run`)
- [x] Backend test suite (`php artisan test`)
- [ ] Manual: on trip detail as a non-owner passenger, click **Enviar mensaje** → confirm first Carpoodatos → confirm second → should land on conversation with driver and **Solicitar asiento** available