### PR TITLE
File max size frontend check

### DIFF
--- a/src/components/Uploadfile.vue
+++ b/src/components/Uploadfile.vue
@@ -4,8 +4,14 @@
 
 <script>
 import { Capacitor } from '@capacitor/core';
+import { useAuthStore } from '../stores/auth';
+import dialogs from '../services/dialogs';
 import {
     IMAGE_UPLOAD_ACCEPT,
+    getDataUrlByteSize,
+    getImageUploadMaxBytes,
+    getImageUploadSizeErrorKey,
+    getImageUploadSizeErrorParams,
     normalizeCapacitorImageFormat
 } from '../utils/imageUpload';
 
@@ -21,6 +27,26 @@ export default {
         this.isNative = Capacitor.isNativePlatform();
     },
     methods: {
+        showOversizedError(displayName) {
+            const maxBytes = getImageUploadMaxBytes(useAuthStore().appConfig);
+            const oversized = [{ displayName }];
+            dialogs.message(
+                this.$t(
+                    getImageUploadSizeErrorKey(oversized),
+                    getImageUploadSizeErrorParams(oversized, maxBytes)
+                ),
+                { estado: 'error' }
+            );
+        },
+        clearInput() {
+            if (this.$refs.input) {
+                this.$refs.input.value = '';
+            }
+        },
+        isDataUrlTooLarge(dataUrl) {
+            const maxBytes = getImageUploadMaxBytes(useAuthStore().appConfig);
+            return getDataUrlByteSize(dataUrl) > maxBytes;
+        },
         async show() {
             if (this.isNative) {
                 const success = await this.showNativePicker();
@@ -46,6 +72,10 @@ export default {
                 if (image && image.base64String) {
                     // Format: data:image/jpeg;base64,{base64String}
                     const imageData = `data:image/${normalizeCapacitorImageFormat(image.format)};base64,${image.base64String}`;
+                    if (this.isDataUrlTooLarge(imageData)) {
+                        this.showOversizedError(this.$t('imageUploadProfilePhoto'));
+                        return true;
+                    }
                     const data = {};
                     data[this.name] = imageData;
                     this.$emit('change', data);
@@ -82,6 +112,11 @@ export default {
         },
 
         createImage(file) {
+            if (file.size > getImageUploadMaxBytes(useAuthStore().appConfig)) {
+                this.showOversizedError(file.name || this.$t('imageUploadProfilePhoto'));
+                this.clearInput();
+                return;
+            }
             /* eslint-disable no-undef */
             let reader = new FileReader();
             let vm = this;

--- a/src/components/Uploadfile.vue
+++ b/src/components/Uploadfile.vue
@@ -5,15 +5,14 @@
 <script>
 import { Capacitor } from '@capacitor/core';
 import { useAuthStore } from '../stores/auth';
-import dialogs from '../services/dialogs';
 import {
     IMAGE_UPLOAD_ACCEPT,
-    getDataUrlByteSize,
-    getImageUploadMaxBytes,
-    getImageUploadSizeErrorKey,
-    getImageUploadSizeErrorParams,
     normalizeCapacitorImageFormat
 } from '../utils/imageUpload';
+import {
+    rejectOversizedDataUrl,
+    rejectOversizedFile
+} from '../utils/imageUploadSelection';
 
 export default {
     name: 'uploadfile',
@@ -27,26 +26,6 @@ export default {
         this.isNative = Capacitor.isNativePlatform();
     },
     methods: {
-        showOversizedError(displayName) {
-            const maxBytes = getImageUploadMaxBytes(useAuthStore().appConfig);
-            const oversized = [{ displayName }];
-            dialogs.message(
-                this.$t(
-                    getImageUploadSizeErrorKey(oversized),
-                    getImageUploadSizeErrorParams(oversized, maxBytes)
-                ),
-                { estado: 'error' }
-            );
-        },
-        clearInput() {
-            if (this.$refs.input) {
-                this.$refs.input.value = '';
-            }
-        },
-        isDataUrlTooLarge(dataUrl) {
-            const maxBytes = getImageUploadMaxBytes(useAuthStore().appConfig);
-            return getDataUrlByteSize(dataUrl) > maxBytes;
-        },
         async show() {
             if (this.isNative) {
                 const success = await this.showNativePicker();
@@ -72,8 +51,12 @@ export default {
                 if (image && image.base64String) {
                     // Format: data:image/jpeg;base64,{base64String}
                     const imageData = `data:image/${normalizeCapacitorImageFormat(image.format)};base64,${image.base64String}`;
-                    if (this.isDataUrlTooLarge(imageData)) {
-                        this.showOversizedError(this.$t('imageUploadProfilePhoto'));
+                    if (rejectOversizedDataUrl(
+                        this,
+                        imageData,
+                        this.$t('imageUploadProfilePhoto'),
+                        useAuthStore().appConfig
+                    )) {
                         return true;
                     }
                     const data = {};
@@ -112,9 +95,13 @@ export default {
         },
 
         createImage(file) {
-            if (file.size > getImageUploadMaxBytes(useAuthStore().appConfig)) {
-                this.showOversizedError(file.name || this.$t('imageUploadProfilePhoto'));
-                this.clearInput();
+            if (rejectOversizedFile(
+                this,
+                file,
+                file.name || this.$t('imageUploadProfilePhoto'),
+                useAuthStore().appConfig,
+                { target: this.$refs.input }
+            )) {
                 return;
             }
             /* eslint-disable no-undef */

--- a/src/components/sections/ManualIdentityValidation.vue
+++ b/src/components/sections/ManualIdentityValidation.vue
@@ -227,8 +227,9 @@ import {
 } from '../../utils/manualValidationUploadWarning';
 import {
     IMAGE_UPLOAD_ACCEPT,
-    filterAllowedImageUploads
+    getImageUploadMaxMb
 } from '../../utils/imageUpload';
+import { applyImageUploadSelection } from '../../utils/imageUploadSelection';
 
 export default {
     name: 'ManualIdentityValidation',
@@ -295,12 +296,7 @@ export default {
             }).format(this.costCents / 100);
         },
         manualValidationMaxFileMb() {
-            const c = this.config;
-            const n = c && c.manual_identity_validation_max_upload_mb;
-            if (n != null && Number(n) > 0) {
-                return Number(n);
-            }
-            return 10;
+            return getImageUploadMaxMb(this.config);
         },
         checkCircleIconSrc() {
             const base = process.env.ROUTE_BASE || '/';
@@ -411,8 +407,22 @@ export default {
             }
         },
         onFileChange(event, type) {
-            const file = filterAllowedImageUploads(event.target.files || [], 1)[0] || null;
-            this.files[type] = file;
+            const fieldLabels = {
+                front: this.$t('manualValidationUploadLabelFront'),
+                back: this.$t('manualValidationUploadLabelBack'),
+                selfie: this.$t('manualValidationUploadLabelSelfie')
+            };
+            const { files, rejected } = applyImageUploadSelection(
+                this,
+                event,
+                event.target.files || [],
+                {
+                    limit: 1,
+                    config: this.config,
+                    getDisplayName: () => fieldLabels[type] || type
+                }
+            );
+            this.files[type] = rejected ? null : (files[0] || null);
         },
         submitImages() {
             if (!this.requestId || !this.files.front || !this.files.back || !this.files.selfie) {

--- a/src/components/sections/UpdateProfile.vue
+++ b/src/components/sections/UpdateProfile.vue
@@ -653,9 +653,9 @@ import { UserApi } from '../../services/api';
 import { getApiErrorMessage } from '../../utils/apiErrors.js';
 import { normalizeFacebookProfileUrl } from '../../utils/facebookProfileUrl.js';
 import {
-    IMAGE_UPLOAD_ACCEPT,
-    filterAllowedImageUploads
+    IMAGE_UPLOAD_ACCEPT
 } from '../../utils/imageUpload';
+import { applyImageUploadSelection } from '../../utils/imageUploadSelection';
 
 class Error {
     constructor(state = false, message = '') {
@@ -850,8 +850,13 @@ export default {
                 });
         },
         onDriverDocumentChange(event) {
-            const files = filterAllowedImageUploads(event.target.files);
-            this.driverFiles = files.length ? files : null;
+            const { files, rejected } = applyImageUploadSelection(
+                this,
+                event,
+                event.target.files,
+                { config: this.config }
+            );
+            this.driverFiles = rejected || !files.length ? null : files;
         },
         dateChange(value) {
             this.birthdayAnswer = value;

--- a/src/components/views/AdminSupportTicketDetail.vue
+++ b/src/components/views/AdminSupportTicketDetail.vue
@@ -201,9 +201,10 @@ import {
     SUPPORT_TICKET_REPLY_EDITOR_CLASS
 } from '../../utils/supportTicketReplyEditor';
 import {
-    IMAGE_UPLOAD_ACCEPT,
-    filterAllowedImageUploads
+    IMAGE_UPLOAD_ACCEPT
 } from '../../utils/imageUpload';
+import { applyImageUploadSelection } from '../../utils/imageUploadSelection';
+import { useAuthStore } from '../../stores/auth';
 
 const PRIORITY_LABEL_KEYS = {
     low: 'prioridadBaja',
@@ -371,7 +372,18 @@ export default {
             return dayjs(value).format('YYYY-MM-DD HH:mm:ss');
         },
         onAttachments(event) {
-            this.attachments = filterAllowedImageUploads(event.target.files, 3);
+            const { files, rejected } = applyImageUploadSelection(
+                this,
+                event,
+                event.target.files,
+                {
+                    limit: 3,
+                    config: useAuthStore().appConfig
+                }
+            );
+            if (!rejected) {
+                this.attachments = files;
+            }
         },
         refresh() {
             return this.fetchAdminOne(this.id).then((data) => {

--- a/src/components/views/Register.vue
+++ b/src/components/views/Register.vue
@@ -389,9 +389,9 @@ import dayjs from '../../dayjs';
 import Spinner from '../Spinner.vue';
 import { isOfflineApiError } from '../../utils/apiErrors.js';
 import {
-    IMAGE_UPLOAD_ACCEPT,
-    filterAllowedImageUploads
+    IMAGE_UPLOAD_ACCEPT
 } from '../../utils/imageUpload';
+import { applyImageUploadSelection } from '../../utils/imageUploadSelection';
 let emailRegex =
     /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/;
 class Error {
@@ -617,8 +617,13 @@ export default {
             return globalError;
         },
         onDriverDocumentChange(event) {
-            const files = filterAllowedImageUploads(event.target.files);
-            this.driverFiles = files.length ? files : null;
+            const { files, rejected } = applyImageUploadSelection(
+                this,
+                event,
+                event.target.files,
+                { config: this.config }
+            );
+            this.driverFiles = rejected || !files.length ? null : files;
         },
         changeBeDriver() {
             this.showBeDriver = !this.showBeDriver;

--- a/src/components/views/TicketDetail.vue
+++ b/src/components/views/TicketDetail.vue
@@ -86,9 +86,10 @@ import {
     SUPPORT_TICKET_REPLY_EDITOR_CLASS
 } from '../../utils/supportTicketReplyEditor';
 import {
-    IMAGE_UPLOAD_ACCEPT,
-    filterAllowedImageUploads
+    IMAGE_UPLOAD_ACCEPT
 } from '../../utils/imageUpload';
+import { applyImageUploadSelection } from '../../utils/imageUploadSelection';
+import { useAuthStore } from '../../stores/auth';
 
 const SUCCESS_TOAST_OPTIONS = { estado: 'success', duration: 2 };
 const ERROR_TOAST_OPTIONS = { estado: 'error', duration: 3 };
@@ -157,7 +158,18 @@ export default {
             return dayjs(value).format('YYYY-MM-DD HH:mm:ss');
         },
         onAttachments(event) {
-            this.attachments = filterAllowedImageUploads(event.target.files, 3);
+            const { files, rejected } = applyImageUploadSelection(
+                this,
+                event,
+                event.target.files,
+                {
+                    limit: 3,
+                    config: useAuthStore().appConfig
+                }
+            );
+            if (!rejected) {
+                this.attachments = files;
+            }
         },
         refresh() {
             return this.fetchOne(this.id).then((data) => {

--- a/src/components/views/TicketNew.vue
+++ b/src/components/views/TicketNew.vue
@@ -39,6 +39,7 @@
 
 <script>
 import { mapActions } from 'pinia';
+import { useAuthStore } from '../../stores/auth';
 import ToastUiEditor from '../elements/ToastUiEditor.vue';
 import { useTicketsStore } from '../../stores/tickets';
 import dialogs from '../../services/dialogs';
@@ -48,9 +49,9 @@ import {
     USER_TICKET_TYPE_VALUES
 } from '../../utils/supportTicketTypeOptions';
 import {
-    IMAGE_UPLOAD_ACCEPT,
-    filterAllowedImageUploads
+    IMAGE_UPLOAD_ACCEPT
 } from '../../utils/imageUpload';
+import { applyImageUploadSelection } from '../../utils/imageUploadSelection';
 
 export default {
     name: 'ticket-new',
@@ -75,7 +76,18 @@ export default {
             createTicketAction: 'createTicket'
         }),
         onCreateAttachments(event) {
-            this.attachments = filterAllowedImageUploads(event.target.files, 3);
+            const { files, rejected } = applyImageUploadSelection(
+                this,
+                event,
+                event.target.files,
+                {
+                    limit: 3,
+                    config: useAuthStore().appConfig
+                }
+            );
+            if (!rejected) {
+                this.attachments = files;
+            }
         },
         createTicket() {
             const markdown = this.$refs.createEditor.invoke('getMarkdown');

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -723,6 +723,11 @@ const messages = {
         manualValidationUploadReqFormatos: 'Archivos permitidos: JPG o PNG.',
         manualValidationUploadReqTamano:
             'Tamaño máximo por archivo: {maxMb} MB.',
+        imageUploadTooLargeSingle:
+            '{fileLabel} supera el tamaño máximo permitido de {maxMb} MB.',
+        imageUploadTooLargeMultiple:
+            'Estos archivos superan el tamaño máximo permitido de {maxMb} MB: {fileLabels}.',
+        imageUploadProfilePhoto: 'Foto de perfil',
         manualValidationUploadDisclaimer:
             'Si la calidad de las imágenes no es suficiente, no podremos procesar la solicitud, no se reembolsará el pago y deberás abonar nuevamente para intentarlo de nuevo.',
         manualValidationUploadLabelFront:
@@ -2198,6 +2203,11 @@ const messages = {
         manualValidationUploadReqFormatos: 'Archivos permitidos: JPG o PNG.',
         manualValidationUploadReqTamano:
             'Tamaño máximo por archivo: {maxMb} MB.',
+        imageUploadTooLargeSingle:
+            '{fileLabel} supera el tamaño máximo permitido de {maxMb} MB.',
+        imageUploadTooLargeMultiple:
+            'Estos archivos superan el tamaño máximo permitido de {maxMb} MB: {fileLabels}.',
+        imageUploadProfilePhoto: 'Foto de perfil',
         manualValidationUploadDisclaimer:
             'Si la calidad de las imágenes no es suficiente, no podremos procesar la solicitud, no se reembolsará el pago y deberás abonar nuevamente para intentarlo de nuevo.',
         manualValidationUploadLabelFront:
@@ -3506,6 +3516,11 @@ const messages = {
             'Photos must be clear, complete, and readable.',
         manualValidationUploadReqFormatos: 'Allowed files: JPG or PNG.',
         manualValidationUploadReqTamano: 'Maximum size per file: {maxMb} MB.',
+        imageUploadTooLargeSingle:
+            '{fileLabel} exceeds the maximum allowed size of {maxMb} MB.',
+        imageUploadTooLargeMultiple:
+            'These files exceed the maximum allowed size of {maxMb} MB: {fileLabels}.',
+        imageUploadProfilePhoto: 'Profile photo',
         manualValidationUploadDisclaimer:
             'If image quality is not sufficient, we cannot process the request, the payment will not be refunded, and you will need to pay again to try again.',
         manualValidationUploadLabelFront: 'Front of ID (DNI or passport)',

--- a/src/language/imageUploadLabels.test.js
+++ b/src/language/imageUploadLabels.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import messages from './i18n';
+
+describe('image upload size labels (i18n)', () => {
+    it.each(['arg', 'en'])('%s locale defines single-file oversize error copy', (locale) => {
+        expect(messages[locale].imageUploadTooLargeSingle).toContain('{fileLabel}');
+        expect(messages[locale].imageUploadTooLargeSingle).toContain('{maxMb}');
+    });
+
+    it.each(['arg', 'en'])('%s locale defines multi-file oversize error copy', (locale) => {
+        expect(messages[locale].imageUploadTooLargeMultiple).toContain('{fileLabels}');
+        expect(messages[locale].imageUploadTooLargeMultiple).toContain('{maxMb}');
+    });
+
+    it.each(['arg', 'en'])('%s locale defines profile photo label for upload errors', (locale) => {
+        expect(messages[locale].imageUploadProfilePhoto).toBeTruthy();
+    });
+});

--- a/src/utils/imageUpload.js
+++ b/src/utils/imageUpload.js
@@ -1,6 +1,8 @@
 export const IMAGE_UPLOAD_ACCEPT =
     'image/jpeg,image/jpg,image/png,image/webp,.jpg,.jpeg,.png,.webp';
 
+export const DEFAULT_IMAGE_UPLOAD_MAX_BYTES = 10 * 1024 * 1024;
+
 const JPEG_EXTENSIONS = new Set(['jpg', 'jpeg']);
 const JPEG_MIMES = new Set(['image/jpeg', 'image/jpg']);
 const ALLOWED_EXTENSIONS = new Set(['jpg', 'jpeg', 'png', 'webp', 'heic', 'heif']);
@@ -73,6 +75,80 @@ export function filterAllowedImageUploads(files, limit = Number.POSITIVE_INFINIT
     return Array.from(files || [])
         .filter(isAllowedImageUpload)
         .slice(0, limit);
+}
+
+export function getImageUploadMaxBytes(config) {
+    const n = config && config.image_upload_max_bytes;
+    if (n != null && Number(n) > 0) {
+        return Number(n);
+    }
+
+    return DEFAULT_IMAGE_UPLOAD_MAX_BYTES;
+}
+
+export function getImageUploadMaxMb(config) {
+    return getImageUploadMaxBytes(config) / (1024 * 1024);
+}
+
+export function findOversizedImageUploads(files, maxBytes, getDisplayName) {
+    return Array.from(files || [])
+        .filter((file) => file && typeof file.size === 'number' && file.size > maxBytes)
+        .map((file, index) => ({
+            file,
+            displayName: getDisplayName ? getDisplayName(file, index) : (file.name || '')
+        }));
+}
+
+export function selectAllowedImageUploads(files, options = {}) {
+    const maxBytes = options.maxBytes ?? DEFAULT_IMAGE_UPLOAD_MAX_BYTES;
+    const allowed = filterAllowedImageUploads(files, options.limit);
+    const oversized = findOversizedImageUploads(allowed, maxBytes, options.getDisplayName);
+    const oversizedFiles = new Set(oversized.map((entry) => entry.file));
+
+    return {
+        files: allowed.filter((file) => !oversizedFiles.has(file)),
+        oversized,
+        maxBytes
+    };
+}
+
+function formatOversizedImageUploadLabels(oversized) {
+    return oversized.map((entry) => entry.displayName).filter(Boolean);
+}
+
+export function getImageUploadSizeErrorKey(oversized) {
+    return oversized.length === 1 ? 'imageUploadTooLargeSingle' : 'imageUploadTooLargeMultiple';
+}
+
+export function getImageUploadSizeErrorParams(oversized, maxBytes) {
+    const maxMb = Math.round(maxBytes / (1024 * 1024));
+    const fileLabels = formatOversizedImageUploadLabels(oversized).join(', ');
+
+    if (oversized.length === 1) {
+        return {
+            fileLabel: fileLabels,
+            maxMb
+        };
+    }
+
+    return {
+        fileLabels,
+        maxMb
+    };
+}
+
+export function getDataUrlByteSize(dataUrl) {
+    const value = String(dataUrl || '');
+    const commaIndex = value.indexOf(',');
+
+    if (commaIndex < 0) {
+        return 0;
+    }
+
+    const base64 = value.slice(commaIndex + 1);
+    const padding = (base64.match(/=+$/) || [''])[0].length;
+
+    return Math.floor((base64.length * 3) / 4) - padding;
 }
 
 export function normalizeCapacitorImageFormat(format) {

--- a/src/utils/imageUpload.js
+++ b/src/utils/imageUpload.js
@@ -90,9 +90,21 @@ export function getImageUploadMaxMb(config) {
     return getImageUploadMaxBytes(config) / (1024 * 1024);
 }
 
+function resolveImageUploadMaxBytes(options = {}) {
+    if (options.maxBytes != null && Number(options.maxBytes) > 0) {
+        return Number(options.maxBytes);
+    }
+
+    return getImageUploadMaxBytes(options.config);
+}
+
+function isOversizedImageUpload(file, maxBytes) {
+    return file && typeof file.size === 'number' && file.size > maxBytes;
+}
+
 export function findOversizedImageUploads(files, maxBytes, getDisplayName) {
     return Array.from(files || [])
-        .filter((file) => file && typeof file.size === 'number' && file.size > maxBytes)
+        .filter((file) => isOversizedImageUpload(file, maxBytes))
         .map((file, index) => ({
             file,
             displayName: getDisplayName ? getDisplayName(file, index) : (file.name || '')
@@ -100,7 +112,7 @@ export function findOversizedImageUploads(files, maxBytes, getDisplayName) {
 }
 
 export function selectAllowedImageUploads(files, options = {}) {
-    const maxBytes = options.maxBytes ?? DEFAULT_IMAGE_UPLOAD_MAX_BYTES;
+    const maxBytes = resolveImageUploadMaxBytes(options);
     const allowed = filterAllowedImageUploads(files, options.limit);
     const oversized = findOversizedImageUploads(allowed, maxBytes, options.getDisplayName);
     const oversizedFiles = new Set(oversized.map((entry) => entry.file));

--- a/src/utils/imageUpload.test.js
+++ b/src/utils/imageUpload.test.js
@@ -115,6 +115,20 @@ describe('imageUpload', () => {
         expect(result.oversized).toEqual([{ file: tooBig, displayName: 'huge.jpg' }]);
     });
 
+    it('reads max bytes from config when selecting uploads', () => {
+        const valid = new File(['a'], 'valid.jpg', { type: 'image/jpeg' });
+        Object.defineProperty(valid, 'size', { value: 100 });
+        const tooBig = new File(['b'], 'huge.jpg', { type: 'image/jpeg' });
+        Object.defineProperty(tooBig, 'size', { value: 3 * 1024 * 1024 });
+
+        const result = selectAllowedImageUploads([valid, tooBig], {
+            config: { image_upload_max_bytes: 2 * 1024 * 1024 }
+        });
+
+        expect(result.files).toEqual([valid]);
+        expect(result.oversized).toHaveLength(1);
+    });
+
     it('builds i18n key and params for a single oversized file', () => {
         const file = new File(['x'], 'selfie.jpg', { type: 'image/jpeg' });
         const oversized = [{ file, displayName: 'Photo of yourself holding your ID' }];

--- a/src/utils/imageUpload.test.js
+++ b/src/utils/imageUpload.test.js
@@ -1,9 +1,17 @@
 import { describe, it, expect } from 'vitest';
 import {
     IMAGE_UPLOAD_ACCEPT,
+    DEFAULT_IMAGE_UPLOAD_MAX_BYTES,
     getImageFileExtension,
+    getImageUploadMaxBytes,
+    getImageUploadMaxMb,
     isAllowedImageUpload,
     filterAllowedImageUploads,
+    findOversizedImageUploads,
+    selectAllowedImageUploads,
+    getImageUploadSizeErrorKey,
+    getImageUploadSizeErrorParams,
+    getDataUrlByteSize,
     normalizeCapacitorImageFormat
 } from './imageUpload';
 
@@ -56,5 +64,88 @@ describe('imageUpload', () => {
     it('normalizes capacitor jpg format to jpeg for data URIs', () => {
         expect(normalizeCapacitorImageFormat('jpg')).toBe('jpeg');
         expect(normalizeCapacitorImageFormat('jpeg')).toBe('jpeg');
+    });
+
+    it('defaults image upload max bytes to 10 MB when config is missing', () => {
+        expect(getImageUploadMaxBytes(null)).toBe(DEFAULT_IMAGE_UPLOAD_MAX_BYTES);
+        expect(DEFAULT_IMAGE_UPLOAD_MAX_BYTES).toBe(10 * 1024 * 1024);
+    });
+
+    it('reads image upload max bytes from server config', () => {
+        expect(getImageUploadMaxBytes({ image_upload_max_bytes: 2 * 1024 * 1024 })).toBe(
+            2 * 1024 * 1024
+        );
+    });
+
+    it('exposes max upload size in megabytes for UI copy', () => {
+        expect(getImageUploadMaxMb({ image_upload_max_bytes: 2 * 1024 * 1024 })).toBe(2);
+    });
+
+    it('finds oversized uploads and keeps a display label per file', () => {
+        const small = new File(['a'], 'ok.jpg', { type: 'image/jpeg' });
+        Object.defineProperty(small, 'size', { value: 100 });
+        const large = new File(['b'], 'big.jpg', { type: 'image/jpeg' });
+        Object.defineProperty(large, 'size', { value: DEFAULT_IMAGE_UPLOAD_MAX_BYTES + 1 });
+
+        const oversized = findOversizedImageUploads([small, large], DEFAULT_IMAGE_UPLOAD_MAX_BYTES, (file) =>
+            file.name === 'big.jpg' ? 'Front of ID' : file.name
+        );
+
+        expect(oversized).toEqual([
+            {
+                file: large,
+                displayName: 'Front of ID'
+            }
+        ]);
+    });
+
+    it('selects allowed uploads and reports oversized files before submit', () => {
+        const valid = new File(['a'], 'valid.jpg', { type: 'image/jpeg' });
+        Object.defineProperty(valid, 'size', { value: 100 });
+        const tooBig = new File(['b'], 'huge.jpg', { type: 'image/jpeg' });
+        Object.defineProperty(tooBig, 'size', { value: DEFAULT_IMAGE_UPLOAD_MAX_BYTES + 1 });
+        const invalid = new File(['c'], 'notes.pdf', { type: 'application/pdf' });
+
+        const result = selectAllowedImageUploads([valid, tooBig, invalid], {
+            limit: 3,
+            maxBytes: DEFAULT_IMAGE_UPLOAD_MAX_BYTES
+        });
+
+        expect(result.files).toEqual([valid]);
+        expect(result.oversized).toEqual([{ file: tooBig, displayName: 'huge.jpg' }]);
+    });
+
+    it('builds i18n key and params for a single oversized file', () => {
+        const file = new File(['x'], 'selfie.jpg', { type: 'image/jpeg' });
+        const oversized = [{ file, displayName: 'Photo of yourself holding your ID' }];
+
+        expect(getImageUploadSizeErrorKey(oversized)).toBe('imageUploadTooLargeSingle');
+        expect(getImageUploadSizeErrorParams(oversized, DEFAULT_IMAGE_UPLOAD_MAX_BYTES)).toEqual({
+            fileLabel: 'Photo of yourself holding your ID',
+            maxMb: 10
+        });
+    });
+
+    it('builds i18n key and params for multiple oversized files', () => {
+        const first = new File(['a'], 'front.jpg', { type: 'image/jpeg' });
+        const second = new File(['b'], 'back.jpg', { type: 'image/jpeg' });
+        const oversized = [
+            { file: first, displayName: 'front.jpg' },
+            { file: second, displayName: 'Back of ID' }
+        ];
+
+        expect(getImageUploadSizeErrorKey(oversized)).toBe('imageUploadTooLargeMultiple');
+        expect(getImageUploadSizeErrorParams(oversized, 2 * 1024 * 1024)).toEqual({
+            fileLabels: 'front.jpg, Back of ID',
+            maxMb: 2
+        });
+    });
+
+    it('estimates decoded byte size from a data URL payload', () => {
+        const bytes = new Uint8Array([1, 2, 3, 4, 5]);
+        const base64 = btoa(String.fromCharCode(...bytes));
+        const dataUrl = `data:image/jpeg;base64,${base64}`;
+
+        expect(getDataUrlByteSize(dataUrl)).toBe(bytes.length);
     });
 });

--- a/src/utils/imageUploadSelection.js
+++ b/src/utils/imageUploadSelection.js
@@ -1,18 +1,24 @@
 import dialogs from '../services/dialogs';
 import {
+    getDataUrlByteSize,
+    getImageUploadMaxBytes,
     getImageUploadSizeErrorKey,
     getImageUploadSizeErrorParams,
     selectAllowedImageUploads
 } from './imageUpload';
 
+export function showImageUploadSizeError(vm, oversized, maxBytes) {
+    dialogs.message(
+        vm.$t(getImageUploadSizeErrorKey(oversized), getImageUploadSizeErrorParams(oversized, maxBytes)),
+        { estado: 'error' }
+    );
+}
+
 export function applyImageUploadSelection(vm, event, files, options = {}) {
     const { files: validFiles, oversized, maxBytes } = selectAllowedImageUploads(files, options);
 
     if (oversized.length) {
-        dialogs.message(
-            vm.$t(getImageUploadSizeErrorKey(oversized), getImageUploadSizeErrorParams(oversized, maxBytes)),
-            { estado: 'error' }
-        );
+        showImageUploadSizeError(vm, oversized, maxBytes);
         if (event && event.target) {
             event.target.value = '';
         }
@@ -20,4 +26,27 @@ export function applyImageUploadSelection(vm, event, files, options = {}) {
     }
 
     return { files: validFiles, rejected: false };
+}
+
+export function rejectOversizedDataUrl(vm, dataUrl, displayName, config) {
+    const maxBytes = getImageUploadMaxBytes(config);
+    if (getDataUrlByteSize(dataUrl) <= maxBytes) {
+        return false;
+    }
+
+    showImageUploadSizeError(vm, [{ displayName }], maxBytes);
+    return true;
+}
+
+export function rejectOversizedFile(vm, file, displayName, config, event) {
+    const maxBytes = getImageUploadMaxBytes(config);
+    if (!file || file.size <= maxBytes) {
+        return false;
+    }
+
+    showImageUploadSizeError(vm, [{ displayName: displayName || file.name || '' }], maxBytes);
+    if (event && event.target) {
+        event.target.value = '';
+    }
+    return true;
 }

--- a/src/utils/imageUploadSelection.js
+++ b/src/utils/imageUploadSelection.js
@@ -1,0 +1,23 @@
+import dialogs from '../services/dialogs';
+import {
+    getImageUploadSizeErrorKey,
+    getImageUploadSizeErrorParams,
+    selectAllowedImageUploads
+} from './imageUpload';
+
+export function applyImageUploadSelection(vm, event, files, options = {}) {
+    const { files: validFiles, oversized, maxBytes } = selectAllowedImageUploads(files, options);
+
+    if (oversized.length) {
+        dialogs.message(
+            vm.$t(getImageUploadSizeErrorKey(oversized), getImageUploadSizeErrorParams(oversized, maxBytes)),
+            { estado: 'error' }
+        );
+        if (event && event.target) {
+            event.target.value = '';
+        }
+        return { files: [], rejected: true };
+    }
+
+    return { files: validFiles, rejected: false };
+}

--- a/src/utils/imageUploadSelection.test.js
+++ b/src/utils/imageUploadSelection.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { DEFAULT_IMAGE_UPLOAD_MAX_BYTES } from './imageUpload';
+import { applyImageUploadSelection } from './imageUploadSelection';
 
 const dialogs = vi.hoisted(() => ({
     message: vi.fn()
@@ -8,8 +9,6 @@ const dialogs = vi.hoisted(() => ({
 vi.mock('../services/dialogs', () => ({
     default: dialogs
 }));
-
-import { applyImageUploadSelection } from './imageUploadSelection';
 
 describe('applyImageUploadSelection', () => {
     beforeEach(() => {

--- a/src/utils/imageUploadSelection.test.js
+++ b/src/utils/imageUploadSelection.test.js
@@ -1,14 +1,15 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { DEFAULT_IMAGE_UPLOAD_MAX_BYTES } from './imageUpload';
-import { applyImageUploadSelection } from './imageUploadSelection';
 
-const dialogs = {
+const dialogs = vi.hoisted(() => ({
     message: vi.fn()
-};
+}));
 
 vi.mock('../services/dialogs', () => ({
     default: dialogs
 }));
+
+import { applyImageUploadSelection } from './imageUploadSelection';
 
 describe('applyImageUploadSelection', () => {
     beforeEach(() => {

--- a/src/utils/imageUploadSelection.test.js
+++ b/src/utils/imageUploadSelection.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { DEFAULT_IMAGE_UPLOAD_MAX_BYTES } from './imageUpload';
+import { applyImageUploadSelection } from './imageUploadSelection';
+
+const dialogs = {
+    message: vi.fn()
+};
+
+vi.mock('../services/dialogs', () => ({
+    default: dialogs
+}));
+
+describe('applyImageUploadSelection', () => {
+    beforeEach(() => {
+        dialogs.message.mockReset();
+    });
+
+    it('rejects oversized files, shows an error, and clears the input', () => {
+        const valid = new File(['a'], 'valid.jpg', { type: 'image/jpeg' });
+        Object.defineProperty(valid, 'size', { value: 100 });
+        const tooBig = new File(['b'], 'huge.jpg', { type: 'image/jpeg' });
+        Object.defineProperty(tooBig, 'size', { value: DEFAULT_IMAGE_UPLOAD_MAX_BYTES + 1 });
+        const input = { value: 'selected' };
+        const vm = {
+            $t: (key, params) => `${key}:${JSON.stringify(params)}`
+        };
+
+        const result = applyImageUploadSelection(vm, { target: input }, [valid, tooBig], {
+            limit: 3,
+            maxBytes: DEFAULT_IMAGE_UPLOAD_MAX_BYTES
+        });
+
+        expect(result).toEqual({ files: [], rejected: true });
+        expect(dialogs.message).toHaveBeenCalledWith(
+            'imageUploadTooLargeSingle:{"fileLabel":"huge.jpg","maxMb":10}',
+            { estado: 'error' }
+        );
+        expect(input.value).toBe('');
+    });
+
+    it('returns valid files when every upload is within the size limit', () => {
+        const valid = new File(['a'], 'valid.jpg', { type: 'image/jpeg' });
+        Object.defineProperty(valid, 'size', { value: 100 });
+        const vm = { $t: (key) => key };
+
+        const result = applyImageUploadSelection(vm, null, [valid], {
+            maxBytes: DEFAULT_IMAGE_UPLOAD_MAX_BYTES
+        });
+
+        expect(result).toEqual({ files: [valid], rejected: false });
+        expect(dialogs.message).not.toHaveBeenCalled();
+    });
+});

--- a/src/utils/imageUploadViews.test.js
+++ b/src/utils/imageUploadViews.test.js
@@ -2,21 +2,30 @@ import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 
-const viewPaths = [
+const selectionViewPaths = [
     '../components/sections/ManualIdentityValidation.vue',
     '../components/sections/UpdateProfile.vue',
     '../components/views/Register.vue',
     '../components/views/TicketNew.vue',
     '../components/views/TicketDetail.vue',
-    '../components/views/AdminSupportTicketDetail.vue',
-    '../components/Uploadfile.vue'
+    '../components/views/AdminSupportTicketDetail.vue'
 ].map((relativePath) => path.resolve(__dirname, relativePath));
 
+const uploadfilePath = path.resolve(__dirname, '../components/Uploadfile.vue');
+
 describe('image upload views', () => {
-    it.each(viewPaths)('%s blocks oversized files before upload', (viewPath) => {
+    it.each(selectionViewPaths)('%s blocks oversized files before upload', (viewPath) => {
         const source = fs.readFileSync(viewPath, 'utf8');
 
         expect(source).toContain('applyImageUploadSelection');
         expect(source).not.toMatch(/filterAllowedImageUploads\(/);
+    });
+
+    it('Uploadfile blocks oversized profile photos before emitting change', () => {
+        const source = fs.readFileSync(uploadfilePath, 'utf8');
+
+        expect(source).toContain('getImageUploadMaxBytes');
+        expect(source).toContain('getDataUrlByteSize');
+        expect(source).toContain('getImageUploadSizeErrorKey');
     });
 });

--- a/src/utils/imageUploadViews.test.js
+++ b/src/utils/imageUploadViews.test.js
@@ -24,8 +24,7 @@ describe('image upload views', () => {
     it('Uploadfile blocks oversized profile photos before emitting change', () => {
         const source = fs.readFileSync(uploadfilePath, 'utf8');
 
-        expect(source).toContain('getImageUploadMaxBytes');
-        expect(source).toContain('getDataUrlByteSize');
-        expect(source).toContain('getImageUploadSizeErrorKey');
+        expect(source).toContain('rejectOversizedDataUrl');
+        expect(source).toContain('rejectOversizedFile');
     });
 });

--- a/src/utils/imageUploadViews.test.js
+++ b/src/utils/imageUploadViews.test.js
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const viewPaths = [
+    '../components/sections/ManualIdentityValidation.vue',
+    '../components/sections/UpdateProfile.vue',
+    '../components/views/Register.vue',
+    '../components/views/TicketNew.vue',
+    '../components/views/TicketDetail.vue',
+    '../components/views/AdminSupportTicketDetail.vue',
+    '../components/Uploadfile.vue'
+].map((relativePath) => path.resolve(__dirname, relativePath));
+
+describe('image upload views', () => {
+    it.each(viewPaths)('%s blocks oversized files before upload', (viewPath) => {
+        const source = fs.readFileSync(viewPath, 'utf8');
+
+        expect(source).toContain('applyImageUploadSelection');
+        expect(source).not.toMatch(/filterAllowedImageUploads\(/);
+    });
+});


### PR DESCRIPTION
## Summary

- Validate image upload size on the frontend **before** sending files to the API, using the server config limit (`image_upload_max_bytes`, default 10 MB).
- Show a localized error that names the offending file(s) — by filename for multi-file uploads, or by field label (e.g. “Front of ID”) in manual identity validation.
- Cover all image upload flows: manual identity validation, support tickets (user + admin), driver docs (register/profile), and profile photo (web file picker + Capacitor camera).

## Cause

Upload size limits were only enforced on the backend. Users could select oversized files and only discover the problem after upload, with no clear indication of which file failed.

## Fix (frontend)

- Added shared utilities in `imageUpload.js` for max-bytes resolution, oversized detection, and i18n error params.
- Added `imageUploadSelection.js` helper to reject oversized files, show an error toast, and clear the file input.
- Wired all upload components to use the helper; profile photo uploads also check base64 payload size.
- Added i18n strings (`imageUploadTooLargeSingle`, `imageUploadTooLargeMultiple`, `imageUploadProfilePhoto`) in `arg` and `en`.
- Aligned manual validation UI copy with `image_upload_max_bytes` from config.

## Test plan

- [ ] Select a file > 10 MB in manual identity validation → error names the field (front/back/selfie), file is not kept.
- [ ] Attach oversized images to a support ticket → error lists filenames, attachments are not added.
- [ ] Upload oversized driver doc on register/profile → error shows filename.
- [ ] Pick oversized profile photo (web + native) → error shows “Profile photo” / filename.
- [ ] Files within the limit still upload normally.