### PR TITLE
Fix banner in Capacitor

### DIFF
--- a/src/components/views/Trips.view.test.js
+++ b/src/components/views/Trips.view.test.js
@@ -11,6 +11,12 @@ describe('Trips.vue app banner', () => {
         expect(viewSource).toContain('showAppBanner');
         expect(viewSource).toContain('v-if="showAppBanner"');
     });
+
+    it('resolves banner image URL for Capacitor bundled host', () => {
+        expect(viewSource).toContain('bannerImageSrc');
+        expect(viewSource).toContain('resolveCapacitorBundledHostUrl');
+        expect(viewSource).toContain(':src="bannerImageSrc"');
+    });
 });
 
 describe('Trips.vue ongoing trip card', () => {

--- a/src/components/views/Trips.vue
+++ b/src/components/views/Trips.vue
@@ -7,7 +7,7 @@
                 class="banner"
                 @click.prevent="onBannerClick"
             >
-                <img alt="" :src="appConfig.banner.image" />
+                <img alt="" :src="bannerImageSrc" />
             </a>
         </template>
         <div v-show="!user && isMobile">
@@ -429,6 +429,7 @@ import {
     shouldHideDonationOnIOSCapacitor
 } from '../../services/capacitor.js';
 import { shouldShowAppBanner } from '../../utils/appBanner.js';
+import { resolveCapacitorBundledHostUrl } from '../../utils/capacitorRemoteUrl.js';
 import { splitFriendTrips } from '../../utils/splitFriendTrips.js';
 import { shouldShowSplitDonationPanel } from '../../utils/tripsSplitDonationBanner.js';
 import { readAllowPreferenceParamsFromQuery } from '../../utils/searchAdvancedFilters.js';
@@ -1033,6 +1034,13 @@ export default {
         showAppBanner() {
             const banner = this.appConfig && this.appConfig.banner;
             return shouldShowAppBanner(banner, this.user);
+        },
+        bannerImageSrc() {
+            const image =
+                this.appConfig &&
+                this.appConfig.banner &&
+                this.appConfig.banner.image;
+            return resolveCapacitorBundledHostUrl(image);
         },
         bannerHref() {
             const url =

--- a/src/utils/capacitorRemoteUrl.js
+++ b/src/utils/capacitorRemoteUrl.js
@@ -1,0 +1,33 @@
+import { Capacitor } from '@capacitor/core';
+
+/**
+ * Capacitor serves the WebView as https://<server.hostname> (e.g. carpoolear.com.ar).
+ * Absolute URLs to that host load from the bundled asset server, not production — /img/* 404s.
+ * Rewrite same-origin http(s) URLs to VITE_API_URL (www on native builds).
+ */
+export function resolveCapacitorBundledHostUrl(url) {
+    if (!url || typeof url !== 'string' || !Capacitor.isNativePlatform()) {
+        return url;
+    }
+
+    const remoteBase = import.meta.env.VITE_API_URL;
+    if (!remoteBase || typeof window === 'undefined') {
+        return url;
+    }
+
+    try {
+        const parsed = new URL(url, window.location.origin);
+        if (parsed.origin !== window.location.origin) {
+            return url;
+        }
+
+        const remoteOrigin = new URL(remoteBase).origin;
+        if (parsed.origin === remoteOrigin) {
+            return url;
+        }
+
+        return `${remoteOrigin}${parsed.pathname}${parsed.search}${parsed.hash}`;
+    } catch (_error) {
+        return url;
+    }
+}

--- a/src/utils/capacitorRemoteUrl.test.js
+++ b/src/utils/capacitorRemoteUrl.test.js
@@ -1,20 +1,13 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
-const { isNativePlatformMock } = vi.hoisted(() => ({
-    isNativePlatformMock: vi.fn(() => false)
-}));
-
 vi.mock('@capacitor/core', () => ({
     Capacitor: {
-        isNativePlatform: isNativePlatformMock
+        isNativePlatform: vi.fn(() => false)
     }
 }));
 
-import { resolveCapacitorBundledHostUrl } from './capacitorRemoteUrl.js';
-
 describe('resolveCapacitorBundledHostUrl', () => {
     beforeEach(() => {
-        isNativePlatformMock.mockReturnValue(false);
         globalThis.window = {
             location: { origin: 'https://carpoolear.com.ar' }
         };
@@ -23,16 +16,28 @@ describe('resolveCapacitorBundledHostUrl', () => {
 
     afterEach(() => {
         vi.unstubAllEnvs();
-        vi.clearAllMocks();
+        vi.resetModules();
     });
 
-    it('returns url unchanged on web', () => {
+    async function loadResolver() {
+        const { Capacitor } = await import('@capacitor/core');
+        Capacitor.isNativePlatform.mockReturnValue(false);
+        return import('./capacitorRemoteUrl.js');
+    }
+
+    it('returns url unchanged on web', async () => {
+        const { resolveCapacitorBundledHostUrl } = await loadResolver();
         const url = 'https://carpoolear.com.ar/img/banner_verificacion.png';
         expect(resolveCapacitorBundledHostUrl(url)).toBe(url);
     });
 
-    it('rewrites same-origin absolute urls on native to VITE_API_URL origin', () => {
-        isNativePlatformMock.mockReturnValue(true);
+    it('rewrites same-origin absolute urls on native to VITE_API_URL origin', async () => {
+        const { Capacitor } = await import('@capacitor/core');
+        Capacitor.isNativePlatform.mockReturnValue(true);
+        const { resolveCapacitorBundledHostUrl } = await import(
+            './capacitorRemoteUrl.js'
+        );
+
         expect(
             resolveCapacitorBundledHostUrl(
                 'https://carpoolear.com.ar/img/banner_verificacion.png'
@@ -40,8 +45,12 @@ describe('resolveCapacitorBundledHostUrl', () => {
         ).toBe('https://www.carpoolear.com.ar/img/banner_verificacion.png');
     });
 
-    it('leaves external urls unchanged on native', () => {
-        isNativePlatformMock.mockReturnValue(true);
+    it('leaves external urls unchanged on native', async () => {
+        const { Capacitor } = await import('@capacitor/core');
+        Capacitor.isNativePlatform.mockReturnValue(true);
+        const { resolveCapacitorBundledHostUrl } = await import(
+            './capacitorRemoteUrl.js'
+        );
         const url = 'https://cdn.example.com/banner.png';
         expect(resolveCapacitorBundledHostUrl(url)).toBe(url);
     });

--- a/src/utils/capacitorRemoteUrl.test.js
+++ b/src/utils/capacitorRemoteUrl.test.js
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+const { isNativePlatformMock } = vi.hoisted(() => ({
+    isNativePlatformMock: vi.fn(() => false)
+}));
+
+vi.mock('@capacitor/core', () => ({
+    Capacitor: {
+        isNativePlatform: isNativePlatformMock
+    }
+}));
+
+import { resolveCapacitorBundledHostUrl } from './capacitorRemoteUrl.js';
+
+describe('resolveCapacitorBundledHostUrl', () => {
+    beforeEach(() => {
+        isNativePlatformMock.mockReturnValue(false);
+        globalThis.window = {
+            location: { origin: 'https://carpoolear.com.ar' }
+        };
+        vi.stubEnv('VITE_API_URL', 'https://www.carpoolear.com.ar');
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+        vi.clearAllMocks();
+    });
+
+    it('returns url unchanged on web', () => {
+        const url = 'https://carpoolear.com.ar/img/banner_verificacion.png';
+        expect(resolveCapacitorBundledHostUrl(url)).toBe(url);
+    });
+
+    it('rewrites same-origin absolute urls on native to VITE_API_URL origin', () => {
+        isNativePlatformMock.mockReturnValue(true);
+        expect(
+            resolveCapacitorBundledHostUrl(
+                'https://carpoolear.com.ar/img/banner_verificacion.png'
+            )
+        ).toBe('https://www.carpoolear.com.ar/img/banner_verificacion.png');
+    });
+
+    it('leaves external urls unchanged on native', () => {
+        isNativePlatformMock.mockReturnValue(true);
+        const url = 'https://cdn.example.com/banner.png';
+        expect(resolveCapacitorBundledHostUrl(url)).toBe(url);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes the account verification image banner not appearing on Capacitor (Android/iOS) while it worked on web.

## Cause

Capacitor serves the WebView from `https://carpoolear.com.ar` (`server.hostname` in `capacitor.config.json`). The API returns banner images as absolute URLs on that same host (e.g. `https://carpoolear.com.ar/img/banner_verificacion.png`). In the native app those requests hit the **bundled asset server**, not production, so the image returns **404** and the banner looks missing.

API calls already work because they target `www.carpoolear.com.ar` via `VITE_API_URL_NATIVE`; `<img src>` did not get the same treatment.

Banner visibility logic (`shouldShowAppBanner`) was correct once remote config loaded — only the image URL was wrong on native.

## Fix (frontend)

- Add `resolveCapacitorBundledHostUrl()` to rewrite same-origin absolute URLs on native to `VITE_API_URL` (e.g. `https://www.carpoolear.com.ar`).
- Use `bannerImageSrc` computed property in `Trips.vue` instead of `appConfig.banner.image` directly.

## Test plan

- [ ] Log in on Capacitor with an unverified account; open `/trips` and confirm the verification banner image loads.
- [ ] Confirm verified accounts still do not see the verification banner.
- [ ] Confirm web `/trips` banner unchanged.
- [ ] `npx vitest run src/utils/capacitorRemoteUrl.test.js src/utils/appBanner.test.js src/components/views/Trips.view.test.js`
- [ ] `npm run lint` (frontend)