### PR TITLE
Accept jpeg

### DIFF
--- a/src/components/Uploadfile.vue
+++ b/src/components/Uploadfile.vue
@@ -1,15 +1,20 @@
 <template>
-    <input ref="input" type="file" @change="onFileChange" v-show="false" accept="image/*" />
+    <input ref="input" type="file" @change="onFileChange" v-show="false" :accept="imageUploadAccept" />
 </template>
 
 <script>
 import { Capacitor } from '@capacitor/core';
+import {
+    IMAGE_UPLOAD_ACCEPT,
+    normalizeCapacitorImageFormat
+} from '../utils/imageUpload';
 
 export default {
     name: 'uploadfile',
     data() {
         return {
-            isNative: false
+            isNative: false,
+            imageUploadAccept: IMAGE_UPLOAD_ACCEPT
         };
     },
     mounted() {
@@ -40,7 +45,7 @@ export default {
 
                 if (image && image.base64String) {
                     // Format: data:image/jpeg;base64,{base64String}
-                    const imageData = `data:image/${image.format || 'jpeg'};base64,${image.base64String}`;
+                    const imageData = `data:image/${normalizeCapacitorImageFormat(image.format)};base64,${image.base64String}`;
                     const data = {};
                     data[this.name] = imageData;
                     this.$emit('change', data);

--- a/src/components/sections/ManualIdentityValidation.vue
+++ b/src/components/sections/ManualIdentityValidation.vue
@@ -161,7 +161,7 @@
                             </label>
                             <input
                                 type="file"
-                                accept="image/jpeg,image/png"
+                                :accept="imageUploadAccept"
                                 ref="frontInput"
                                 @change="onFileChange($event, 'front')"
                                 required
@@ -175,7 +175,7 @@
                             </label>
                             <input
                                 type="file"
-                                accept="image/jpeg,image/png"
+                                :accept="imageUploadAccept"
                                 ref="backInput"
                                 @change="onFileChange($event, 'back')"
                                 required
@@ -189,7 +189,7 @@
                             </label>
                             <input
                                 type="file"
-                                accept="image/jpeg,image/png"
+                                :accept="imageUploadAccept"
                                 ref="selfieInput"
                                 @change="onFileChange($event, 'selfie')"
                                 required
@@ -225,6 +225,10 @@ import {
     getManualValidationUploadWarningKey,
     MANUAL_VALIDATION_UPLOAD_WARNING_STYLE
 } from '../../utils/manualValidationUploadWarning';
+import {
+    IMAGE_UPLOAD_ACCEPT,
+    filterAllowedImageUploads
+} from '../../utils/imageUpload';
 
 export default {
     name: 'ManualIdentityValidation',
@@ -248,7 +252,8 @@ export default {
                 front: null,
                 back: null,
                 selfie: null
-            }
+            },
+            imageUploadAccept: IMAGE_UPLOAD_ACCEPT
         };
     },
     computed: {
@@ -406,8 +411,8 @@ export default {
             }
         },
         onFileChange(event, type) {
-            const file = event.target.files && event.target.files[0];
-            this.files[type] = file || null;
+            const file = filterAllowedImageUploads(event.target.files || [], 1)[0] || null;
+            this.files[type] = file;
         },
         submitImages() {
             if (!this.requestId || !this.files.front || !this.files.back || !this.files.selfie) {

--- a/src/components/sections/UpdateProfile.vue
+++ b/src/components/sections/UpdateProfile.vue
@@ -356,6 +356,7 @@
                             type="file"
                             id="driver_documentation"
                             multiple
+                            :accept="imageUploadAccept"
                             @change="onDriverDocumentChange"
                         />
                         <p class="help-block">
@@ -651,6 +652,10 @@ import modal from '../Modal';
 import { UserApi } from '../../services/api';
 import { getApiErrorMessage } from '../../utils/apiErrors.js';
 import { normalizeFacebookProfileUrl } from '../../utils/facebookProfileUrl.js';
+import {
+    IMAGE_UPLOAD_ACCEPT,
+    filterAllowedImageUploads
+} from '../../utils/imageUpload';
 
 class Error {
     constructor(state = false, message = '') {
@@ -689,6 +694,7 @@ export default {
             showChangePassword: false,
             showBeDriver: false,
             driverFiles: null,
+            imageUploadAccept: IMAGE_UPLOAD_ACCEPT,
             banks: [],
             accountTypes: [],
             showModalDeleteAccount: false,
@@ -844,9 +850,8 @@ export default {
                 });
         },
         onDriverDocumentChange(event) {
-            if (event.target.files) {
-                this.driverFiles = event.target.files;
-            }
+            const files = filterAllowedImageUploads(event.target.files);
+            this.driverFiles = files.length ? files : null;
         },
         dateChange(value) {
             this.birthdayAnswer = value;

--- a/src/components/views/AdminSupportTicketDetail.vue
+++ b/src/components/views/AdminSupportTicketDetail.vue
@@ -83,7 +83,7 @@
                 resizable
                 :class="supportTicketReplyEditorClass"
             />
-            <input ref="attachmentInput" class="mtop-10" type="file" accept="image/*" multiple @change="onAttachments" />
+            <input ref="attachmentInput" class="mtop-10" type="file" :accept="imageUploadAccept" multiple @change="onAttachments" />
             <div class="reply-actions">
                 <div class="reply-actions-left">
                     <button
@@ -200,6 +200,10 @@ import {
     SUPPORT_TICKET_REPLY_EDITOR_HEIGHT,
     SUPPORT_TICKET_REPLY_EDITOR_CLASS
 } from '../../utils/supportTicketReplyEditor';
+import {
+    IMAGE_UPLOAD_ACCEPT,
+    filterAllowedImageUploads
+} from '../../utils/imageUpload';
 
 const PRIORITY_LABEL_KEYS = {
     low: 'prioridadBaja',
@@ -225,6 +229,7 @@ export default {
             ticket: null,
             attachmentBlobUrls: {},
             attachments: [],
+            imageUploadAccept: IMAGE_UPLOAD_ACCEPT,
             internalNote: '',
             ticketType: '',
             ticketTypeOptions,
@@ -366,7 +371,7 @@ export default {
             return dayjs(value).format('YYYY-MM-DD HH:mm:ss');
         },
         onAttachments(event) {
-            this.attachments = Array.from(event.target.files || []).slice(0, 3);
+            this.attachments = filterAllowedImageUploads(event.target.files, 3);
         },
         refresh() {
             return this.fetchAdminOne(this.id).then((data) => {

--- a/src/components/views/Register.vue
+++ b/src/components/views/Register.vue
@@ -232,6 +232,7 @@
                         type="file"
                         id="driver_documentation"
                         multiple
+                        :accept="imageUploadAccept"
                         @change="onDriverDocumentChange"
                     />
                     <p class="help-block">{{ $t('requisitosRegister') }}</p>
@@ -387,6 +388,10 @@ import modal from '../Modal';
 import dayjs from '../../dayjs';
 import Spinner from '../Spinner.vue';
 import { isOfflineApiError } from '../../utils/apiErrors.js';
+import {
+    IMAGE_UPLOAD_ACCEPT,
+    filterAllowedImageUploads
+} from '../../utils/imageUpload';
 let emailRegex =
     /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/;
 class Error {
@@ -432,6 +437,7 @@ export default {
             minDate: dayjs('1900-01-01').toDate(),
             showBeDriver: false,
             driverFiles: null,
+            imageUploadAccept: IMAGE_UPLOAD_ACCEPT,
             banks: [],
             accountTypes: [],
             loading: false,
@@ -611,10 +617,8 @@ export default {
             return globalError;
         },
         onDriverDocumentChange(event) {
-            console.log('file input ', event);
-            if (event.target.files) {
-                this.driverFiles = event.target.files;
-            }
+            const files = filterAllowedImageUploads(event.target.files);
+            this.driverFiles = files.length ? files : null;
         },
         changeBeDriver() {
             this.showBeDriver = !this.showBeDriver;

--- a/src/components/views/TicketDetail.vue
+++ b/src/components/views/TicketDetail.vue
@@ -48,7 +48,7 @@
                     :class="supportTicketReplyEditorClass"
                 />
                 <label class="control-label mtop-10">{{ $t('adjuntarImagenes') }}</label>
-                <input ref="attachmentInput" class="mtop-10" type="file" accept="image/*" multiple @change="onAttachments" />
+                <input ref="attachmentInput" class="mtop-10" type="file" :accept="imageUploadAccept" multiple @change="onAttachments" />
                 <p class="help-block">{{ $t('maximo3Imagenes') }}</p>
                 <button type="button" class="btn btn-primary" :disabled="replySubmitting" @click="sendReply">
                     {{ replySubmitting ? $t('enviando') : $t('responder') }}
@@ -85,6 +85,10 @@ import {
     SUPPORT_TICKET_REPLY_EDITOR_HEIGHT,
     SUPPORT_TICKET_REPLY_EDITOR_CLASS
 } from '../../utils/supportTicketReplyEditor';
+import {
+    IMAGE_UPLOAD_ACCEPT,
+    filterAllowedImageUploads
+} from '../../utils/imageUpload';
 
 const SUCCESS_TOAST_OPTIONS = { estado: 'success', duration: 2 };
 const ERROR_TOAST_OPTIONS = { estado: 'error', duration: 3 };
@@ -97,6 +101,7 @@ export default {
             ticket: null,
             attachmentBlobUrls: {},
             attachments: [],
+            imageUploadAccept: IMAGE_UPLOAD_ACCEPT,
             editorOptions: {
                 usageStatistics: false,
                 hideModeSwitch: true,
@@ -152,7 +157,7 @@ export default {
             return dayjs(value).format('YYYY-MM-DD HH:mm:ss');
         },
         onAttachments(event) {
-            this.attachments = Array.from(event.target.files || []).slice(0, 3);
+            this.attachments = filterAllowedImageUploads(event.target.files, 3);
         },
         refresh() {
             return this.fetchOne(this.id).then((data) => {

--- a/src/components/views/TicketNew.vue
+++ b/src/components/views/TicketNew.vue
@@ -29,7 +29,7 @@
                     class="mtop-10"
                 />
                 <label class="control-label mtop-10">{{ $t('adjuntosTicket') }}</label>
-                <input class="mtop-10" type="file" accept="image/*" multiple @change="onCreateAttachments" />
+                <input class="mtop-10" type="file" :accept="imageUploadAccept" multiple @change="onCreateAttachments" />
                 <p class="help-block">{{ $t('maximo3Imagenes') }}</p>
                 <button class="btn btn-primary" @click="createTicket">{{ $t('crearTicket') }}</button>
             </div>
@@ -47,6 +47,10 @@ import {
     USER_TICKET_TYPE_OPTIONS,
     USER_TICKET_TYPE_VALUES
 } from '../../utils/supportTicketTypeOptions';
+import {
+    IMAGE_UPLOAD_ACCEPT,
+    filterAllowedImageUploads
+} from '../../utils/imageUpload';
 
 export default {
     name: 'ticket-new',
@@ -57,6 +61,7 @@ export default {
                 subject: ''
             },
             attachments: [],
+            imageUploadAccept: IMAGE_UPLOAD_ACCEPT,
             ticketTypeOptions: USER_TICKET_TYPE_OPTIONS,
             editorOptions: {
                 usageStatistics: false,
@@ -70,7 +75,7 @@ export default {
             createTicketAction: 'createTicket'
         }),
         onCreateAttachments(event) {
-            this.attachments = Array.from(event.target.files || []).slice(0, 3);
+            this.attachments = filterAllowedImageUploads(event.target.files, 3);
         },
         createTicket() {
             const markdown = this.$refs.createEditor.invoke('getMarkdown');

--- a/src/utils/imageUpload.js
+++ b/src/utils/imageUpload.js
@@ -69,6 +69,12 @@ export function isAllowedImageUpload(file) {
     return isAllowedExtension(extension) || isAllowedMime(mime);
 }
 
+export function filterAllowedImageUploads(files, limit = Number.POSITIVE_INFINITY) {
+    return Array.from(files || [])
+        .filter(isAllowedImageUpload)
+        .slice(0, limit);
+}
+
 export function normalizeCapacitorImageFormat(format) {
     const normalized = String(format || 'jpeg').toLowerCase();
 

--- a/src/utils/imageUpload.js
+++ b/src/utils/imageUpload.js
@@ -1,0 +1,76 @@
+export const IMAGE_UPLOAD_ACCEPT =
+    'image/jpeg,image/jpg,image/png,image/webp,.jpg,.jpeg,.png,.webp';
+
+const JPEG_EXTENSIONS = new Set(['jpg', 'jpeg']);
+const JPEG_MIMES = new Set(['image/jpeg', 'image/jpg']);
+const ALLOWED_EXTENSIONS = new Set(['jpg', 'jpeg', 'png', 'webp', 'heic', 'heif']);
+const ALLOWED_MIMES = new Set([
+    'image/jpeg',
+    'image/jpg',
+    'image/png',
+    'image/webp',
+    'image/heic',
+    'image/heif'
+]);
+
+export function getImageFileExtension(file) {
+    const name = file && file.name ? String(file.name) : '';
+    const dotIndex = name.lastIndexOf('.');
+
+    if (dotIndex < 0) {
+        return '';
+    }
+
+    return name.slice(dotIndex + 1).toLowerCase();
+}
+
+function isAllowedExtension(extension, allowedExtensions = ALLOWED_EXTENSIONS) {
+    if (!extension) {
+        return false;
+    }
+
+    if (allowedExtensions.has(extension)) {
+        return true;
+    }
+
+    if (JPEG_EXTENSIONS.has(extension)) {
+        return [...allowedExtensions].some((allowed) => JPEG_EXTENSIONS.has(allowed));
+    }
+
+    return false;
+}
+
+function isAllowedMime(mime, allowedMimes = ALLOWED_MIMES) {
+    if (!mime) {
+        return false;
+    }
+
+    const normalized = String(mime).toLowerCase();
+
+    if (allowedMimes.has(normalized)) {
+        return true;
+    }
+
+    if (JPEG_MIMES.has(normalized)) {
+        return [...allowedMimes].some((allowed) => JPEG_MIMES.has(allowed));
+    }
+
+    return false;
+}
+
+export function isAllowedImageUpload(file) {
+    if (!file) {
+        return false;
+    }
+
+    const extension = getImageFileExtension(file);
+    const mime = file.type ? String(file.type).toLowerCase() : '';
+
+    return isAllowedExtension(extension) || isAllowedMime(mime);
+}
+
+export function normalizeCapacitorImageFormat(format) {
+    const normalized = String(format || 'jpeg').toLowerCase();
+
+    return normalized === 'jpg' ? 'jpeg' : normalized;
+}

--- a/src/utils/imageUpload.test.js
+++ b/src/utils/imageUpload.test.js
@@ -2,7 +2,9 @@ import { describe, it, expect } from 'vitest';
 import {
     IMAGE_UPLOAD_ACCEPT,
     getImageFileExtension,
-    isAllowedImageUpload
+    isAllowedImageUpload,
+    filterAllowedImageUploads,
+    normalizeCapacitorImageFormat
 } from './imageUpload';
 
 describe('imageUpload', () => {
@@ -39,5 +41,20 @@ describe('imageUpload', () => {
         const file = new File(['x'], 'notes.pdf', { type: 'application/pdf' });
 
         expect(isAllowedImageUpload(file)).toBe(false);
+    });
+
+    it('filters uploads keeping jpeg files and dropping invalid ones', () => {
+        const files = [
+            new File(['a'], 'valid.jpeg', { type: 'image/jpeg' }),
+            new File(['b'], 'invalid.pdf', { type: 'application/pdf' })
+        ];
+
+        expect(filterAllowedImageUploads(files)).toHaveLength(1);
+        expect(filterAllowedImageUploads(files)[0].name).toBe('valid.jpeg');
+    });
+
+    it('normalizes capacitor jpg format to jpeg for data URIs', () => {
+        expect(normalizeCapacitorImageFormat('jpg')).toBe('jpeg');
+        expect(normalizeCapacitorImageFormat('jpeg')).toBe('jpeg');
     });
 });

--- a/src/utils/imageUpload.test.js
+++ b/src/utils/imageUpload.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import {
+    IMAGE_UPLOAD_ACCEPT,
+    getImageFileExtension,
+    isAllowedImageUpload
+} from './imageUpload';
+
+describe('imageUpload', () => {
+    it('exposes accept attribute covering jpg and jpeg', () => {
+        expect(IMAGE_UPLOAD_ACCEPT).toContain('.jpg');
+        expect(IMAGE_UPLOAD_ACCEPT).toContain('.jpeg');
+        expect(IMAGE_UPLOAD_ACCEPT).toContain('image/jpeg');
+    });
+
+    it('reads file extension from name', () => {
+        expect(getImageFileExtension({ name: 'photo.JPEG' })).toBe('jpeg');
+        expect(getImageFileExtension({ name: 'no-extension' })).toBe('');
+    });
+
+    it('accepts .jpeg uploads when .jpg is allowed', () => {
+        const file = new File(['x'], 'scan.jpeg', { type: 'image/jpeg' });
+
+        expect(isAllowedImageUpload(file)).toBe(true);
+    });
+
+    it('accepts .jpg uploads when .jpeg is allowed', () => {
+        const file = new File(['x'], 'scan.jpg', { type: 'image/jpeg' });
+
+        expect(isAllowedImageUpload(file)).toBe(true);
+    });
+
+    it('accepts image/jpg MIME for jpeg files', () => {
+        const file = new File(['x'], 'scan.jpeg', { type: 'image/jpg' });
+
+        expect(isAllowedImageUpload(file)).toBe(true);
+    });
+
+    it('rejects non-image uploads', () => {
+        const file = new File(['x'], 'notes.pdf', { type: 'application/pdf' });
+
+        expect(isAllowedImageUpload(file)).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

Fix image uploads rejecting `.jpeg` files while `.jpg` was accepted.

### Cause
- **Backend:** `ImageUploadValidator` treated `jpg` and `jpeg` as distinct extensions. If only one was in the allowed list (or a client sent the non-standard `image/jpg` MIME), valid JPEG uploads could be rejected.
- **Frontend:** Upload inputs used inconsistent `accept` values and had no shared client-side rules, so some pickers/devices could surface `.jpeg` files without the app handling them consistently.

### Fix


**Frontend**
- Add `src/utils/imageUpload.js` with shared helpers (`IMAGE_UPLOAD_ACCEPT`, `isAllowedImageUpload`, `filterAllowedImageUploads`, `normalizeCapacitorImageFormat`).
- Use helpers in manual identity validation, support tickets, driver docs, profile photo upload, and registration.
- Normalize Capacitor camera `jpg` format to `jpeg` in data URIs.
- Update file inputs to accept both `.jpg` and `.jpeg`.

## Test plan
- [ ] Upload a `.jpeg` photo in manual identity validation
- [ ] Upload a `.jpeg` driver document on register/profile
- [ ] Attach a `.jpeg` image to a support ticket
- [ ] Upload profile photo from mobile (Capacitor camera / gallery)
- [ ] Confirm `.jpg` uploads still work in all flows