### PR TITLE
Changelog: link to complete list

### DIFF
--- a/src/components/ChangelogModal.view.test.js
+++ b/src/components/ChangelogModal.view.test.js
@@ -62,4 +62,16 @@ describe('ChangelogModal view', () => {
         expect(viewSource).toMatch(/changelog-modal-footer[\s\S]*flex-shrink:\s*0/);
         expect(viewSource).toMatch(/changelog-modal-dialog[\s\S]*min-height:\s*0/);
     });
+
+    it('shows a splash-only link to the full changelog in the footer', () => {
+        expect(viewSource).toContain('changelogModalViewPrevious');
+        expect(viewSource).toContain('changelog-modal-view-previous');
+        expect(viewSource).toMatch(/v-if="!navigationMode"[\s\S]*changelog-modal-view-previous/);
+        expect(viewSource).toMatch(/changelog-modal-view-previous[\s\S]*@click[^"]*="openFromNavigation"/);
+    });
+
+    it('styles the full changelog link larger than the intro text', () => {
+        expect(viewSource).toMatch(/changelog-modal-intro[\s\S]*font-size:\s*0\.95rem/);
+        expect(viewSource).toMatch(/changelog-modal-view-previous[\s\S]*font-size:\s*1\.1rem/);
+    });
 });

--- a/src/components/ChangelogModal.view.test.js
+++ b/src/components/ChangelogModal.view.test.js
@@ -74,4 +74,8 @@ describe('ChangelogModal view', () => {
         expect(viewSource).toMatch(/changelog-modal-intro[\s\S]*font-size:\s*0\.95rem/);
         expect(viewSource).toMatch(/changelog-modal-view-previous[\s\S]*font-size:\s*1\.1rem/);
     });
+
+    it('keeps the OK button right-aligned when the splash link is hidden', () => {
+        expect(viewSource).toMatch(/changelog-modal-ok[\s\S]*margin-left:\s*auto/);
+    });
 });

--- a/src/components/ChangelogModal.vue
+++ b/src/components/ChangelogModal.vue
@@ -45,6 +45,14 @@
             </div>
 
             <div class="changelog-modal-footer">
+                <a
+                    v-if="!navigationMode"
+                    href="#"
+                    class="changelog-modal-view-previous"
+                    @click.prevent="openFromNavigation"
+                >
+                    {{ $t('changelogModalViewPrevious') }}
+                </a>
                 <button type="button" class="btn btn-primary changelog-modal-ok" @click="close">
                     {{ $t('changelogModalOk') }}
                 </button>
@@ -302,10 +310,25 @@ export default {
 
 .changelog-modal-footer {
     flex-shrink: 0;
-    text-align: right;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.changelog-modal-view-previous {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #036686;
+    text-decoration: none;
+}
+
+.changelog-modal-view-previous:hover,
+.changelog-modal-view-previous:focus {
+    text-decoration: underline;
 }
 
 .changelog-modal-ok {
     min-width: 88px;
+    margin-left: auto;
 }
 </style>

--- a/src/language/changelogModalLabels.test.js
+++ b/src/language/changelogModalLabels.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import messages from './i18n';
+
+const CHANGELOG_MODAL_LABELS = {
+    arg: {
+        changelogModalViewPrevious: 'Ver cambios anteriores'
+    },
+    chl: {
+        changelogModalViewPrevious: 'Ver cambios anteriores'
+    },
+    en: {
+        changelogModalViewPrevious: 'View previous changes'
+    }
+};
+
+describe('changelog modal labels (i18n)', () => {
+    it.each(Object.entries(CHANGELOG_MODAL_LABELS))(
+        '%s locale defines the splash link to the full changelog',
+        (locale, expected) => {
+            Object.entries(expected).forEach(([key, label]) => {
+                expect(messages[locale][key]).toBe(label);
+            });
+        }
+    );
+});

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -84,6 +84,7 @@ const messages = {
         changelogModalIntro:
             'Estuvimos haciendo mejoras, te dejamos lo que cambiamos para que estés al tanto :)',
         changelogModalOk: 'OK',
+        changelogModalViewPrevious: 'Ver cambios anteriores',
         adminNavChangelog: 'Changelog',
         changelogVersion: 'Versión',
         changelogContenido: 'Contenido',
@@ -1614,6 +1615,7 @@ const messages = {
         changelogModalIntro:
             'Estuvimos haciendo mejoras, te dejamos lo que cambiamos para que estés al tanto :)',
         changelogModalOk: 'OK',
+        changelogModalViewPrevious: 'Ver cambios anteriores',
         adminNavChangelog: 'Changelog',
         changelogVersion: 'Versión',
         changelogContenido: 'Contenido',
@@ -2908,6 +2910,7 @@ const messages = {
         changelogModalIntro:
             'We have been making improvements. Here is what changed so you are up to date :)',
         changelogModalOk: 'OK',
+        changelogModalViewPrevious: 'View previous changes',
         adminNavChangelog: 'Changelog',
         changelogVersion: 'Version',
         changelogContenido: 'Content',


### PR DESCRIPTION
## Summary

- Add a **"Ver cambios anteriores"** link at the bottom of the changelog splash modal (auto-shown on new app version), linking to the full changelog history.
- Link is shown only in splash mode (`!navigationMode`); hidden when viewing the full changelog from the menu.
- Link text uses a larger font size (1.1rem) than the modal intro (0.95rem).
- i18n keys added for `arg`, `chl`, and `en`.

## Cause

Users seeing the version splash had no way to browse older changelogs without closing the modal and opening the full changelog from the profile menu.

## Fix (frontend)

- `ChangelogModal.vue`: footer link calling `openFromNavigation` to switch to the full changelog view; footer flex layout keeps the OK button right-aligned when the link is hidden.
- `i18n.js`: new `changelogModalViewPrevious` label.
- Tests: `ChangelogModal.view.test.js`, `changelogModalLabels.test.js`.


## Test plan

- [ ] Log in on a version with an unseen changelog; confirm splash shows **"Ver cambios anteriores"** in the footer.
- [ ] Click the link; confirm the modal switches to the full changelog list (all versions).
- [ ] Open full changelog from the menu; confirm the link is **not** shown.
- [ ] Confirm OK button stays right-aligned in both modes.
- [ ] Switch locale to English; confirm **"View previous changes"** appears.