### PR TITLE
Stop hidden onboarding overlay from blocking taps

### DIFF
--- a/src/components/sections/OnBoarding.vue
+++ b/src/components/sections/OnBoarding.vue
@@ -87,7 +87,11 @@ export default {
             );
         }, 600);
         document.documentElement.style.overflow = 'hidden';
-        document.body.scroll = 'no';
+        document.body.style.overflow = 'hidden';
+    },
+    beforeUnmount() {
+        document.documentElement.style.overflow = '';
+        document.body.style.overflow = '';
     },
     computed: {
         ...mapState(useAuthStore, {
@@ -149,8 +153,8 @@ export default {
             this.endActions();
         },
         endActions() {
-            document.documentElement.style.overflow = 'auto';
-            document.body.style.scroll = 'yes';
+            document.documentElement.style.overflow = '';
+            document.body.style.overflow = '';
             this.setFirstTimeAppOpenInDevice();
         }
     },

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -784,10 +784,12 @@
     background-color: #000000db;
     opacity: 0;
     padding: 10em;
+    pointer-events: none;
   }
   .on-boarding--overlay.show {
       opacity: 1;
       padding: 0;
+      pointer-events: auto;
   }
   .on-boarding--container {
       width: 100%;


### PR DESCRIPTION
## Summary

Fixes a Capacitor Android issue where the app became unresponsive after registration: users could scroll on **Editar perfil** (`#/setting/profile`) but could not tap navigation, form fields, or buttons.

## Cause

After registration, the onboarding overlay (`.on-boarding--overlay`) stayed mounted in the DOM while `on_boarding_view` was still being persisted. Once dismissed or hidden, it rendered at `opacity: 0` but kept default `pointer-events: auto`, so the full-screen layer at `z-index: 9999` continued intercepting all touches underneath.

Runtime evidence (`elementFromPoint` on touch) showed taps hitting `on-boarding--overlay` even on `profile_update`, with `onBoardingOpacity: "0"` and `onBoardingShow: false`.

## Fix (frontend)

- **`src/styles/base.css`**: Set `pointer-events: none` on the hidden onboarding overlay; only enable `pointer-events: auto` when `.show` is active.
- **`src/components/sections/OnBoarding.vue`**: Use `body.style.overflow` instead of the invalid `body.scroll` property; restore overflow on dismiss and in `beforeUnmount`.


## Test plan

- [ ] Register a new user on Android (Capacitor build via USB)
- [ ] Go to **Editar perfil** and confirm navigation, inputs, and photo upload respond to taps
- [ ] Walk through the onboarding carousel and confirm it still blocks interaction while visible
- [ ] After completing onboarding, confirm the app remains fully interactive