### PR TITLE
Carpoodatos: link Mesa de ayuda

### DIFF
--- a/src/components/views/Trip.view.test.js
+++ b/src/components/views/Trip.view.test.js
@@ -30,6 +30,29 @@ describe('Trip.vue passenger message carpoodatos flow', () => {
     });
 });
 
+describe('Trip.vue carpoodatos mesa de ayuda contact', () => {
+    const mesaAyudaLinkPattern =
+        /<span>\{\{\s*\$t\('mesaAyudaContactoLead'\)\s*\}\}<\/span>\s*<router-link\s+:to="\{\s*name:\s*'tickets'\s*\}">\{\{\s*\$t\('mesaAyuda'\)\s*\}\}<\/router-link>\{\{\s*\$t\('mesaAyudaContactoTail'\)\s*\}\}/;
+
+    it('links the request-seat carpoodatos modal to mesa de ayuda', () => {
+        const requestSeatModal = viewSource.match(
+            /showModalRequestSeat[\s\S]*?showModalPricing/
+        )[0];
+
+        expect(requestSeatModal).toMatch(mesaAyudaLinkPattern);
+        expect(requestSeatModal).not.toContain('carpoodatosContactoEmail');
+    });
+
+    it('links the pricing carpoodatos modal to mesa de ayuda', () => {
+        const pricingModal = viewSource.match(
+            /showModalPricing[\s\S]*?matcheosDelViaje/
+        )[0];
+
+        expect(pricingModal).toMatch(mesaAyudaLinkPattern);
+        expect(pricingModal).not.toContain('carpoodatosContactoRedes');
+    });
+});
+
 describe('Trip.vue driver seat requests warning', () => {
     it('shows a warning link to my-trips when the driver has pending seat requests', () => {
         expect(viewSource).toContain('shouldShowTripSeatRequestsWarning');

--- a/src/components/views/Trip.vue
+++ b/src/components/views/Trip.vue
@@ -117,7 +117,8 @@
                                             {{ $t('carpoodatosNoPidasAsiento') }}
                                         </p>
                                         <p>
-                                            {{ $t('carpoodatosContactoEmail', { email: config.admin_email }) }}
+                                            <span>{{ $t('mesaAyudaContactoLead') }}</span>
+                                            <router-link :to="{ name: 'tickets' }">{{ $t('mesaAyuda') }}</router-link>{{ $t('mesaAyudaContactoTail') }}
                                         </p>
                                     </div>
                                     <div
@@ -191,7 +192,8 @@
                                             {{ $t('carpoodatosContribucionMaxima') }}
                                         </p>
                                         <p>
-                                            {{ $t('carpoodatosContactoRedes', { email: config.admin_email }) }}
+                                            <span>{{ $t('mesaAyudaContactoLead') }}</span>
+                                            <router-link :to="{ name: 'tickets' }">{{ $t('mesaAyuda') }}</router-link>{{ $t('mesaAyudaContactoTail') }}
                                         </p>
                                     </div>
                                     <div

--- a/src/language/carpoodatosContact.test.js
+++ b/src/language/carpoodatosContact.test.js
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import messages from './i18n';
+
+const LOCALES = ['arg', 'chl', 'en'];
+
+describe('carpoodatos contact copy', () => {
+    it.each(LOCALES)(
+        '%s locale reuses mesa de ayuda contact keys instead of email copy',
+        (locale) => {
+            expect(messages[locale]).not.toHaveProperty(
+                'carpoodatosContactoEmail'
+            );
+            expect(messages[locale]).not.toHaveProperty(
+                'carpoodatosContactoRedes'
+            );
+            expect(messages[locale].mesaAyudaContactoLead).toBeTruthy();
+            expect(messages[locale].mesaAyuda).toBeTruthy();
+            expect(messages[locale].mesaAyudaContactoTail).toBeTruthy();
+        }
+    );
+});

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -1055,16 +1055,12 @@ const messages = {
             'Podrán calificarse aunque el viaje se cancele, te bajen o te bajes del viaje.',
         carpoodatosNoPidasAsiento:
             'No pidas asiento si no tenés seguridad de que vas a viajar, muchas personas también están buscando el mismo viaje que vos. Si ocurriera algo que te impida viajar, avisale lo más rápido que puedas a la persona con que ibas a compartir el viaje.',
-        carpoodatosContactoEmail:
-            'Cualquier duda escribinos a {email} o nuestras redes sociales.',
         noVolverAMostrarMensaje: 'No volver a mostrar mensaje',
         solicitarAsiento: 'Solicitar asiento',
         carpoodatosAntesConfirmar:
             'Antes de confirmar el viaje y para evitar sorpresas, tené en cuenta de coordinar y acordar el punto de encuentro, el horario, la disponibilidad de espacio para equipaje, la cantidad total de pasajeros y la contribución por los gastos de combustible y peaje.',
         carpoodatosContribucionMaxima:
             'La contribución máxima que puede pedir un conductor es igual a gastos de combustible + peaje dividido la cantidad de personas viajando en el auto. Durante la coordinación previa al viaje, cualquier persona puede pedir hacer la división con tickets de combustible y peaje en mano.',
-        carpoodatosContactoRedes:
-            'Cualquier duda escribinos a {email} o por mensaje privado a nuestras redes sociales (facebook,instagram y tweeter).',
         matcheosDelViaje: 'Matcheos del viaje',
         viajaEl: 'Viaja el',
         mensajeParaUsuariosSeleccionados:
@@ -2375,8 +2371,6 @@ const messages = {
             'Podrán calificarse aunque el viaje se cancele, te bajen o te bajes del viaje.',
         carpoodatosNoPidasAsiento:
             'No pidas asiento si no tenés seguridad de que vas a viajar, muchas personas también están buscando el mismo viaje que vos. Si ocurriera algo que te impida viajar, avisale lo más rápido que puedas a la persona con que ibas a compartir el viaje.',
-        carpoodatosContactoEmail:
-            'Cualquier duda escribinos a {email} o nuestras redes sociales.',
         noVolverAMostrarMensaje: 'No volver a mostrar mensaje',
         enviarMensaje: 'Enviar mensaje',
         solicitarAsiento: 'Solicitar asiento',
@@ -2384,8 +2378,6 @@ const messages = {
             'Antes de confirmar el viaje y para evitar sorpresas, tené en cuenta de coordinar y acordar el punto de encuentro, el horario, la disponibilidad de espacio para equipaje, la cantidad total de pasajeros y la contribución por los gastos de combustible y peaje.',
         carpoodatosContribucionMaxima:
             'La contribución máxima que puede pedir un conductor es igual a gastos de combustible + peaje dividido la cantidad de personas viajando en el auto. Durante la coordinación previa al viaje, cualquier persona puede pedir hacer la división con tickets de combustible y peaje en mano.',
-        carpoodatosContactoRedes:
-            'Cualquier duda escribinos a {email} o por mensaje privado a nuestras redes sociales (facebook,instagram y tweeter).',
         matcheosDelViaje: 'Matcheos del viaje',
         viajaEl: 'Viaja el',
         mensajeParaUsuariosSeleccionados:
@@ -3878,16 +3870,12 @@ const messages = {
             'You can rate each other even if the trip is canceled, you are removed, or you leave the trip.',
         carpoodatosNoPidasAsiento:
             "Don't request a seat if you're not sure you're going to travel, many other people are also looking for the same trip as you. If something happens that prevents you from traveling, let the person you were going to share the trip with know as soon as possible.",
-        carpoodatosContactoEmail:
-            'Any questions, write to us at {email} or our social networks.',
         noVolverAMostrarMensaje: 'Do not show message again',
         solicitarAsiento: 'Request seat',
         carpoodatosAntesConfirmar:
             'Before confirming the trip and to avoid surprises, make sure to coordinate and agree on the meeting point, time, luggage space availability, total number of passengers, and contribution for fuel and toll expenses.',
         carpoodatosContribucionMaxima:
             'The maximum contribution a driver can request equals fuel costs + tolls divided by the number of people traveling in the car. During pre-trip coordination, anyone can request to do the division with fuel and toll receipts in hand.',
-        carpoodatosContactoRedes:
-            'Any questions, write to us at {email} or by private message to our social networks (Facebook, Instagram, and Twitter).',
         matcheosDelViaje: 'Trip matches',
         viajaEl: 'Travels on',
         mensajeParaUsuariosSeleccionados: 'Message for selected users',


### PR DESCRIPTION
## Summary

Replace email and social-media contact copy in the Trip page Carpoodatos modals with a link to Mesa de ayuda, matching the pattern already used in UpdateProfile modals.

## Cause

The Carpoodatos modals (request-seat and pricing/confirm) still directed users to `carpoolear@stsrosario.org.ar` and social networks instead of the in-app Mesa de ayuda (`/soporte`).

## Fix

### Frontend

- Updated both Carpoodatos contact paragraphs in `Trip.vue` to use `mesaAyudaContactoLead`, `mesaAyuda`, and `mesaAyudaContactoTail` with a `router-link` to `{ name: 'tickets' }`.
- Removed unused i18n keys `carpoodatosContactoEmail` and `carpoodatosContactoRedes` from all locales.
- Added view and i18n tests to lock in the new behavior and prevent regression.

### Backend

No changes required.

## Test plan

- [x] Unit tests: `Trip.view.test.js`, `carpoodatosContact.test.js`
- [x] Frontend lint (`npm run lint`)
- [x] Backend test suite (`php artisan test`)
- [ ] Manual: open a trip as passenger → trigger Carpoodatos modal → confirm contact paragraph links to Mesa de ayuda
- [ ] Manual: trigger the pricing/confirm Carpoodatos modal → same link behavior