### PR TITLE
Message deleted images

### DIFF
--- a/src/components/views/AdminManualIdentityValidationReview.view.test.js
+++ b/src/components/views/AdminManualIdentityValidationReview.view.test.js
@@ -33,4 +33,11 @@ describe('AdminManualIdentityValidationReview view', () => {
         expect(viewSource).toContain(':user-id="item.user_id"');
         expect(viewSource).toContain(':user-name="item.user_name"');
     });
+
+    it('shows purged photos message only when images were deleted by admin', () => {
+        expect(viewSource).toContain('shouldShowPurgedPhotosMessage');
+        expect(viewSource).toContain('v-else-if="shouldShowPurgedPhotosMessage(item)"');
+        expect(viewSource).toContain("{{ $t('fotosPurgadas') }}");
+        expect(viewSource).not.toContain('v-else class="alert alert-info">{{ $t(\'fotosPurgadas\') }}');
+    });
 });

--- a/src/components/views/AdminManualIdentityValidationReview.vue
+++ b/src/components/views/AdminManualIdentityValidationReview.vue
@@ -110,7 +110,7 @@
                                 </div>
                             </div>
                         </div>
-                        <div v-else class="alert alert-info">{{ $t('fotosPurgadas') }}</div>
+                        <div v-else-if="shouldShowPurgedPhotosMessage(item)" class="alert alert-info">{{ $t('fotosPurgadas') }}</div>
 
                         <div v-if="item.paid" class="review-actions">
                             <h4>{{ $t('accion') }}</h4>
@@ -186,6 +186,7 @@ import { mapState } from 'pinia';
 import { useAuthStore } from '../../stores/auth';
 import dialogs from '../../services/dialogs.js';
 import { displayDniOrDash as formatDisplayDniOrDash } from '../../utils/formatDisplayDni';
+import { shouldShowPurgedPhotosMessage } from '../../utils/adminManualIdentityValidationImages.js';
 
 export default {
     name: 'AdminManualIdentityValidationReview',
@@ -218,6 +219,7 @@ export default {
         }
     },
     methods: {
+        shouldShowPurgedPhotosMessage,
         displayDniOrDash(value) {
             return formatDisplayDniOrDash(
                 value,

--- a/src/utils/adminManualIdentityValidationImages.js
+++ b/src/utils/adminManualIdentityValidationImages.js
@@ -1,0 +1,3 @@
+export function shouldShowPurgedPhotosMessage(item) {
+    return Boolean(item && !item.has_images && item.images_purged_at);
+}

--- a/src/utils/adminManualIdentityValidationImages.test.js
+++ b/src/utils/adminManualIdentityValidationImages.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { shouldShowPurgedPhotosMessage } from './adminManualIdentityValidationImages.js';
+
+describe('shouldShowPurgedPhotosMessage', () => {
+    it('returns false when photos were never submitted', () => {
+        expect(shouldShowPurgedPhotosMessage({
+            has_images: false,
+            images_purged_at: null
+        })).toBe(false);
+    });
+
+    it('returns true when an admin purged the photos', () => {
+        expect(shouldShowPurgedPhotosMessage({
+            has_images: false,
+            images_purged_at: '2026-06-15 12:00:00'
+        })).toBe(true);
+    });
+
+    it('returns false when photos are still available', () => {
+        expect(shouldShowPurgedPhotosMessage({
+            has_images: true,
+            images_purged_at: '2026-06-15 12:00:00'
+        })).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes admin manual verification detail showing "Fotos eliminadas" for paid requests where the user has not uploaded photos yet.

### Cause
The admin review view treated `!has_images` as "photos were purged", but that state also applies when payment is complete and photos were never submitted.

### Frontend
- Added `shouldShowPurgedPhotosMessage()` helper
- Updated `AdminManualIdentityValidationReview` to show "Fotos eliminadas" only when `images_purged_at` is present (not merely when `has_images` is false)

## Test plan
- [ ] Open a paid manual verification request with no submitted photos → "Fotos eliminadas" should **not** appear
- [ ] Open a request with uploaded photos → photos display normally
- [ ] Purge photos as admin → "Fotos eliminadas" appears
- [ ] User resubmits photos after purge → photos display again and purge message disappears