### PR TITLE
Show web build number on the native splash screen

### DIFF
--- a/src/utils/customSplash.js
+++ b/src/utils/customSplash.js
@@ -1,5 +1,5 @@
 export const CUSTOM_SPLASH_DISMISS_MS = 3000;
-export const SPLASH_WEB_BUILD_NUMBER = 121;
+export const SPLASH_WEB_BUILD_NUMBER = 124;
 
 export function formatSplashVersionText({
     version,
@@ -10,7 +10,7 @@ export function formatSplashVersionText({
         version != null && String(version) !== '' ? String(version) : '0';
     const base = `Version ${resolvedVersion}`;
 
-    return isNativePlatform ? base : `${base} - build ${webBuildNumber}`;
+    return `${base} - build ${webBuildNumber}`;
 }
 
 export function resolveSplashVersion({ appVersionInfo, windowAppVersion }) {

--- a/src/utils/customSplash.test.js
+++ b/src/utils/customSplash.test.js
@@ -12,19 +12,19 @@ describe('formatSplashVersionText', () => {
     it('shows version and build number on web', () => {
         expect(
             formatSplashVersionText({ version: '3.2.5', isNativePlatform: false })
-        ).toBe('Version 3.2.5 - build 116');
+        ).toBe('Version 3.2.5 - build 124');
     });
 
-    it('shows version only on native platforms', () => {
+    it('shows version and build number on native platforms', () => {
         expect(
             formatSplashVersionText({ version: '123', isNativePlatform: true })
-        ).toBe('Version 123');
+        ).toBe('Version 123 - build 124');
     });
 
     it('falls back to zero when version is missing', () => {
         expect(
             formatSplashVersionText({ version: null, isNativePlatform: false })
-        ).toBe('Version 0 - build 116');
+        ).toBe('Version 0 - build 124');
     });
 });
 
@@ -117,6 +117,6 @@ describe('CUSTOM_SPLASH_DISMISS_MS', () => {
     });
 
     it('exposes the web build number used on the splash screen', () => {
-        expect(SPLASH_WEB_BUILD_NUMBER).toBe(116);
+        expect(SPLASH_WEB_BUILD_NUMBER).toBe(124);
     });
 });


### PR DESCRIPTION
## Summary

Shows the web bundle build number on the native splash screen (iOS/Android), not just on web.

## Cause

After `npm run build` + `npx cap sync`, it was hard to confirm the device was running the latest JS bundle. The splash showed only the app version (e.g. `Version 3.3.1`) on native; the web build number was hidden.

## Fix (frontend)

- `formatSplashVersionText` now always appends `- build N` on all platforms
- `SPLASH_WEB_BUILD_NUMBER` bumped to **124**
- Tests updated in `customSplash.test.js`

## Test plan

- [ ] Rebuild, `cap sync`, run on iOS/Android
- [ ] Splash bottom-left shows e.g. `Version 3.3.1 - build 124` for ~3 seconds
- [ ] Web splash unchanged in behavior (still shows build number)