### PR TITLE
Account verification override fix

### DIFF
--- a/src/components/sections/IdentityValidation.view.test.js
+++ b/src/components/sections/IdentityValidation.view.test.js
@@ -5,6 +5,19 @@ import path from 'node:path';
 const viewPath = path.resolve(__dirname, 'IdentityValidation.vue');
 const viewSource = fs.readFileSync(viewPath, 'utf8');
 
+describe('IdentityValidation admin review note contexts', () => {
+    it('uses approval note helper in success banner', () => {
+        expect(viewSource).toContain('displayableManualApprovalReviewNote');
+        expect(viewSource).toContain('manualApprovalReviewNoteLabelKey');
+    });
+
+    it('uses rejection note helper only in rejection notice', () => {
+        expect(viewSource).toContain('displayableManualRejectionReviewNote');
+        expect(viewSource).toContain('manualRejectionReviewNoteLabelKey');
+        expect(viewSource).not.toContain(':note="displayableManualReviewNote"');
+    });
+});
+
 describe('IdentityValidation rejected manual verification', () => {
     it('passes the current user into manual rejection choice-card helper', () => {
         expect(viewSource).toContain('user: this.user');

--- a/src/components/sections/IdentityValidation.view.test.js
+++ b/src/components/sections/IdentityValidation.view.test.js
@@ -6,8 +6,8 @@ const viewPath = path.resolve(__dirname, 'IdentityValidation.vue');
 const viewSource = fs.readFileSync(viewPath, 'utf8');
 
 describe('IdentityValidation rejected manual verification', () => {
-    it('uses shared success banner helper so rejected manual flow is not hidden', () => {
-        expect(viewSource).toContain('shouldShowIdentityVerificationSuccessBanner');
+    it('passes the current user into manual rejection choice-card helper', () => {
+        expect(viewSource).toContain('user: this.user');
     });
 
     it('shows retry prompt and choice cards when manual verification was rejected', () => {

--- a/src/components/sections/IdentityValidation.view.test.js
+++ b/src/components/sections/IdentityValidation.view.test.js
@@ -33,8 +33,7 @@ describe('IdentityValidation rejected manual verification', () => {
     });
 
     it('does not render standalone in-flow review note when manual verification was rejected', () => {
-        expect(viewSource).toContain('v-if="!showManualRejectedWithChoiceCards"');
-        expect(viewSource).toContain('in-flow');
+        expect(viewSource).not.toContain('in-flow');
     });
 });
 
@@ -113,10 +112,12 @@ describe('IdentityValidation Mercado Pago ownership warning', () => {
 });
 
 describe('IdentityValidation manual admin review note', () => {
-    it('shows admin review note in success banner and main flow when present', () => {
+    it('shows admin review note in success banner and rejection notice when present', () => {
         expect(viewSource).toContain('IdentityValidationAdminReviewNote');
-        expect(viewSource).toContain('displayableManualReviewNote');
-        expect(viewSource).toContain('manualAdminReviewNoteLabelKey');
+        expect(viewSource).toContain('displayableManualApprovalReviewNote');
+        expect(viewSource).toContain('displayableManualRejectionReviewNote');
+        expect(viewSource).toContain('manualApprovalReviewNoteLabelKey');
+        expect(viewSource).toContain('manualRejectionReviewNoteLabelKey');
         expect(viewSource).toContain('manualIdentityValidationReviewNote');
     });
 

--- a/src/components/sections/IdentityValidation.vue
+++ b/src/components/sections/IdentityValidation.vue
@@ -525,7 +525,8 @@ export default {
         /** Manual docs rejected: show red banner + MP / manual choice cards. */
         showManualRejectedWithChoiceCards() {
             return isManualRejectedWithChoiceCards(this.manualStatus, {
-                manualEnabled: this.identityValidationManualEnabled
+                manualEnabled: this.identityValidationManualEnabled,
+                user: this.user
             });
         },
         manualRejectionSupportWarningKey() {

--- a/src/components/sections/IdentityValidation.vue
+++ b/src/components/sections/IdentityValidation.vue
@@ -20,8 +20,8 @@
                     {{ $t('identityVerificationSuccessEmphasis') }}
                 </p>
                 <IdentityValidationAdminReviewNote
-                    :note="displayableManualReviewNote"
-                    :label-key="manualAdminReviewNoteLabelKey"
+                    :note="displayableManualApprovalReviewNote"
+                    :label-key="manualApprovalReviewNoteLabelKey"
                 />
                 <router-link
                     :to="{ name: 'trips', params: { clearSearch: true } }"
@@ -33,12 +33,6 @@
         </div>
 
         <div v-else>
-        <IdentityValidationAdminReviewNote
-            v-if="!showManualRejectedWithChoiceCards"
-            :note="displayableManualReviewNote"
-            :label-key="manualAdminReviewNoteLabelKey"
-            in-flow
-        />
         <div class="alert alert-danger" v-if="resultMessage === 'error'">
             {{ $t('resultError') }}
         </div>
@@ -244,8 +238,8 @@
                         {{ $t('identityValidationRejectionNoticeBody') }}
                     </p>
                     <IdentityValidationAdminReviewNote
-                        :note="displayableManualReviewNote"
-                        :label-key="manualAdminReviewNoteLabelKey"
+                        :note="displayableManualRejectionReviewNote"
+                        :label-key="manualRejectionReviewNoteLabelKey"
                     />
                     <p
                         v-if="manualRejectionSupportWarningKey"
@@ -420,7 +414,8 @@ import {
     getMismatchSupportWarningKey
 } from '../../utils/identityValidationMismatchDetails';
 import {
-    getDisplayableManualReviewNote,
+    getDisplayableManualApprovalReviewNote,
+    getDisplayableManualRejectionReviewNote,
     getManualReviewNoteLabelKey
 } from '../../utils/manualIdentityValidationReviewNote';
 import { shouldShowIdentityVerificationSuccessBanner } from '../../utils/identityValidationSuccessBanner';
@@ -533,11 +528,17 @@ export default {
             if (!this.showManualRejectedWithChoiceCards) return null;
             return getManualRejectionSupportWarningKey(this.manualStatus.reject_reason);
         },
-        displayableManualReviewNote() {
-            return getDisplayableManualReviewNote(this.manualStatus);
+        displayableManualApprovalReviewNote() {
+            return getDisplayableManualApprovalReviewNote(this.manualStatus);
         },
-        manualAdminReviewNoteLabelKey() {
-            return getManualReviewNoteLabelKey(this.manualStatus?.review_status);
+        displayableManualRejectionReviewNote() {
+            return getDisplayableManualRejectionReviewNote(this.manualStatus);
+        },
+        manualApprovalReviewNoteLabelKey() {
+            return getManualReviewNoteLabelKey('approved');
+        },
+        manualRejectionReviewNoteLabelKey() {
+            return getManualReviewNoteLabelKey('rejected');
         },
         showVerificationSuccessBanner() {
             return shouldShowIdentityVerificationSuccessBanner({

--- a/src/utils/adminUserIdentityVerification.js
+++ b/src/utils/adminUserIdentityVerification.js
@@ -1,4 +1,5 @@
 import { formatAdminUserPropertyValue } from './adminUserDetailProperties';
+import { isUserIdentityVerified } from './userIdentityVerification';
 
 const IDENTITY_VERIFICATION_DETAIL_KEYS = [
     {
@@ -27,16 +28,6 @@ const METHOD_LABEL_KEYS = {
     mercado_pago: 'adminIdentityValidationMethodMercadoPago',
     manual: 'adminIdentityValidationMethodManual'
 };
-
-function isUserIdentityVerified(user) {
-    if (!user) {
-        return false;
-    }
-    if (typeof user.identity_validated === 'boolean') {
-        return user.identity_validated;
-    }
-    return Number(user.identity_validated) > 0;
-}
 
 function formatIdentityValidationMethod(type, translate) {
     if (!type) {

--- a/src/utils/identityValidationSuccessBanner.js
+++ b/src/utils/identityValidationSuccessBanner.js
@@ -16,7 +16,7 @@ export function shouldShowIdentityVerificationSuccessBanner({
     if (isManualDocsPendingAdminReview(manualStatus)) {
         return false;
     }
-    if (isManualIdentityValidationRejected(manualStatus)) {
+    if (isManualIdentityValidationRejected(manualStatus, user)) {
         return false;
     }
     if (resultMessage === 'success') {

--- a/src/utils/identityValidationSuccessBanner.test.js
+++ b/src/utils/identityValidationSuccessBanner.test.js
@@ -7,10 +7,26 @@ describe('shouldShowIdentityVerificationSuccessBanner', () => {
         identity_validated_at: '2026-06-01 10:00:00'
     };
 
-    it('returns false when manual verification was rejected even if user still looks verified', () => {
+    it('returns true when user is verified even if manual verification was previously rejected', () => {
         expect(
             shouldShowIdentityVerificationSuccessBanner({
                 user: verifiedUser,
+                manualStatus: {
+                    has_submission: true,
+                    paid: true,
+                    submitted_at: '2026-06-02 12:00:00',
+                    review_status: 'rejected',
+                    review_note: 'Prueba'
+                },
+                resultMessage: null
+            })
+        ).toBe(true);
+    });
+
+    it('returns false when manual verification was rejected and user is not verified', () => {
+        expect(
+            shouldShowIdentityVerificationSuccessBanner({
+                user: { identity_validated: false, identity_validated_at: null },
                 manualStatus: {
                     has_submission: true,
                     paid: true,

--- a/src/utils/manualIdentityValidationReviewNote.js
+++ b/src/utils/manualIdentityValidationReviewNote.js
@@ -1,9 +1,22 @@
-export function getDisplayableManualReviewNote(manualStatus) {
+export function getDisplayableManualReviewNote(manualStatus, options = {}) {
     if (!shouldDisplayManualReviewNote(manualStatus)) {
         return '';
     }
 
+    const requiredReviewStatus = options.reviewStatus;
+    if (requiredReviewStatus && manualStatus.review_status !== requiredReviewStatus) {
+        return '';
+    }
+
     return String(manualStatus.review_note).trim();
+}
+
+export function getDisplayableManualApprovalReviewNote(manualStatus) {
+    return getDisplayableManualReviewNote(manualStatus, { reviewStatus: 'approved' });
+}
+
+export function getDisplayableManualRejectionReviewNote(manualStatus) {
+    return getDisplayableManualReviewNote(manualStatus, { reviewStatus: 'rejected' });
 }
 
 export function shouldDisplayManualReviewNote(manualStatus) {

--- a/src/utils/manualIdentityValidationReviewNote.test.js
+++ b/src/utils/manualIdentityValidationReviewNote.test.js
@@ -20,6 +20,45 @@ describe('manualIdentityValidationReviewNote', () => {
         ).toBe('Documentación correcta.');
     });
 
+    it('returns empty text for rejected note outside rejection context', () => {
+        expect(
+            getDisplayableManualReviewNote(
+                {
+                    has_submission: true,
+                    review_status: 'rejected',
+                    review_note: 'Prueba'
+                },
+                { reviewStatus: 'approved' }
+            )
+        ).toBe('');
+    });
+
+    it('returns rejected note only in rejection context', () => {
+        expect(
+            getDisplayableManualReviewNote(
+                {
+                    has_submission: true,
+                    review_status: 'rejected',
+                    review_note: 'Prueba'
+                },
+                { reviewStatus: 'rejected' }
+            )
+        ).toBe('Prueba');
+    });
+
+    it('returns approved note only in success context', () => {
+        expect(
+            getDisplayableManualReviewNote(
+                {
+                    has_submission: true,
+                    review_status: 'approved',
+                    review_note: 'Todo correcto'
+                },
+                { reviewStatus: 'approved' }
+            )
+        ).toBe('Todo correcto');
+    });
+
     it('does not display note without a submission', () => {
         expect(shouldDisplayManualReviewNote({ has_submission: false, review_note: 'Hola' })).toBe(false);
         expect(shouldDisplayManualReviewNote({ has_submission: true, review_note: 'Hola' })).toBe(true);

--- a/src/utils/manualIdentityValidationReviewNote.test.js
+++ b/src/utils/manualIdentityValidationReviewNote.test.js
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
     getDisplayableManualReviewNote,
+    getDisplayableManualApprovalReviewNote,
+    getDisplayableManualRejectionReviewNote,
     getManualReviewNoteLabelKey,
     shouldDisplayManualReviewNote
 } from './manualIdentityValidationReviewNote.js';
@@ -57,6 +59,24 @@ describe('manualIdentityValidationReviewNote', () => {
                 { reviewStatus: 'approved' }
             )
         ).toBe('Todo correcto');
+    });
+
+    it('exposes context-specific helpers for approval and rejection notes', () => {
+        const rejectedStatus = {
+            has_submission: true,
+            review_status: 'rejected',
+            review_note: 'Prueba'
+        };
+        const approvedStatus = {
+            has_submission: true,
+            review_status: 'approved',
+            review_note: 'Todo correcto'
+        };
+
+        expect(getDisplayableManualRejectionReviewNote(rejectedStatus)).toBe('Prueba');
+        expect(getDisplayableManualApprovalReviewNote(rejectedStatus)).toBe('');
+        expect(getDisplayableManualApprovalReviewNote(approvedStatus)).toBe('Todo correcto');
+        expect(getDisplayableManualRejectionReviewNote(approvedStatus)).toBe('');
     });
 
     it('does not display note without a submission', () => {

--- a/src/utils/manualIdentityValidationStatus.js
+++ b/src/utils/manualIdentityValidationStatus.js
@@ -1,13 +1,29 @@
-export function isManualIdentityValidationRejected(manualStatus) {
+function isUserIdentityVerified(user) {
+    if (!user) {
+        return false;
+    }
+    if (typeof user.identity_validated === 'boolean') {
+        return user.identity_validated;
+    }
+    return Number(user.identity_validated) > 0;
+}
+
+export function isManualIdentityValidationRejected(manualStatus, user = null) {
+    if (isUserIdentityVerified(user)) {
+        return false;
+    }
     if (!manualStatus || !manualStatus.has_submission || !manualStatus.paid || !manualStatus.submitted_at) {
         return false;
     }
     return manualStatus.review_status === 'rejected';
 }
 
-export function isManualRejectedWithChoiceCards(manualStatus, { manualEnabled = true } = {}) {
+export function isManualRejectedWithChoiceCards(
+    manualStatus,
+    { manualEnabled = true, user = null } = {}
+) {
     if (!manualEnabled) {
         return false;
     }
-    return isManualIdentityValidationRejected(manualStatus);
+    return isManualIdentityValidationRejected(manualStatus, user);
 }

--- a/src/utils/manualIdentityValidationStatus.js
+++ b/src/utils/manualIdentityValidationStatus.js
@@ -1,12 +1,4 @@
-function isUserIdentityVerified(user) {
-    if (!user) {
-        return false;
-    }
-    if (typeof user.identity_validated === 'boolean') {
-        return user.identity_validated;
-    }
-    return Number(user.identity_validated) > 0;
-}
+import { isUserIdentityVerified } from './userIdentityVerification.js';
 
 export function isManualIdentityValidationRejected(manualStatus, user = null) {
     if (isUserIdentityVerified(user)) {

--- a/src/utils/manualIdentityValidationStatus.test.js
+++ b/src/utils/manualIdentityValidationStatus.test.js
@@ -16,6 +16,23 @@ describe('isManualIdentityValidationRejected', () => {
         ).toBe(true);
     });
 
+    it('returns false when user is already verified even if manual submission was rejected', () => {
+        expect(
+            isManualIdentityValidationRejected(
+                {
+                    has_submission: true,
+                    paid: true,
+                    submitted_at: '2026-06-02 12:00:00',
+                    review_status: 'rejected'
+                },
+                {
+                    identity_validated: true,
+                    identity_validated_at: '2026-06-03 10:00:00'
+                }
+            )
+        ).toBe(false);
+    });
+
     it('returns false when review is still pending', () => {
         expect(
             isManualIdentityValidationRejected({
@@ -39,6 +56,26 @@ describe('isManualRejectedWithChoiceCards', () => {
                     review_status: 'rejected'
                 },
                 { manualEnabled: false }
+            )
+        ).toBe(false);
+    });
+
+    it('returns false when user is already verified even if manual submission was rejected', () => {
+        expect(
+            isManualRejectedWithChoiceCards(
+                {
+                    has_submission: true,
+                    paid: true,
+                    submitted_at: '2026-06-02 12:00:00',
+                    review_status: 'rejected'
+                },
+                {
+                    manualEnabled: true,
+                    user: {
+                        identity_validated: true,
+                        identity_validated_at: '2026-06-03 10:00:00'
+                    }
+                }
             )
         ).toBe(false);
     });

--- a/src/utils/userIdentityVerification.js
+++ b/src/utils/userIdentityVerification.js
@@ -1,0 +1,9 @@
+export function isUserIdentityVerified(user) {
+    if (!user) {
+        return false;
+    }
+    if (typeof user.identity_validated === 'boolean') {
+        return user.identity_validated;
+    }
+    return Number(user.identity_validated) > 0;
+}


### PR DESCRIPTION
## Summary

Fixes a bug where users who were verified after a prior rejection still saw rejection state on the account verification page.

### Cause
If a user had a manual verification rejection (or MP rejection metadata), then later got approved via Mercado Pago account verification, stale rejection data remained in the database and the frontend still treated them as rejected.

### Backend
- Added `UserIdentityVerificationSuccessService` to centralize successful verification handling.
- On verification success, clears:
  - User rejection fields (`identity_validation_rejected_at`, `identity_validation_reject_reason`)
  - `mercado_pago_rejected_validations` records for the user
  - Rejected `manual_identity_validations` records (with stored images)
- Wired into:
  - Mercado Pago OAuth callback
  - Admin manual identity validation approval
  - Admin Mercado Pago rejected validation approval (preserves the row under review for audit)
- Extracted shared `ManualIdentityValidationDeletion` helper used by reset/success flows.
- Regression tests: unit + integration for OAuth and manual admin approval paths.

## Test plan
- [x] Backend unit tests (`UserIdentityVerificationSuccessServiceTest`)
- [x] Backend integration tests (MP OAuth + admin manual approval)
- [x] Frontend unit tests (`manualIdentityValidationStatus`, `identityValidationSuccessBanner`)
- [x] Full backend test suite
- [x] Frontend ESLint
- [x] Manual: user with manual rejection → verify via Mercado Pago → verification page shows success banner, not rejection