### PR TITLE
Splash tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,48 +39,9 @@
    integrity="sha512-Rksm5RenBEKSKFjgI3a41vrjkw4EVPlJ3+OiI65vTjIdo9brlAacEuKOiQ5OFh7cOI1bkDwLqdLw3Zg0cRJAAQ=="
    crossorigin=""/>
    <link rel="stylesheet" href="https://unpkg.com/leaflet-routing-machine@latest/dist/leaflet-routing-machine.css" />
-    <style>
-      .bootstrap-splash-screen {
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background-color: #FFFFFF;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        z-index: 9999;
-      }
-
-      .bootstrap-splash-image {
-        width: 100%;
-        height: 100%;
-        object-fit: contain;
-        max-width: 100%;
-        max-height: 100%;
-      }
-
-      .bootstrap-splash-version {
-        position: absolute;
-        bottom: 20px;
-        left: 20px;
-        color: #999;
-        font-size: 12px;
-        font-family: Arial, sans-serif;
-      }
-    </style>
   </head>
   <body>
     <div id="fb-root"></div>
-    <div id="bootstrap-splash" class="bootstrap-splash-screen">
-      <img
-        src="%BASE_URL%img/splash-android-1280x1920.png"
-        alt="Carpoolear"
-        class="bootstrap-splash-image"
-      />
-      <div id="bootstrap-splash-version" class="bootstrap-splash-version"></div>
-    </div>
     <div id="app">
 
     </div>

--- a/src/App.splash.test.js
+++ b/src/App.splash.test.js
@@ -21,9 +21,9 @@ describe('App custom splash', () => {
     it('keeps splash enabled by default for the public app', () => {
         expect(appSource).toMatch(/showCustomSplash:\s*true/);
         expect(appSource).toContain('class="custom-splash-screen"');
-        expect(appSource).toContain('getRemainingSplashMs');
+        expect(appSource).toContain('CUSTOM_SPLASH_DISMISS_MS');
         expect(appSource).toMatch(
-            /setTimeout\s*\([\s\S]*showCustomSplash\s*=\s*false[\s\S]*getRemainingSplashMs/
+            /setTimeout\s*\([\s\S]*showCustomSplash\s*=\s*false[\s\S]*CUSTOM_SPLASH_DISMISS_MS/
         );
     });
 
@@ -43,31 +43,26 @@ describe('App custom splash', () => {
         expect(appSource).toContain('class="splash-version"');
         expect(appSource).toContain('formatSplashVersionText');
         expect(appSource).toContain('resolveSplashVersion');
+        expect(appSource).toContain('SPLASH_WEB_BUILD_NUMBER');
+    });
+
+    it('uses a single vue splash overlay without bootstrap handoff', () => {
+        expect(appSource).not.toContain('hideBootstrapSplash');
+        expect(appSource).not.toContain('getRemainingSplashMs');
+        expect(appSource).not.toContain('__customSplashStartedAt');
     });
 });
 
-describe('index.html bootstrap splash', () => {
-    it('shows splash immediately on cold page load before Vue mounts', () => {
-        expect(indexSource).toContain('id="bootstrap-splash"');
-        expect(indexSource).toContain('splash-android-1280x1920.png');
-        expect(indexSource).toContain('bootstrap-splash-screen');
-    });
-
-    it('includes a bootstrap version label for the splash overlay', () => {
-        expect(indexSource).toContain('id="bootstrap-splash-version"');
-        expect(indexSource).toContain('bootstrap-splash-version');
+describe('index.html splash', () => {
+    it('does not render a duplicate bootstrap splash before Vue mounts', () => {
+        expect(indexSource).not.toContain('id="bootstrap-splash"');
+        expect(indexSource).not.toContain('bootstrap-splash-screen');
+        expect(indexSource).not.toContain('bootstrap-splash-image');
     });
 });
 
-describe('main.js bootstrap splash', () => {
-    it('initializes bootstrap splash before system-ready', () => {
-        expect(mainSource).toContain('initBootstrapSplash');
-        expect(mainSource.indexOf('initBootstrapSplash')).toBeLessThan(
-            mainSource.indexOf("bus.on('system-ready'")
-        );
-    });
-
-    it('passes native platform flag when initializing bootstrap splash', () => {
-        expect(mainSource).toContain('isNativePlatform: Capacitor.isNativePlatform()');
+describe('main.js splash', () => {
+    it('does not initialize a bootstrap splash before system-ready', () => {
+        expect(mainSource).not.toContain('initBootstrapSplash');
     });
 });

--- a/src/App.vue
+++ b/src/App.vue
@@ -54,12 +54,12 @@ import { Capacitor } from '@capacitor/core';
 import { AppUpdate } from '@capawesome/capacitor-app-update';
 import { compareAndroidVersion, compareSemver } from './utils/versionCompare';
 import {
+    CUSTOM_SPLASH_DISMISS_MS,
     formatSplashVersionText,
-    getRemainingSplashMs,
-    hideBootstrapSplash,
     isAdminAppUrl,
     isCustomSplashVisible,
-    resolveSplashVersion
+    resolveSplashVersion,
+    SPLASH_WEB_BUILD_NUMBER
 } from './utils/customSplash';
 import footerApp from './components/sections/FooterApp.vue';
 import headerApp from './components/sections/HeaderApp.vue';
@@ -164,19 +164,13 @@ export default {
         }
 
         if (isAdminAppUrl(this.$route)) {
-            hideBootstrapSplash();
             this.showCustomSplash = false;
             return;
         }
 
-        hideBootstrapSplash();
-
         setTimeout(() => {
             this.showCustomSplash = false;
-        }, getRemainingSplashMs(
-            performance.now(),
-            window.__customSplashStartedAt
-        ));
+        }, CUSTOM_SPLASH_DISMISS_MS);
     },
     computed: {
         // Same version we send in X-App-Version header for all requests (network.js getHeader)
@@ -187,7 +181,8 @@ export default {
                     windowAppVersion:
                         typeof window !== 'undefined' ? window.appVersion : null
                 }),
-                isNativePlatform: Capacitor.isNativePlatform()
+                isNativePlatform: Capacitor.isNativePlatform(),
+                webBuildNumber: SPLASH_WEB_BUILD_NUMBER
             });
         },
         ...mapState(useCordovaStore, {
@@ -294,9 +289,7 @@ export default {
         },
         '$route'(to) {
             if (isAdminAppUrl(to)) {
-                hideBootstrapSplash();
                 this.showCustomSplash = false;
-                window.__customSplashStartedAt = null;
             }
         },
         appConfig(value) {

--- a/src/main.js
+++ b/src/main.js
@@ -36,8 +36,6 @@ import bus from './services/bus-event';
 import { DebugApi } from './services/api';
 import { init as initDebugLogger } from './services/debug';
 import { installPrototypes } from './prototypes';
-import { initBootstrapSplash } from './utils/customSplash';
-
 // Capacitor plugins
 import { StatusBar, Style } from '@capacitor/status-bar';
 import { SplashScreen } from '@capacitor/splash-screen';
@@ -50,10 +48,6 @@ const debugApi = new DebugApi();
 
 // Initialize debug logger: clear logs on app init, patch console if debug mode enabled
 initDebugLogger();
-
-initBootstrapSplash({
-    isNativePlatform: Capacitor.isNativePlatform()
-});
 
 // Initialize Capacitor plugins
 const initializeCapacitorPlugins = async () => {

--- a/src/utils/customSplash.js
+++ b/src/utils/customSplash.js
@@ -1,6 +1,5 @@
 export const CUSTOM_SPLASH_DISMISS_MS = 3000;
 export const SPLASH_WEB_BUILD_NUMBER = 116;
-export const BOOTSTRAP_SPLASH_VERSION_ID = 'bootstrap-splash-version';
 
 export function formatSplashVersionText({
     version,
@@ -26,26 +25,6 @@ export function resolveSplashVersion({ appVersionInfo, windowAppVersion }) {
     return '0';
 }
 
-export function updateBootstrapSplashVersion(
-    doc,
-    { version, isNativePlatform = false, webBuildNumber = SPLASH_WEB_BUILD_NUMBER }
-) {
-    if (!doc) {
-        return;
-    }
-
-    const versionEl = doc.getElementById(BOOTSTRAP_SPLASH_VERSION_ID);
-    if (!versionEl) {
-        return;
-    }
-
-    versionEl.textContent = formatSplashVersionText({
-        version,
-        isNativePlatform,
-        webBuildNumber
-    });
-}
-
 export function isAdminAppUrl(location) {
     if (!location) {
         return false;
@@ -68,61 +47,4 @@ export function isCustomSplashVisible({ location, showCustomSplash }) {
     }
 
     return Boolean(showCustomSplash);
-}
-
-export function getRemainingSplashMs(
-    now,
-    startedAt,
-    dismissMs = CUSTOM_SPLASH_DISMISS_MS
-) {
-    if (startedAt == null) {
-        return 0;
-    }
-
-    return Math.max(0, dismissMs - (now - startedAt));
-}
-
-export function hideBootstrapSplash(doc = typeof document !== 'undefined' ? document : null) {
-    if (!doc) {
-        return;
-    }
-
-    const bootstrapSplash = doc.getElementById('bootstrap-splash');
-    if (bootstrapSplash) {
-        bootstrapSplash.remove();
-    }
-}
-
-export function initBootstrapSplash({
-    location = typeof window !== 'undefined' ? window.location : null,
-    doc = typeof document !== 'undefined' ? document : null,
-    now = typeof performance !== 'undefined' ? performance.now() : 0,
-    windowAppVersion = typeof window !== 'undefined' ? window.appVersion : null,
-    isNativePlatform = false,
-    setStartedAt = (value) => {
-        if (typeof window !== 'undefined') {
-            window.__customSplashStartedAt = value;
-        }
-    },
-    scheduleTimeout = (fn, delay) => setTimeout(fn, delay)
-} = {}) {
-    if (isAdminAppUrl(location)) {
-        hideBootstrapSplash(doc);
-        setStartedAt(null);
-        return { skipped: true, startedAt: null };
-    }
-
-    updateBootstrapSplashVersion(doc, {
-        version: resolveSplashVersion({ windowAppVersion }),
-        isNativePlatform
-    });
-
-    const startedAt = now;
-    setStartedAt(startedAt);
-
-    scheduleTimeout(() => {
-        hideBootstrapSplash(doc);
-    }, getRemainingSplashMs(now, startedAt));
-
-    return { skipped: false, startedAt };
 }

--- a/src/utils/customSplash.test.js
+++ b/src/utils/customSplash.test.js
@@ -1,15 +1,11 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
     CUSTOM_SPLASH_DISMISS_MS,
     formatSplashVersionText,
-    getRemainingSplashMs,
-    hideBootstrapSplash,
-    initBootstrapSplash,
     isAdminAppUrl,
     isCustomSplashVisible,
     resolveSplashVersion,
-    SPLASH_WEB_BUILD_NUMBER,
-    updateBootstrapSplashVersion
+    SPLASH_WEB_BUILD_NUMBER
 } from './customSplash.js';
 
 describe('formatSplashVersionText', () => {
@@ -49,22 +45,6 @@ describe('resolveSplashVersion', () => {
                 windowAppVersion: '3.2.5'
             })
         ).toBe('3.2.5');
-    });
-});
-
-describe('updateBootstrapSplashVersion', () => {
-    it('writes version text into the bootstrap splash label', () => {
-        const versionEl = { textContent: '' };
-        const doc = {
-            getElementById: vi.fn((id) => (id === 'bootstrap-splash-version' ? versionEl : null))
-        };
-
-        updateBootstrapSplashVersion(doc, {
-            version: '3.2.5',
-            isNativePlatform: false
-        });
-
-        expect(versionEl.textContent).toBe('Version 3.2.5 - build 116');
     });
 });
 
@@ -128,97 +108,6 @@ describe('isCustomSplashVisible', () => {
                 showCustomSplash: false
             })
         ).toBe(false);
-    });
-});
-
-describe('getRemainingSplashMs', () => {
-    it('counts down from page load so public users keep the full splash window', () => {
-        expect(getRemainingSplashMs(2500, 0)).toBe(500);
-        expect(getRemainingSplashMs(4000, 0)).toBe(0);
-        expect(getRemainingSplashMs(1000, 500)).toBe(2500);
-    });
-
-    it('returns zero when splash was skipped', () => {
-        expect(getRemainingSplashMs(1000, null)).toBe(0);
-    });
-});
-
-describe('hideBootstrapSplash', () => {
-    it('removes the bootstrap splash element', () => {
-        const bootstrapSplash = { remove: vi.fn() };
-        const doc = {
-            getElementById: vi.fn(() => bootstrapSplash)
-        };
-
-        hideBootstrapSplash(doc);
-
-        expect(doc.getElementById).toHaveBeenCalledWith('bootstrap-splash');
-        expect(bootstrapSplash.remove).toHaveBeenCalled();
-    });
-});
-
-describe('initBootstrapSplash', () => {
-    it('shows bootstrap splash immediately for public routes', () => {
-        const startedAtValues = [];
-        const timeouts = [];
-        const versionEl = { textContent: '' };
-        const doc = {
-            getElementById: vi.fn((id) => (id === 'bootstrap-splash-version' ? versionEl : null))
-        };
-
-        const result = initBootstrapSplash({
-            location: { pathname: '/trips', hash: '' },
-            doc,
-            now: 100,
-            windowAppVersion: '3.2.5',
-            isNativePlatform: false,
-            setStartedAt: (value) => startedAtValues.push(value),
-            scheduleTimeout: (fn, delay) => {
-                timeouts.push({ fn, delay });
-                return delay;
-            }
-        });
-
-        expect(result.skipped).toBe(false);
-        expect(startedAtValues).toEqual([100]);
-        expect(versionEl.textContent).toBe('Version 3.2.5 - build 116');
-        expect(timeouts).toEqual([
-            expect.objectContaining({ delay: CUSTOM_SPLASH_DISMISS_MS })
-        ]);
-    });
-
-    it('skips bootstrap splash for admin URLs', () => {
-        const bootstrapSplash = { remove: vi.fn() };
-        const startedAtValues = [];
-
-        const result = initBootstrapSplash({
-            location: { pathname: '/admin/users', hash: '' },
-            doc: {
-                getElementById: () => bootstrapSplash
-            },
-            now: 100,
-            setStartedAt: (value) => startedAtValues.push(value),
-            scheduleTimeout: vi.fn()
-        });
-
-        expect(result.skipped).toBe(true);
-        expect(bootstrapSplash.remove).toHaveBeenCalled();
-        expect(startedAtValues).toEqual([null]);
-    });
-
-    it('skips bootstrap splash for hash-mode admin URLs', () => {
-        const bootstrapSplash = { remove: vi.fn() };
-
-        const result = initBootstrapSplash({
-            location: { pathname: '/', hash: '#/admin/users' },
-            doc: { getElementById: () => bootstrapSplash },
-            now: 100,
-            setStartedAt: () => {},
-            scheduleTimeout: vi.fn()
-        });
-
-        expect(result.skipped).toBe(true);
-        expect(bootstrapSplash.remove).toHaveBeenCalled();
     });
 });
 


### PR DESCRIPTION
## Summary

Restore the single Vue splash overlay that worked before recent splash changes, while keeping the admin-route skip (`/admin` URLs do not show the splash).

## Cause

Recent splash work introduced a duplicate bootstrap splash in `index.html` that handed off to the Vue overlay on mount. That caused:
- **Image stretch flash**: bootstrap image removed → Vue image reloaded via `$publicImg()` → brief wrong sizing before CSS settled
- **Missing build number**: version text lived on the bootstrap layer, which was removed immediately when Vue mounted

## Fix (frontend)

- Remove bootstrap splash from `index.html` and `initBootstrapSplash` from `main.js`
- Restore simple `CUSTOM_SPLASH_DISMISS_MS` (3s) timer in `App.vue`
- Keep `isCustomSplashVisible` / `isAdminAppUrl` so splash only shows on non-`/admin` routes
- Restore `splashVersionText` with `formatSplashVersionText` and explicit `SPLASH_WEB_BUILD_NUMBER` on web (`Version X.Y.Z - build 116`)
- Remove unused bootstrap helpers from `customSplash.js`


## Test plan

- [x] Frontend lint (`npm run lint`)
- [x] Frontend unit tests (`npm run test:unit -- --run`) — 868 passed
- [x] Backend tests (`composer test`) — 3209 passed
- [ ] Manual: open public route — splash shows for ~3s with version + build number, image not stretched
- [ ] Manual: open `/admin/*` route — no splash overlay