### PR TITLE
Manual verification changes

### DIFF
--- a/src/components/sections/IdentityValidation.view.test.js
+++ b/src/components/sections/IdentityValidation.view.test.js
@@ -80,6 +80,12 @@ describe('IdentityValidation rejection warnings', () => {
     it('uses manual reject reason to choose support warning copy', () => {
         expect(viewSource).toContain('manualStatus.reject_reason');
     });
+
+    it('links to manual upload when resubmit without payment is available', () => {
+        expect(viewSource).toContain('canManualResubmitWithoutPayment');
+        expect(viewSource).toContain('manualValidationResubmitRoute');
+        expect(viewSource).toContain('identityValidationRejectionResubmitDocumentsCta');
+    });
 });
 
 describe('IdentityValidation Mercado Pago ownership warning', () => {

--- a/src/components/sections/IdentityValidation.vue
+++ b/src/components/sections/IdentityValidation.vue
@@ -431,7 +431,7 @@ import {
     getManualReviewNoteLabelKey
 } from '../../utils/manualIdentityValidationReviewNote';
 import { shouldShowIdentityVerificationSuccessBanner } from '../../utils/identityValidationSuccessBanner';
-import { isManualRejectedWithChoiceCards, canManualResubmitWithoutPayment, getManualValidationResubmitRoute } from '../../utils/manualIdentityValidationStatus';
+import { isManualRejectedWithChoiceCards, canManualResubmitWithoutPayment, getManualValidationResubmitRoute, getManualValidationRestartRoute } from '../../utils/manualIdentityValidationStatus';
 import IdentityValidationAdminReviewNote from '../IdentityValidationAdminReviewNote.vue';
 
 const EMPTY_WARNING_PARTS = { leadKey: null, tailKey: null };
@@ -674,6 +674,11 @@ export default {
             this.$router.push(PROFILE_EDIT_ROUTE);
         },
         goToManualValidation() {
+            const restartRoute = getManualValidationRestartRoute(this.manualStatus);
+            if (restartRoute && !this.isIdentityValidationBlockedByMissingDni) {
+                this.$router.push(restartRoute);
+                return;
+            }
             this.$router.push(getManualIdentityValidationRoute(this.user));
         },
         onPendingManualSwitchClick() {

--- a/src/components/sections/IdentityValidation.vue
+++ b/src/components/sections/IdentityValidation.vue
@@ -248,7 +248,19 @@
                         <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                         {{ $t(manualRejectionSupportWarningKey) }}
                     </p>
-                    <p class="identity-validation-rejection-notice__emphasis">
+                    <p
+                        v-if="canManualResubmitWithoutPayment"
+                        class="identity-validation-rejection-notice__emphasis"
+                    >
+                        <router-link
+                            class="identity-validation-rejection-notice__resubmit-link"
+                            :to="manualValidationResubmitRoute"
+                        >{{ $t('identityValidationRejectionResubmitDocumentsCta') }}</router-link>
+                    </p>
+                    <p
+                        v-else
+                        class="identity-validation-rejection-notice__emphasis"
+                    >
                         <strong class="identity-validation-rejection-notice__emphasis-strong">{{ $t('identityValidationRejectionNoticeContactLead') }}</strong><router-link class="identity-validation-rejection-notice__mesa-link" :to="{ name: 'tickets' }">{{ $t('mesaAyuda') }}</router-link>{{ $t('identityValidationRejectionNoticeContactTail') }}
                     </p>
                 </div>
@@ -419,7 +431,7 @@ import {
     getManualReviewNoteLabelKey
 } from '../../utils/manualIdentityValidationReviewNote';
 import { shouldShowIdentityVerificationSuccessBanner } from '../../utils/identityValidationSuccessBanner';
-import { isManualRejectedWithChoiceCards } from '../../utils/manualIdentityValidationStatus';
+import { isManualRejectedWithChoiceCards, canManualResubmitWithoutPayment, getManualValidationResubmitRoute } from '../../utils/manualIdentityValidationStatus';
 import IdentityValidationAdminReviewNote from '../IdentityValidationAdminReviewNote.vue';
 
 const EMPTY_WARNING_PARTS = { leadKey: null, tailKey: null };
@@ -438,7 +450,10 @@ export default {
                 paid_at: null,
                 review_status: null,
                 submitted_at: null,
-                review_note: null
+                review_note: null,
+                submission_count: null,
+                max_submissions: null,
+                can_resubmit_without_payment: false
             },
             loadingOAuth: false,
             loadingPreference: false
@@ -524,6 +539,12 @@ export default {
                 user: this.user
             });
         },
+        canManualResubmitWithoutPayment() {
+            return canManualResubmitWithoutPayment(this.manualStatus);
+        },
+        manualValidationResubmitRoute() {
+            return getManualValidationResubmitRoute(this.manualStatus);
+        },
         manualRejectionSupportWarningKey() {
             if (!this.showManualRejectedWithChoiceCards) return null;
             return getManualRejectionSupportWarningKey(this.manualStatus.reject_reason);
@@ -589,7 +610,10 @@ export default {
                 paid_at: null,
                 review_status: null,
                 submitted_at: null,
-                review_note: null
+                review_note: null,
+                submission_count: null,
+                max_submissions: null,
+                can_resubmit_without_payment: false
             };
             const userApi = new UserApi();
             return userApi.getManualIdentityValidationStatus()

--- a/src/components/sections/ManualIdentityValidation.vue
+++ b/src/components/sections/ManualIdentityValidation.vue
@@ -6,7 +6,7 @@
         </div>
         <template v-else>
             <div
-                v-if="(statusPaidAt || statusSubmittedAt) && !(canUpload && !alreadySubmitted)"
+                v-if="showStatusDatesPanel"
                 class="panel panel-default status-dates-panel"
             >
                 <div class="panel-body">
@@ -230,6 +230,10 @@ import {
     getImageUploadMaxMb
 } from '../../utils/imageUpload';
 import { applyImageUploadSelection } from '../../utils/imageUploadSelection';
+import {
+    shouldShowManualValidationAlreadySubmitted,
+    shouldShowManualValidationPayAgain
+} from '../../utils/manualIdentityValidationStatus';
 
 export default {
     name: 'ManualIdentityValidation',
@@ -241,6 +245,8 @@ export default {
             unpaidPending: false,
             statusPaidAt: null,
             statusSubmittedAt: null,
+            reviewStatus: null,
+            forcePaymentRestart: false,
             loadingPreference: false,
             loadingQr: false,
             submitting: false,
@@ -283,11 +289,27 @@ export default {
         canUpload() {
             return this.requestId && (this.paymentSuccess || this.canResubmitWithoutPayment);
         },
+        manualStatusSnapshot() {
+            return {
+                submitted_at: this.statusSubmittedAt,
+                review_status: this.reviewStatus,
+                can_resubmit_without_payment: this.canResubmitWithoutPayment
+            };
+        },
         alreadySubmitted() {
-            if (this.canResubmitWithoutPayment) {
+            if (this.forcePaymentRestart) {
                 return false;
             }
-            return this.statusSubmittedAt != null;
+            return shouldShowManualValidationAlreadySubmitted(this.manualStatusSnapshot);
+        },
+        showStatusDatesPanel() {
+            if (this.forcePaymentRestart) {
+                return false;
+            }
+            if (shouldShowManualValidationPayAgain(this.manualStatusSnapshot)) {
+                return false;
+            }
+            return (this.statusPaidAt || this.statusSubmittedAt) && !(this.canUpload && !this.alreadySubmitted);
         },
         formattedCostDisplay() {
             if (this.costCents <= 0) return '—';
@@ -316,6 +338,12 @@ export default {
                 this.canResubmitWithoutPayment = true;
                 this.paymentSuccess = true;
             }
+            if (q.restart === '1' || q.restart === 'true') {
+                this.forcePaymentRestart = true;
+                this.requestId = null;
+                this.paymentSuccess = false;
+                this.canResubmitWithoutPayment = false;
+            }
         },
         fetchStatus() {
             const userApi = new UserApi();
@@ -324,7 +352,17 @@ export default {
                     const data = res.data || res;
                     this.statusPaidAt = data.paid_at || null;
                     this.statusSubmittedAt = data.submitted_at || null;
+                    this.reviewStatus = data.review_status || null;
                     this.canResubmitWithoutPayment = data.can_resubmit_without_payment === true;
+                    if (this.forcePaymentRestart && shouldShowManualValidationPayAgain(data)) {
+                        this.requestId = null;
+                        this.paymentSuccess = false;
+                        this.unpaidPending = data.has_submission && data.paid === false;
+                        if (this.unpaidPending && data.request_id) {
+                            this.requestId = data.request_id;
+                        }
+                        return;
+                    }
                     if (data.has_submission && data.paid === false) {
                         this.unpaidPending = true;
                         if (data.request_id && !this.requestId) {

--- a/src/components/sections/ManualIdentityValidation.vue
+++ b/src/components/sections/ManualIdentityValidation.vue
@@ -249,6 +249,7 @@ export default {
             qrImageUrl: null,
             qrData: null,
             pollIntervalId: null,
+            canResubmitWithoutPayment: false,
             files: {
                 front: null,
                 back: null,
@@ -280,9 +281,12 @@ export default {
             return SWITCH_TO_MERCADO_PAGO_ROUTE;
         },
         canUpload() {
-            return this.requestId && this.paymentSuccess;
+            return this.requestId && (this.paymentSuccess || this.canResubmitWithoutPayment);
         },
         alreadySubmitted() {
+            if (this.canResubmitWithoutPayment) {
+                return false;
+            }
             return this.statusSubmittedAt != null;
         },
         formattedCostDisplay() {
@@ -308,6 +312,10 @@ export default {
             const q = this.$route.query;
             this.requestId = q.request_id ? parseInt(q.request_id, 10) : null;
             this.paymentSuccess = q.payment_success === '1' || q.payment_success === 'true';
+            if (q.resubmit === '1' || q.resubmit === 'true') {
+                this.canResubmitWithoutPayment = true;
+                this.paymentSuccess = true;
+            }
         },
         fetchStatus() {
             const userApi = new UserApi();
@@ -316,6 +324,7 @@ export default {
                     const data = res.data || res;
                     this.statusPaidAt = data.paid_at || null;
                     this.statusSubmittedAt = data.submitted_at || null;
+                    this.canResubmitWithoutPayment = data.can_resubmit_without_payment === true;
                     if (data.has_submission && data.paid === false) {
                         this.unpaidPending = true;
                         if (data.request_id && !this.requestId) {
@@ -325,6 +334,11 @@ export default {
                     if (data.has_submission && data.paid === true && data.request_id && !data.submitted_at) {
                         this.requestId = data.request_id;
                         this.paymentSuccess = true;
+                    }
+                    if (data.can_resubmit_without_payment && data.request_id) {
+                        this.requestId = data.request_id;
+                        this.paymentSuccess = true;
+                        this.statusSubmittedAt = null;
                     }
                 })
                 .catch(() => {});

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -668,6 +668,8 @@ const messages = {
         identityValidationRejectionNoticeContactLead:
             'Podés intentar nuevamente o escribinos desde la ',
         identityValidationRejectionNoticeContactTail: '.',
+        identityValidationRejectionResubmitDocumentsCta:
+            'Click acá para subir los documentos nuevamente',
         identityValidationRejectionSupportWarningNameMismatch:
             'Parece que no coincide tu nombre, creá un ticket de Mesa de Ayuda así te ayudamos a cambiarlo y podés intentar nuevamente.',
         identityValidationRejectionSupportWarningNameMismatchLead:
@@ -2148,6 +2150,8 @@ const messages = {
         identityValidationRejectionNoticeContactLead:
             'Podés intentar nuevamente o escribinos desde la ',
         identityValidationRejectionNoticeContactTail: '.',
+        identityValidationRejectionResubmitDocumentsCta:
+            'Click acá para subir los documentos nuevamente',
         identityValidationRejectionSupportWarningNameMismatch:
             'Parece que no coincide tu nombre, creá un ticket de Mesa de Ayuda así te ayudamos a cambiarlo y podés intentar nuevamente.',
         identityValidationRejectionSupportWarningNameMismatchLead:
@@ -3462,6 +3466,8 @@ const messages = {
         identityValidationRejectionNoticeContactLead:
             'You can try again or reach out through the ',
         identityValidationRejectionNoticeContactTail: '.',
+        identityValidationRejectionResubmitDocumentsCta:
+            'Click here to upload your documents again',
         identityValidationRejectionSupportWarningNameMismatch:
             "It looks like your name doesn't match. Create a Help Desk ticket so we can help you update it and try again.",
         identityValidationRejectionSupportWarningNameMismatchLead:

--- a/src/utils/manualIdentityValidationStatus.js
+++ b/src/utils/manualIdentityValidationStatus.js
@@ -21,10 +21,13 @@ export function isManualRejectedWithChoiceCards(
 }
 
 export function canManualResubmitWithoutPayment(manualStatus) {
+    /* eslint-disable camelcase -- manual status API uses snake_case */
     return manualStatus?.can_resubmit_without_payment === true;
+    /* eslint-enable camelcase */
 }
 
 export function getManualValidationResubmitRoute(manualStatus) {
+    /* eslint-disable camelcase -- manual status API uses snake_case */
     if (!canManualResubmitWithoutPayment(manualStatus) || !manualStatus?.request_id) {
         return null;
     }
@@ -36,4 +39,5 @@ export function getManualValidationResubmitRoute(manualStatus) {
             resubmit: '1'
         }
     };
+    /* eslint-enable camelcase */
 }

--- a/src/utils/manualIdentityValidationStatus.js
+++ b/src/utils/manualIdentityValidationStatus.js
@@ -19,3 +19,21 @@ export function isManualRejectedWithChoiceCards(
     }
     return isManualIdentityValidationRejected(manualStatus, user);
 }
+
+export function canManualResubmitWithoutPayment(manualStatus) {
+    return manualStatus?.can_resubmit_without_payment === true;
+}
+
+export function getManualValidationResubmitRoute(manualStatus) {
+    if (!canManualResubmitWithoutPayment(manualStatus) || !manualStatus?.request_id) {
+        return null;
+    }
+
+    return {
+        name: 'identity_validation_manual',
+        query: {
+            request_id: manualStatus.request_id,
+            resubmit: '1'
+        }
+    };
+}

--- a/src/utils/manualIdentityValidationStatus.js
+++ b/src/utils/manualIdentityValidationStatus.js
@@ -41,3 +41,43 @@ export function getManualValidationResubmitRoute(manualStatus) {
     };
     /* eslint-enable camelcase */
 }
+
+export function shouldShowManualValidationPayAgain(manualStatus) {
+    /* eslint-disable camelcase -- manual status API uses snake_case */
+    if (!manualStatus?.submitted_at) {
+        return false;
+    }
+    if (manualStatus.review_status !== 'rejected') {
+        return false;
+    }
+
+    return !canManualResubmitWithoutPayment(manualStatus);
+    /* eslint-enable camelcase */
+}
+
+export function shouldShowManualValidationAlreadySubmitted(manualStatus) {
+    /* eslint-disable camelcase -- manual status API uses snake_case */
+    if (!manualStatus?.submitted_at) {
+        return false;
+    }
+    if (canManualResubmitWithoutPayment(manualStatus)) {
+        return false;
+    }
+    if (manualStatus.review_status === 'rejected') {
+        return false;
+    }
+
+    return true;
+    /* eslint-enable camelcase */
+}
+
+export function getManualValidationRestartRoute(manualStatus) {
+    if (!shouldShowManualValidationPayAgain(manualStatus)) {
+        return null;
+    }
+
+    return {
+        name: 'identity_validation_manual',
+        query: { restart: '1' }
+    };
+}

--- a/src/utils/manualIdentityValidationStatus.test.js
+++ b/src/utils/manualIdentityValidationStatus.test.js
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import {
     isManualIdentityValidationRejected,
-    isManualRejectedWithChoiceCards
+    isManualRejectedWithChoiceCards,
+    canManualResubmitWithoutPayment,
+    getManualValidationResubmitRoute
 } from './manualIdentityValidationStatus';
 
 describe('isManualIdentityValidationRejected', () => {
@@ -78,5 +80,46 @@ describe('isManualRejectedWithChoiceCards', () => {
                 }
             )
         ).toBe(false);
+    });
+});
+
+describe('canManualResubmitWithoutPayment', () => {
+    it('returns true when API reports resubmit is allowed', () => {
+        expect(
+            canManualResubmitWithoutPayment({
+                can_resubmit_without_payment: true
+            })
+        ).toBe(true);
+    });
+
+    it('returns false when resubmit is not allowed', () => {
+        expect(
+            canManualResubmitWithoutPayment({
+                can_resubmit_without_payment: false
+            })
+        ).toBe(false);
+    });
+});
+
+describe('getManualValidationResubmitRoute', () => {
+    it('returns manual upload route with request_id when resubmit is allowed', () => {
+        expect(
+            getManualValidationResubmitRoute({
+                can_resubmit_without_payment: true,
+                request_id: 42
+            })
+        ).toEqual({
+            name: 'identity_validation_manual',
+            query: { request_id: 42, resubmit: '1' }
+        });
+    });
+
+    it('returns null when resubmit is not allowed', () => {
+        expect(
+            getManualValidationResubmitRoute({
+                can_resubmit_without_payment: false,
+                request_id: 42
+            })
+        ).toBeNull();
     });
 });

--- a/src/utils/manualIdentityValidationStatus.test.js
+++ b/src/utils/manualIdentityValidationStatus.test.js
@@ -3,7 +3,9 @@ import {
     isManualIdentityValidationRejected,
     isManualRejectedWithChoiceCards,
     canManualResubmitWithoutPayment,
-    getManualValidationResubmitRoute
+    getManualValidationResubmitRoute,
+    shouldShowManualValidationAlreadySubmitted,
+    getManualValidationRestartRoute
 } from './manualIdentityValidationStatus';
 
 describe('isManualIdentityValidationRejected', () => {
@@ -119,6 +121,65 @@ describe('getManualValidationResubmitRoute', () => {
             getManualValidationResubmitRoute({
                 can_resubmit_without_payment: false,
                 request_id: 42
+            })
+        ).toBeNull();
+    });
+});
+
+describe('shouldShowManualValidationAlreadySubmitted', () => {
+    it('returns true when docs are pending admin review', () => {
+        expect(
+            shouldShowManualValidationAlreadySubmitted({
+                submitted_at: '2026-06-19 09:42:00',
+                review_status: 'pending',
+                can_resubmit_without_payment: false
+            })
+        ).toBe(true);
+    });
+
+    it('returns false when rejected and free resubmit is still available', () => {
+        expect(
+            shouldShowManualValidationAlreadySubmitted({
+                submitted_at: '2026-06-19 09:42:00',
+                review_status: 'rejected',
+                can_resubmit_without_payment: true
+            })
+        ).toBe(false);
+    });
+
+    it('returns false when rejected and submission attempts are exhausted', () => {
+        expect(
+            shouldShowManualValidationAlreadySubmitted({
+                submitted_at: '2026-06-19 09:42:00',
+                review_status: 'rejected',
+                can_resubmit_without_payment: false,
+                submission_count: 3,
+                max_submissions: 3
+            })
+        ).toBe(false);
+    });
+});
+
+describe('getManualValidationRestartRoute', () => {
+    it('returns manual route with restart query when payment is required after rejection', () => {
+        expect(
+            getManualValidationRestartRoute({
+                submitted_at: '2026-06-19 09:42:00',
+                review_status: 'rejected',
+                can_resubmit_without_payment: false
+            })
+        ).toEqual({
+            name: 'identity_validation_manual',
+            query: { restart: '1' }
+        });
+    });
+
+    it('returns null when free resubmit is still available', () => {
+        expect(
+            getManualValidationRestartRoute({
+                submitted_at: '2026-06-19 09:42:00',
+                review_status: 'rejected',
+                can_resubmit_without_payment: true
             })
         ).toBeNull();
     });

--- a/src/utils/manualIdentityValidationUpload.test.js
+++ b/src/utils/manualIdentityValidationUpload.test.js
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const viewPath = path.resolve(
+    __dirname,
+    '../components/sections/ManualIdentityValidation.vue'
+);
+const viewSource = fs.readFileSync(viewPath, 'utf8');
+
+describe('ManualIdentityValidation resubmit upload flow', () => {
+    it('tracks can_resubmit_without_payment from status API', () => {
+        expect(viewSource).toContain('canResubmitWithoutPayment');
+        expect(viewSource).toContain('can_resubmit_without_payment');
+    });
+
+    it('shows upload form when resubmit is allowed without a new payment', () => {
+        expect(viewSource).toContain('canUpload()');
+        expect(viewSource).toContain('canResubmitWithoutPayment');
+    });
+});

--- a/src/utils/manualIdentityValidationUpload.test.js
+++ b/src/utils/manualIdentityValidationUpload.test.js
@@ -18,4 +18,13 @@ describe('ManualIdentityValidation resubmit upload flow', () => {
         expect(viewSource).toContain('canUpload()');
         expect(viewSource).toContain('canResubmitWithoutPayment');
     });
+
+    it('uses shouldShowManualValidationAlreadySubmitted for submitted-state panel', () => {
+        expect(viewSource).toContain('shouldShowManualValidationAlreadySubmitted');
+    });
+
+    it('supports restart query param to begin payment again after exhausted rejections', () => {
+        expect(viewSource).toContain('forcePaymentRestart');
+        expect(viewSource).toContain("q.restart === '1'");
+    });
 });


### PR DESCRIPTION
## Summary

Users who paid for manual identity verification and had their submission rejected can now resubmit documents without paying again, up to a configurable limit (default: 3 submissions per payment). After exhausting attempts, they can start a new paid manual verification flow.

## Cause

- Rejected manual verifications left users stuck: they had already paid but could not re-upload documents without paying again.
- The rejection card linked to Mesa de ayuda instead of the upload flow.
- After 3 rejections, visiting `/setting/identity-validation/manual` still showed “Documentación enviada” because `submitted_at` was set, blocking the payment restart screen.

## Frontend (`carpoolear`)

**Changes**
- Rejection card: when resubmit is allowed, show **“Click acá para subir los documentos nuevamente”** linking to the manual upload screen (replaces Mesa de ayuda link).
- `ManualIdentityValidation`: detect `can_resubmit_without_payment` from the status API and show the upload form without requiring a new payment.
- After exhausted rejections: show the payment screen again instead of “Documentación enviada”.
- Support `?restart=1` when restarting from the rejection choice card; manual verification button navigates with this param when payment is required again.

## Test plan

- [ ] Reject a paid manual submission → rejection card shows resubmit link (not Mesa de ayuda).
- [ ] Click resubmit link → lands on upload screen without payment.
- [ ] Resubmit documents → status returns to pending review.
- [ ] Repeat until 3 total submissions → resubmit link disappears; manual verification requires payment again.
- [ ] After 3 rejections, open `/setting/identity-validation/manual` → payment screen is shown (not “Documentación enviada”).
- [ ] Click “Solicitar verificación manual” after exhausted rejections → opens with `?restart=1` and payment flow works.
- [ ] Change `MANUAL_IDENTITY_VALIDATION_MAX_SUBMISSIONS` in backend config and verify the limit is respected.