### PR TITLE
Support info

### DIFF
--- a/src/components/sections/Debug.vue
+++ b/src/components/sections/Debug.vue
@@ -38,7 +38,7 @@
 <script>
 /* jshint esversion: 6 */
 
-import { getInstance, init as initDebugLogger } from '../../services/debug';
+import { getInstance, init as initDebugLogger, refreshSupportInfoSnapshot } from '../../services/debug';
 
 export default {
     name: 'Debug',
@@ -60,16 +60,21 @@ export default {
         this.refreshState();
     },
     methods: {
-        refreshState() {
+        async refreshState() {
             let instance = getInstance();
             if (!instance) {
-                initDebugLogger().then(() => {
-                    this.refreshState();
-                }).catch((err) => {
+                try {
+                    await initDebugLogger();
+                } catch (err) {
                     console.error('Debug init failed:', err);
-                });
+                    return;
+                }
+                instance = getInstance();
+            }
+            if (!instance) {
                 return;
             }
+            await refreshSupportInfoSnapshot(instance);
             this.debugEnabled = instance.isEnabled();
             this.debugInfo = instance.getDebugInfo();
         },
@@ -83,6 +88,7 @@ export default {
             try {
                 await instance.setEnabled(!this.debugEnabled);
                 this.debugEnabled = instance.isEnabled();
+                await refreshSupportInfoSnapshot(instance);
                 this.debugInfo = instance.getDebugInfo();
             } catch (err) {
                 console.error('Toggle debug mode failed:', err);

--- a/src/components/views/TicketNew.view.test.js
+++ b/src/components/views/TicketNew.view.test.js
@@ -12,4 +12,10 @@ describe('TicketNew view', () => {
         expect(source).toContain('USER_TICKET_TYPE_OPTIONS');
         expect(source).toContain('USER_TICKET_TYPE_VALUES');
     });
+
+    it('appends support info to ticket messages', () => {
+        expect(source).toContain("from '../../utils/supportInfo'");
+        expect(source).toContain('appendSupportInfoToMessage');
+        expect(source).toContain('fetchSupportInfoSnapshot');
+    });
 });

--- a/src/components/views/TicketNew.vue
+++ b/src/components/views/TicketNew.vue
@@ -52,6 +52,10 @@ import {
     IMAGE_UPLOAD_ACCEPT
 } from '../../utils/imageUpload';
 import { applyImageUploadSelection } from '../../utils/imageUploadSelection';
+import {
+    appendSupportInfoToMessage,
+    fetchSupportInfoSnapshot
+} from '../../utils/supportInfo';
 
 export default {
     name: 'ticket-new',
@@ -89,12 +93,14 @@ export default {
                 this.attachments = files;
             }
         },
-        createTicket() {
+        async createTicket() {
             const markdown = this.$refs.createEditor.invoke('getMarkdown');
+            const snapshot = await fetchSupportInfoSnapshot();
+            const messageMarkdown = appendSupportInfoToMessage(markdown, snapshot);
             return this.createTicketAction({
                 type: this.form.type,
                 subject: this.form.subject,
-                message_markdown: markdown,
+                message_markdown: messageMarkdown,
                 attachments: this.attachments
             }).then((ticket) => {
                 this.$router.push({ name: 'ticket-detail', params: { id: ticket.id } });

--- a/src/services/debug/debugLogger.js
+++ b/src/services/debug/debugLogger.js
@@ -1,5 +1,10 @@
 /* jshint esversion: 6 */
 
+import {
+    buildSupportInfoSnapshot,
+    formatSupportInfoBlock
+} from '../../utils/supportInfo.js';
+
 const STORAGE_KEY = 'DEBUG_MODE_ENABLED';
 const LOG_LEVELS = ['log', 'info', 'warn', 'error', 'debug'];
 
@@ -22,14 +27,21 @@ function createDebugLogger(options = {}) {
         getItem: () => Promise.resolve(null),
         setItem: () => Promise.resolve()
     };
-    const getDeviceInfo = options.getDeviceInfo || function () {
-        return {
-            appVersion: (typeof window !== 'undefined' && window.appVersion) || 'unknown',
-            device: (typeof window !== 'undefined' && window.device) || { platform: 'unknown', model: 'unknown', osVersion: 'unknown' },
-            notificationPermission: typeof window !== 'undefined' && window.Notification ? window.Notification.permission : 'unknown',
-            networkOnline: (typeof navigator !== 'undefined' && navigator.onLine !== undefined) ? navigator.onLine : true
-        };
+    const getSupportInfoSnapshot = options.getSupportInfoSnapshot || function () {
+        return buildSupportInfoSnapshot({
+            windowAppVersion: (typeof window !== 'undefined' && window.appVersion) || null,
+            device: (typeof window !== 'undefined' && window.device) || null,
+            notificationPermission: typeof window !== 'undefined' && window.Notification
+                ? window.Notification.permission
+                : null,
+            networkOnline: (typeof navigator !== 'undefined' && navigator.onLine !== undefined)
+                ? navigator.onLine
+                : null,
+            userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : null
+        });
     };
+
+    let supportInfoSnapshot = getSupportInfoSnapshot();
 
     let logBuffer = [];
     let enabled = false;
@@ -75,15 +87,19 @@ function createDebugLogger(options = {}) {
         logBuffer = [];
     }
 
+    function setSupportInfoSnapshot(snapshot) {
+        supportInfoSnapshot = snapshot;
+    }
+
+    function refreshSupportInfoSnapshot() {
+        supportInfoSnapshot = getSupportInfoSnapshot();
+    }
+
     function getDebugInfo() {
-        const info = getDeviceInfo();
         const lines = [];
 
         lines.push('=== Carpoolear Debug Info ===');
-        lines.push(`App Version: ${info.appVersion}`);
-        lines.push(`Device: ${JSON.stringify(info.device)}`);
-        lines.push(`Notification Permission: ${info.notificationPermission}`);
-        lines.push(`Network: ${info.networkOnline ? 'online' : 'offline'}`);
+        lines.push(formatSupportInfoBlock(supportInfoSnapshot));
         lines.push('');
         lines.push('=== Console Logs ===');
 
@@ -128,6 +144,8 @@ function createDebugLogger(options = {}) {
         init,
         clearLogs,
         getDebugInfo,
+        setSupportInfoSnapshot,
+        refreshSupportInfoSnapshot,
         isEnabled,
         isEnabledAsync,
         setEnabled
@@ -143,11 +161,11 @@ function getDefaultInstance() {
     return defaultInstance;
 }
 
-function init(cache, getDeviceInfo) {
+function init(cache, getSupportInfoSnapshot) {
     if (!defaultInstance) {
         defaultInstance = createDebugLogger({
             storage: cache,
-            getDeviceInfo
+            getSupportInfoSnapshot
         });
     }
     return defaultInstance;

--- a/src/services/debug/debugLogger.test.js
+++ b/src/services/debug/debugLogger.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createDebugLogger } from './debugLogger.js';
+import { buildSupportInfoSnapshot } from '../../utils/supportInfo.js';
 
 describe('debugLogger', () => {
     let mockStorage;
-    let mockGetDeviceInfo;
+    let mockGetSupportInfoSnapshot;
     let originalConsole;
 
     beforeEach(() => {
@@ -11,12 +12,17 @@ describe('debugLogger', () => {
             getItem: vi.fn().mockResolvedValue(null),
             setItem: vi.fn().mockResolvedValue()
         };
-        mockGetDeviceInfo = vi.fn().mockReturnValue({
-            appVersion: '3.1.6',
-            device: { platform: 'web', model: 'Test', osVersion: '1.0' },
-            notificationPermission: 'default',
-            networkOnline: true
-        });
+        mockGetSupportInfoSnapshot = vi.fn().mockReturnValue(
+            buildSupportInfoSnapshot({
+                appVersionInfo: null,
+                windowAppVersion: '3.1.6',
+                capacitorPlatform: 'web',
+                isNativePlatform: false,
+                device: { platform: 'web', model: 'Test', version: '1.0' },
+                notificationPermission: 'default',
+                networkOnline: true
+            })
+        );
         originalConsole = { ...console };
     });
 
@@ -29,7 +35,7 @@ describe('debugLogger', () => {
     describe('init', () => {
         it('clears the log buffer on init', async () => {
             mockStorage.getItem.mockResolvedValue(true);
-            const logger = createDebugLogger({ storage: mockStorage, getDeviceInfo: mockGetDeviceInfo });
+            const logger = createDebugLogger({ storage: mockStorage, getSupportInfoSnapshot: mockGetSupportInfoSnapshot });
             await logger.init();
             console.log('first');
             await logger.init();
@@ -41,7 +47,7 @@ describe('debugLogger', () => {
 
         it('reads enabled state from storage on init', async () => {
             mockStorage.getItem.mockResolvedValue(true);
-            const logger = createDebugLogger({ storage: mockStorage, getDeviceInfo: mockGetDeviceInfo });
+            const logger = createDebugLogger({ storage: mockStorage, getSupportInfoSnapshot: mockGetSupportInfoSnapshot });
             await logger.init();
             expect(logger.isEnabled()).toBe(true);
         });
@@ -50,7 +56,7 @@ describe('debugLogger', () => {
     describe('log capture', () => {
         it('captures console.log when enabled', async () => {
             mockStorage.getItem.mockResolvedValue(true);
-            const logger = createDebugLogger({ storage: mockStorage, getDeviceInfo: mockGetDeviceInfo });
+            const logger = createDebugLogger({ storage: mockStorage, getSupportInfoSnapshot: mockGetSupportInfoSnapshot });
             await logger.init();
             console.log('hello world');
             const info = logger.getDebugInfo();
@@ -60,7 +66,7 @@ describe('debugLogger', () => {
 
         it('captures console.warn when enabled', async () => {
             mockStorage.getItem.mockResolvedValue(true);
-            const logger = createDebugLogger({ storage: mockStorage, getDeviceInfo: mockGetDeviceInfo });
+            const logger = createDebugLogger({ storage: mockStorage, getSupportInfoSnapshot: mockGetSupportInfoSnapshot });
             await logger.init();
             console.warn('warning message');
             const info = logger.getDebugInfo();
@@ -70,7 +76,7 @@ describe('debugLogger', () => {
 
         it('captures console.error when enabled', async () => {
             mockStorage.getItem.mockResolvedValue(true);
-            const logger = createDebugLogger({ storage: mockStorage, getDeviceInfo: mockGetDeviceInfo });
+            const logger = createDebugLogger({ storage: mockStorage, getSupportInfoSnapshot: mockGetSupportInfoSnapshot });
             await logger.init();
             console.error('error message');
             const info = logger.getDebugInfo();
@@ -82,7 +88,7 @@ describe('debugLogger', () => {
     describe('clearLogs', () => {
         it('clears previous logs', async () => {
             mockStorage.getItem.mockResolvedValue(true);
-            const logger = createDebugLogger({ storage: mockStorage, getDeviceInfo: mockGetDeviceInfo });
+            const logger = createDebugLogger({ storage: mockStorage, getSupportInfoSnapshot: mockGetSupportInfoSnapshot });
             await logger.init();
             console.log('before clear');
             logger.clearLogs();
@@ -94,23 +100,19 @@ describe('debugLogger', () => {
     });
 
     describe('getDebugInfo', () => {
-        it('includes app version in output', async () => {
-            const logger = createDebugLogger({ storage: mockStorage, getDeviceInfo: mockGetDeviceInfo });
+        it('includes labeled support info fields in output', async () => {
+            const logger = createDebugLogger({ storage: mockStorage, getSupportInfoSnapshot: mockGetSupportInfoSnapshot });
             await logger.init();
             const info = logger.getDebugInfo();
-            expect(info).toContain('3.1.6');
-        });
-
-        it('includes device info in output', async () => {
-            const logger = createDebugLogger({ storage: mockStorage, getDeviceInfo: mockGetDeviceInfo });
-            await logger.init();
-            const info = logger.getDebugInfo();
-            expect(info).toContain('web');
-            expect(info).toContain('Test');
+            expect(info).toContain('App Version: 3.1.6');
+            expect(info).toContain('Platform: web');
+            expect(info).toContain('Device Model: Test');
+            expect(info).toContain('OS Version: 1.0');
+            expect(info).not.toContain('"platform"');
         });
 
         it('includes notification permission in output', async () => {
-            const logger = createDebugLogger({ storage: mockStorage, getDeviceInfo: mockGetDeviceInfo });
+            const logger = createDebugLogger({ storage: mockStorage, getSupportInfoSnapshot: mockGetSupportInfoSnapshot });
             await logger.init();
             const info = logger.getDebugInfo();
             expect(info).toContain('default');
@@ -118,23 +120,37 @@ describe('debugLogger', () => {
 
         it('includes captured log lines', async () => {
             mockStorage.getItem.mockResolvedValue(true);
-            const logger = createDebugLogger({ storage: mockStorage, getDeviceInfo: mockGetDeviceInfo });
+            const logger = createDebugLogger({ storage: mockStorage, getSupportInfoSnapshot: mockGetSupportInfoSnapshot });
             await logger.init();
             console.log('my log entry');
             const info = logger.getDebugInfo();
             expect(info).toContain('my log entry');
         });
+
+        it('uses refreshed support info snapshot when updated', async () => {
+            const logger = createDebugLogger({ storage: mockStorage, getSupportInfoSnapshot: mockGetSupportInfoSnapshot });
+            await logger.init();
+            logger.setSupportInfoSnapshot(buildSupportInfoSnapshot({
+                windowAppVersion: '9.9.9',
+                capacitorPlatform: 'android',
+                isNativePlatform: true,
+                device: { platform: 'android', model: 'Pixel', version: '15' }
+            }));
+            const info = logger.getDebugInfo();
+            expect(info).toContain('App Version: 9.9.9');
+            expect(info).toContain('Platform: android');
+        });
     });
 
     describe('isEnabled / setEnabled', () => {
         it('returns false when not enabled', async () => {
-            const logger = createDebugLogger({ storage: mockStorage, getDeviceInfo: mockGetDeviceInfo });
+            const logger = createDebugLogger({ storage: mockStorage, getSupportInfoSnapshot: mockGetSupportInfoSnapshot });
             await logger.init();
             expect(logger.isEnabled()).toBe(false);
         });
 
         it('persists enabled state via storage', async () => {
-            const logger = createDebugLogger({ storage: mockStorage, getDeviceInfo: mockGetDeviceInfo });
+            const logger = createDebugLogger({ storage: mockStorage, getSupportInfoSnapshot: mockGetSupportInfoSnapshot });
             await logger.init();
             mockStorage.setItem.mockClear();
             await logger.setEnabled(true);
@@ -143,7 +159,7 @@ describe('debugLogger', () => {
 
         it('reads enabled state from storage', async () => {
             mockStorage.getItem.mockResolvedValue(true);
-            const logger = createDebugLogger({ storage: mockStorage, getDeviceInfo: mockGetDeviceInfo });
+            const logger = createDebugLogger({ storage: mockStorage, getSupportInfoSnapshot: mockGetSupportInfoSnapshot });
             const enabled = await logger.isEnabledAsync();
             expect(enabled).toBe(true);
         });

--- a/src/services/debug/index.js
+++ b/src/services/debug/index.js
@@ -2,45 +2,53 @@
 
 import cache from '../cache';
 import { createDebugLogger } from './debugLogger.js';
+import {
+    buildSupportInfoSnapshot,
+    fetchSupportInfoSnapshot
+} from '../../utils/supportInfo.js';
 
 let defaultInstance = null;
 
-async function getDeviceInfo() {
-    let device = (window && window.device) || { platform: 'unknown', model: 'unknown', osVersion: 'unknown' };
-    let networkOnline = (typeof navigator !== 'undefined' && navigator.onLine !== undefined) ? navigator.onLine : true;
-    try {
-        const { useCordovaStore } = await import('../../stores/cordova');
-        const store = useCordovaStore();
-        if (store && store.device) {
-            device = store.device;
-        }
-        if (store && store.networkState !== undefined) {
-            networkOnline = store.networkState;
-        }
-    } catch (e) {
-        // Store not ready yet, use window/navigator fallbacks
-    }
-    return {
-        appVersion: (window && window.appVersion) || 'unknown',
-        device,
+function getSupportInfoSnapshot() {
+    return buildSupportInfoSnapshot({
+        windowAppVersion: typeof window !== 'undefined' && window.appVersion
+            ? window.appVersion
+            : null,
+        device: typeof window !== 'undefined' && window.device ? window.device : null,
         notificationPermission: typeof window !== 'undefined' && window.Notification
             ? window.Notification.permission
-            : 'unknown',
-        networkOnline
-    };
+            : null,
+        networkOnline: typeof navigator !== 'undefined' && navigator.onLine !== undefined
+            ? navigator.onLine
+            : null,
+        userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : null
+    });
+}
+
+async function refreshSupportInfoSnapshot(instance) {
+    if (!instance) {
+        return;
+    }
+
+    try {
+        const snapshot = await fetchSupportInfoSnapshot();
+        instance.setSupportInfoSnapshot(snapshot);
+    } catch (err) {
+        instance.refreshSupportInfoSnapshot();
+    }
 }
 
 async function init() {
     defaultInstance = createDebugLogger({
         storage: cache,
-        getDeviceInfo
+        getSupportInfoSnapshot
     });
     await defaultInstance.init();
+    await refreshSupportInfoSnapshot(defaultInstance);
 }
 
 function getInstance() {
     return defaultInstance;
 }
 
-export { init, getInstance };
-export { createDebugLogger } from './debugLogger.js';
+export { init, getInstance, refreshSupportInfoSnapshot };

--- a/src/utils/supportInfo.js
+++ b/src/utils/supportInfo.js
@@ -155,3 +155,72 @@ export function appendSupportInfoToMessage(message, snapshot) {
 
     return `${trimmed}\n\n${block}`;
 }
+
+export async function fetchSupportInfoSnapshot(deps = {}) {
+    const {
+        importCordovaStore = () => import('../stores/cordova.js'),
+        importRootStore = () => import('../stores/root.js'),
+        importCapacitorCore = () => import('@capacitor/core'),
+        windowRef = typeof window !== 'undefined' ? window : null,
+        navigatorRef = typeof navigator !== 'undefined' ? navigator : null
+    } = deps;
+
+    let appVersionInfo = null;
+    let device = windowRef && windowRef.device ? windowRef.device : null;
+    let deviceId = null;
+    let networkOnline = navigatorRef && navigatorRef.onLine !== undefined
+        ? navigatorRef.onLine
+        : null;
+    let capacitorPlatform = 'unknown';
+    let isNativePlatform = false;
+
+    try {
+        const { Capacitor } = await importCapacitorCore();
+        capacitorPlatform = Capacitor.getPlatform();
+        isNativePlatform = Capacitor.isNativePlatform();
+    } catch (e) {
+        // Capacitor unavailable in test or web-only contexts
+    }
+
+    try {
+        const { useRootStore } = await importRootStore();
+        const rootStore = useRootStore();
+        if (rootStore && rootStore.appVersionInfo) {
+            appVersionInfo = rootStore.appVersionInfo;
+        }
+    } catch (e) {
+        // Store not ready yet
+    }
+
+    try {
+        const { useCordovaStore } = await importCordovaStore();
+        const store = useCordovaStore();
+        if (store) {
+            if (store.device) {
+                device = store.device;
+            }
+            if (store.deviceId) {
+                deviceId = store.deviceId;
+            }
+            if (store.networkState !== undefined) {
+                networkOnline = store.networkState;
+            }
+        }
+    } catch (e) {
+        // Store not ready yet
+    }
+
+    return buildSupportInfoSnapshot({
+        appVersionInfo,
+        windowAppVersion: windowRef && windowRef.appVersion ? windowRef.appVersion : null,
+        capacitorPlatform,
+        isNativePlatform,
+        device,
+        deviceId,
+        networkOnline,
+        notificationPermission: windowRef && windowRef.Notification
+            ? windowRef.Notification.permission
+            : null,
+        userAgent: navigatorRef ? navigatorRef.userAgent : null
+    });
+}

--- a/src/utils/supportInfo.js
+++ b/src/utils/supportInfo.js
@@ -1,0 +1,110 @@
+import { SPLASH_WEB_BUILD_NUMBER } from './customSplash.js';
+
+export const SUPPORT_INFO_SECTION_HEADER = '--- Información del dispositivo ---';
+
+function displayValue(value, fallback = 'unknown') {
+    if (value === null || value === undefined || value === '') {
+        return fallback;
+    }
+    return String(value);
+}
+
+export function resolveAppVersion({
+    appVersionInfo,
+    windowAppVersion,
+    webBuildNumber = SPLASH_WEB_BUILD_NUMBER,
+    isNativePlatform = false
+} = {}) {
+    if (appVersionInfo && appVersionInfo.version != null && appVersionInfo.version !== '') {
+        return {
+            appVersion: String(appVersionInfo.version),
+            appVersionName: displayValue(appVersionInfo.versionName, ''),
+            appVersionSource: displayValue(appVersionInfo.versionSource, 'unknown'),
+            webBuildNumber: isNativePlatform ? '' : String(webBuildNumber)
+        };
+    }
+
+    if (windowAppVersion) {
+        return {
+            appVersion: String(windowAppVersion),
+            appVersionName: '',
+            appVersionSource: 'fallback',
+            webBuildNumber: isNativePlatform ? '' : String(webBuildNumber)
+        };
+    }
+
+    return {
+        appVersion: 'unknown',
+        appVersionName: '',
+        appVersionSource: 'unknown',
+        webBuildNumber: isNativePlatform ? '' : String(webBuildNumber)
+    };
+}
+
+export function normalizeDeviceRecord(device) {
+    if (!device || typeof device !== 'object') {
+        return {
+            operatingSystem: 'unknown',
+            deviceModel: 'unknown',
+            osVersion: 'unknown',
+            deviceManufacturer: 'unknown',
+            isVirtual: 'unknown',
+            webViewVersion: 'unknown'
+        };
+    }
+
+    const operatingSystem = displayValue(
+        device.platform || device.operatingSystem,
+        'unknown'
+    );
+    const osVersion = displayValue(
+        device.osVersion || device.version || device.os,
+        'unknown'
+    );
+
+    return {
+        operatingSystem,
+        deviceModel: displayValue(device.model, 'unknown'),
+        osVersion,
+        deviceManufacturer: displayValue(device.manufacturer, 'unknown'),
+        isVirtual: device.isVirtual === undefined
+            ? 'unknown'
+            : String(Boolean(device.isVirtual)),
+        webViewVersion: displayValue(device.webViewVersion, 'unknown')
+    };
+}
+
+export function buildSupportInfoSnapshot(deps = {}) {
+    const {
+        appVersionInfo = null,
+        windowAppVersion = null,
+        capacitorPlatform = 'unknown',
+        isNativePlatform = false,
+        webBuildNumber = SPLASH_WEB_BUILD_NUMBER,
+        device = null,
+        deviceId = null,
+        networkOnline = null,
+        notificationPermission = null,
+        userAgent = null
+    } = deps;
+
+    const versionFields = resolveAppVersion({
+        appVersionInfo,
+        windowAppVersion,
+        webBuildNumber,
+        isNativePlatform
+    });
+    const deviceFields = normalizeDeviceRecord(device);
+
+    return {
+        ...versionFields,
+        platform: displayValue(capacitorPlatform, 'unknown'),
+        ...deviceFields,
+        deviceId: displayValue(deviceId, 'unknown'),
+        networkOnline: networkOnline === null
+            ? 'unknown'
+            : (networkOnline ? 'online' : 'offline'),
+        notificationPermission: displayValue(notificationPermission, 'unknown'),
+        userAgent: displayValue(userAgent, 'unknown')
+    };
+}

--- a/src/utils/supportInfo.js
+++ b/src/utils/supportInfo.js
@@ -108,3 +108,50 @@ export function buildSupportInfoSnapshot(deps = {}) {
         userAgent: displayValue(userAgent, 'unknown')
     };
 }
+
+const SUPPORT_INFO_FIELD_LABELS = [
+    ['appVersion', 'App Version'],
+    ['appVersionName', 'App Version Name'],
+    ['appVersionSource', 'App Version Source'],
+    ['webBuildNumber', 'Web Build'],
+    ['platform', 'Platform'],
+    ['operatingSystem', 'Operating System'],
+    ['deviceModel', 'Device Model'],
+    ['osVersion', 'OS Version'],
+    ['deviceManufacturer', 'Manufacturer'],
+    ['isVirtual', 'Is Virtual Device'],
+    ['webViewVersion', 'WebView Version'],
+    ['deviceId', 'Device ID'],
+    ['networkOnline', 'Network'],
+    ['notificationPermission', 'Notification Permission'],
+    ['userAgent', 'User Agent']
+];
+
+export function formatSupportInfoLines(snapshot) {
+    const lines = [SUPPORT_INFO_SECTION_HEADER];
+
+    SUPPORT_INFO_FIELD_LABELS.forEach(([key, label]) => {
+        const value = snapshot[key];
+        if (value === '' || value === undefined) {
+            return;
+        }
+        lines.push(`${label}: ${value}`);
+    });
+
+    return lines;
+}
+
+export function formatSupportInfoBlock(snapshot) {
+    return formatSupportInfoLines(snapshot).join('\n');
+}
+
+export function appendSupportInfoToMessage(message, snapshot) {
+    const block = formatSupportInfoBlock(snapshot);
+    const trimmed = message == null ? '' : String(message).trim();
+
+    if (!trimmed) {
+        return block;
+    }
+
+    return `${trimmed}\n\n${block}`;
+}

--- a/src/utils/supportInfo.test.js
+++ b/src/utils/supportInfo.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { buildSupportInfoSnapshot } from './supportInfo.js';
+
+describe('buildSupportInfoSnapshot', () => {
+    it('includes app version from native appVersionInfo on android', () => {
+        const snapshot = buildSupportInfoSnapshot({
+            appVersionInfo: {
+                version: '120',
+                versionName: '3.2.9',
+                versionSource: 'real',
+                platform: 'android'
+            },
+            capacitorPlatform: 'android',
+            isNativePlatform: true
+        });
+
+        expect(snapshot.appVersion).toBe('120');
+        expect(snapshot.appVersionName).toBe('3.2.9');
+        expect(snapshot.appVersionSource).toBe('real');
+        expect(snapshot.platform).toBe('android');
+    });
+
+    it('includes web build number when running on web', () => {
+        const snapshot = buildSupportInfoSnapshot({
+            windowAppVersion: '3.2.9',
+            capacitorPlatform: 'web',
+            isNativePlatform: false,
+            webBuildNumber: 120
+        });
+
+        expect(snapshot.appVersion).toBe('3.2.9');
+        expect(snapshot.webBuildNumber).toBe('120');
+        expect(snapshot.platform).toBe('web');
+    });
+
+    it('normalizes device fields without undefined values', () => {
+        const snapshot = buildSupportInfoSnapshot({
+            device: {
+                platform: 'android',
+                model: 'Pixel 7',
+                version: '14',
+                manufacturer: 'Google',
+                isVirtual: false,
+                webViewVersion: '120.0.0'
+            },
+            deviceId: 'abc-123',
+            networkOnline: true,
+            notificationPermission: 'granted'
+        });
+
+        expect(snapshot.deviceModel).toBe('Pixel 7');
+        expect(snapshot.osVersion).toBe('14');
+        expect(snapshot.operatingSystem).toBe('android');
+        expect(snapshot.deviceManufacturer).toBe('Google');
+        expect(snapshot.deviceId).toBe('abc-123');
+        expect(snapshot.networkOnline).toBe('online');
+        expect(snapshot.notificationPermission).toBe('granted');
+        expect(snapshot.isVirtual).toBe('false');
+        expect(snapshot.webViewVersion).toBe('120.0.0');
+        expect(Object.values(snapshot).every((value) => value !== undefined)).toBe(true);
+    });
+});

--- a/src/utils/supportInfo.test.js
+++ b/src/utils/supportInfo.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
     appendSupportInfoToMessage,
     buildSupportInfoSnapshot,
+    fetchSupportInfoSnapshot,
     formatSupportInfoBlock,
     SUPPORT_INFO_SECTION_HEADER
 } from './supportInfo.js';
@@ -109,5 +110,49 @@ describe('appendSupportInfoToMessage', () => {
         expect(result.startsWith('Need help with login')).toBe(true);
         expect(result).toContain(SUPPORT_INFO_SECTION_HEADER);
         expect(result).toContain('Web Build: 120');
+    });
+});
+
+describe('fetchSupportInfoSnapshot', () => {
+    it('collects data from injected stores and globals', async () => {
+        const snapshot = await fetchSupportInfoSnapshot({
+            importCordovaStore: async () => ({
+                useCordovaStore: () => ({
+                    device: { platform: 'ios', model: 'iPhone', version: '17.4' },
+                    deviceId: 'device-uuid',
+                    networkState: false
+                })
+            }),
+            importRootStore: async () => ({
+                useRootStore: () => ({
+                    appVersionInfo: {
+                        version: '3.2.9',
+                        versionSource: 'real',
+                        platform: 'ios'
+                    }
+                })
+            }),
+            importCapacitorCore: async () => ({
+                Capacitor: {
+                    getPlatform: () => 'ios',
+                    isNativePlatform: () => true
+                }
+            }),
+            windowRef: {
+                appVersion: '3.2.9',
+                Notification: { permission: 'granted' }
+            },
+            navigatorRef: {
+                userAgent: 'TestAgent/1.0',
+                onLine: true
+            }
+        });
+
+        expect(snapshot.appVersion).toBe('3.2.9');
+        expect(snapshot.platform).toBe('ios');
+        expect(snapshot.deviceModel).toBe('iPhone');
+        expect(snapshot.deviceId).toBe('device-uuid');
+        expect(snapshot.networkOnline).toBe('offline');
+        expect(snapshot.notificationPermission).toBe('granted');
     });
 });

--- a/src/utils/supportInfo.test.js
+++ b/src/utils/supportInfo.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { buildSupportInfoSnapshot } from './supportInfo.js';
+import {
+    appendSupportInfoToMessage,
+    buildSupportInfoSnapshot,
+    formatSupportInfoBlock,
+    SUPPORT_INFO_SECTION_HEADER
+} from './supportInfo.js';
 
 describe('buildSupportInfoSnapshot', () => {
     it('includes app version from native appVersionInfo on android', () => {
@@ -58,5 +63,51 @@ describe('buildSupportInfoSnapshot', () => {
         expect(snapshot.isVirtual).toBe('false');
         expect(snapshot.webViewVersion).toBe('120.0.0');
         expect(Object.values(snapshot).every((value) => value !== undefined)).toBe(true);
+    });
+});
+
+describe('formatSupportInfoBlock', () => {
+    it('renders labeled device and app fields', () => {
+        const snapshot = buildSupportInfoSnapshot({
+            appVersionInfo: {
+                version: '120',
+                versionName: '3.2.9',
+                versionSource: 'real',
+                platform: 'android'
+            },
+            capacitorPlatform: 'android',
+            isNativePlatform: true,
+            device: {
+                platform: 'android',
+                model: 'Pixel 7',
+                version: '14'
+            }
+        });
+
+        const block = formatSupportInfoBlock(snapshot);
+
+        expect(block).toContain(SUPPORT_INFO_SECTION_HEADER);
+        expect(block).toContain('App Version: 120');
+        expect(block).toContain('App Version Name: 3.2.9');
+        expect(block).toContain('Platform: android');
+        expect(block).toContain('Device Model: Pixel 7');
+        expect(block).toContain('OS Version: 14');
+    });
+});
+
+describe('appendSupportInfoToMessage', () => {
+    it('appends support info block after the user message', () => {
+        const snapshot = buildSupportInfoSnapshot({
+            windowAppVersion: '3.2.9',
+            capacitorPlatform: 'web',
+            isNativePlatform: false,
+            webBuildNumber: 120
+        });
+
+        const result = appendSupportInfoToMessage('Need help with login', snapshot);
+
+        expect(result.startsWith('Need help with login')).toBe(true);
+        expect(result).toContain(SUPPORT_INFO_SECTION_HEADER);
+        expect(result).toContain('Web Build: 120');
     });
 });


### PR DESCRIPTION
## Summary

Improve device and app metadata shown on the Debug screen and automatically appended to new support ticket messages.

## Cause

The Debug screen frequently showed `undefined` values because:
- `getDeviceInfo()` was async but `getDebugInfo()` called it synchronously, so a Promise was stringified instead of resolved data
- Cordova/Capacitor device objects use `version` while the logger expected `osVersion`
- Device info was rendered as raw JSON with many missing fields

## Fix (Frontend)

- Add `src/utils/supportInfo.js` with pure helpers to build, format, and append a support info snapshot (app version from Capacitor/native store or `window.appVersion` fallback, web build number on web, platform, OS, device model, OS version, manufacturer, network, notification permission, user agent, etc.)
- Update `debugLogger` to use labeled support info output instead of raw JSON
- Refresh support info asynchronously on Debug screen load/toggle via Pinia stores and Capacitor
- Append the same support info block to the end of `message_markdown` when users create a ticket in `TicketNew.vue`

## Test plan

- [ ] Open Settings → Debug and verify labeled fields (App Version, Platform, Device Model, OS Version, etc.) — no `undefined`
- [ ] Toggle debug mode and confirm info refreshes correctly
- [ ] Copy debug info to clipboard and verify content
- [ ] Create a support ticket and confirm device/app metadata appears at the bottom of the first message
- [ ] Verify on web, Android, and iOS if possible (native app version vs web build number)