### PR TITLE
Fix image uploads

### DIFF
--- a/src/components/sections/ManualIdentityValidation.vue
+++ b/src/components/sections/ManualIdentityValidation.vue
@@ -230,6 +230,7 @@ import {
     getImageUploadMaxMb
 } from '../../utils/imageUpload';
 import { applyImageUploadSelection } from '../../utils/imageUploadSelection';
+import { compressImageFilesForUpload } from '../../utils/imageUploadCompress';
 import {
     shouldShowManualValidationAlreadySubmitted,
     shouldShowManualValidationPayAgain
@@ -476,29 +477,35 @@ export default {
             );
             this.files[type] = rejected ? null : (files[0] || null);
         },
-        submitImages() {
+        async submitImages() {
             if (!this.requestId || !this.files.front || !this.files.back || !this.files.selfie) {
                 this.submitError = this.$t('todosLosArchivosRequeridos');
                 return;
             }
             this.submitting = true;
             this.submitError = null;
-            const formData = new FormData();
-            formData.append('request_id', this.requestId);
-            formData.append('front_image', this.files.front);
-            formData.append('back_image', this.files.back);
-            formData.append('selfie_image', this.files.selfie);
 
-            const userApi = new UserApi();
-            userApi.submitManualIdentityValidation(this.requestId, formData)
-                .then(() => {
-                    this.$router.push({ name: 'identity_validation', query: { result: 'manual_submitted' } });
-                })
-                .catch((err) => {
-                    this.submitting = false;
-                    const msg = (err.response && err.response.data && (err.response.data.message || err.response.data.error)) || this.$t('resultError');
-                    this.submitError = typeof msg === 'string' ? msg : this.$t('resultError');
-                });
+            try {
+                const [front, back, selfie] = await compressImageFilesForUpload(
+                    [this.files.front, this.files.back, this.files.selfie],
+                    this.config
+                );
+
+                const formData = new FormData();
+                formData.append('request_id', this.requestId);
+                formData.append('front_image', front);
+                formData.append('back_image', back);
+                formData.append('selfie_image', selfie);
+
+                const userApi = new UserApi();
+                await userApi.submitManualIdentityValidation(this.requestId, formData);
+                this.$router.push({ name: 'identity_validation', query: { result: 'manual_submitted' } });
+            } catch (err) {
+                this.submitting = false;
+                const responseData = (err && err.data) || (err.response && err.response.data) || {};
+                const msg = responseData.message || responseData.error || err.message || this.$t('resultError');
+                this.submitError = typeof msg === 'string' ? msg : this.$t('resultError');
+            }
         }
     },
     watch: {

--- a/src/components/views/AdminSupportTicketDetail.vue
+++ b/src/components/views/AdminSupportTicketDetail.vue
@@ -204,6 +204,7 @@ import {
     IMAGE_UPLOAD_ACCEPT
 } from '../../utils/imageUpload';
 import { applyImageUploadSelection } from '../../utils/imageUploadSelection';
+import { compressImageFilesForUpload } from '../../utils/imageUploadCompress';
 import { useAuthStore } from '../../stores/auth';
 
 const PRIORITY_LABEL_KEYS = {
@@ -445,7 +446,7 @@ export default {
             this.replyEditorInitialValue = current + sep + chunk;
             this.replyEditorKey += 1;
         },
-        sendReply() {
+        async sendReply() {
             if (this.replySubmitting) {
                 return undefined;
             }
@@ -456,7 +457,18 @@ export default {
                 return undefined;
             }
             this.replySubmitting = true;
-            return this.adminReply(this.id, { message_markdown: messageMarkdown, attachments: this.attachments })
+            let attachments = this.attachments;
+            try {
+                attachments = await compressImageFilesForUpload(
+                    this.attachments,
+                    useAuthStore().appConfig
+                );
+            } catch (err) {
+                this.replySubmitting = false;
+                dialogs.message(this.$t('errorDatos'), ERROR_TOAST_OPTIONS);
+                return undefined;
+            }
+            return this.adminReply(this.id, { message_markdown: messageMarkdown, attachments })
                 .then(() => this.refresh())
                 .then(() => {
                     dialogs.message(this.$t('respuestaEnviada'), SUCCESS_TOAST_OPTIONS);

--- a/src/components/views/TicketDetail.vue
+++ b/src/components/views/TicketDetail.vue
@@ -89,6 +89,7 @@ import {
     IMAGE_UPLOAD_ACCEPT
 } from '../../utils/imageUpload';
 import { applyImageUploadSelection } from '../../utils/imageUploadSelection';
+import { compressImageFilesForUpload } from '../../utils/imageUploadCompress';
 import { useAuthStore } from '../../stores/auth';
 
 const SUCCESS_TOAST_OPTIONS = { estado: 'success', duration: 2 };
@@ -197,7 +198,7 @@ export default {
                 });
             });
         },
-        sendReply() {
+        async sendReply() {
             if (this.replySubmitting) {
                 return undefined;
             }
@@ -207,9 +208,20 @@ export default {
                 return undefined;
             }
             this.replySubmitting = true;
+            let attachments = this.attachments;
+            try {
+                attachments = await compressImageFilesForUpload(
+                    this.attachments,
+                    useAuthStore().appConfig
+                );
+            } catch (err) {
+                this.replySubmitting = false;
+                dialogs.message(this.$t('errorDatos'), ERROR_TOAST_OPTIONS);
+                return undefined;
+            }
             return this.replyTicket(this.id, {
                 message_markdown: markdown,
-                attachments: this.attachments
+                attachments
             })
                 .then(() => this.refresh())
                 .then(() => {

--- a/src/components/views/TicketNew.vue
+++ b/src/components/views/TicketNew.vue
@@ -52,6 +52,7 @@ import {
     IMAGE_UPLOAD_ACCEPT
 } from '../../utils/imageUpload';
 import { applyImageUploadSelection } from '../../utils/imageUploadSelection';
+import { compressImageFilesForUpload } from '../../utils/imageUploadCompress';
 import {
     appendSupportInfoToMessage,
     fetchSupportInfoSnapshot,
@@ -110,11 +111,21 @@ export default {
             }
             const snapshot = await fetchSupportInfoSnapshot();
             const messageMarkdown = appendSupportInfoToMessage(markdown, snapshot);
+            let attachments = this.attachments;
+            try {
+                attachments = await compressImageFilesForUpload(
+                    this.attachments,
+                    useAuthStore().appConfig
+                );
+            } catch (err) {
+                dialogs.message(this.$t('errorDatos'), { estado: 'error' });
+                return;
+            }
             return this.createTicketAction({
                 type: this.form.type,
                 subject: this.form.subject,
                 message_markdown: messageMarkdown,
-                attachments: this.attachments
+                attachments
             }).then((ticket) => {
                 this.$router.push({ name: 'ticket-detail', params: { id: ticket.id } });
             }).catch(() => dialogs.message(this.$t('errorDatos'), { estado: 'error' }));

--- a/src/utils/imageUploadCompress.js
+++ b/src/utils/imageUploadCompress.js
@@ -105,8 +105,8 @@ export async function compressImageFileForUpload(file, options = {}) {
     ctx.drawImage(img, 0, 0, width, height);
 
     let lastBlob = null;
-    for (const quality of QUALITY_STEPS) {
-        const blob = await canvasToJpegBlob(canvas, quality);
+    for (let stepIndex = 0; stepIndex < QUALITY_STEPS.length; stepIndex += 1) {
+        const blob = await canvasToJpegBlob(canvas, QUALITY_STEPS[stepIndex]);
         if (!blob) {
             continue;
         }

--- a/src/utils/imageUploadCompress.js
+++ b/src/utils/imageUploadCompress.js
@@ -1,0 +1,131 @@
+import { Capacitor } from '@capacitor/core';
+import { DEFAULT_IMAGE_UPLOAD_MAX_BYTES, getImageUploadMaxBytes } from './imageUpload';
+
+export const DEFAULT_COMPRESS_MAX_DIMENSION = 3072;
+export const NATIVE_UPLOAD_TARGET_BYTES = 3 * 1024 * 1024;
+const QUALITY_STEPS = [0.88, 0.78, 0.68, 0.58, 0.48];
+
+export function resolveNativeUploadMaxBytes(config) {
+    const maxBytes = getImageUploadMaxBytes(config);
+
+    if (Capacitor.isNativePlatform()) {
+        return Math.min(maxBytes, NATIVE_UPLOAD_TARGET_BYTES);
+    }
+
+    return maxBytes;
+}
+
+export async function compressImageFilesForUpload(files, config, options = {}) {
+    const maxBytes = options.maxBytes ?? resolveNativeUploadMaxBytes(config);
+    const list = Array.from(files || []);
+
+    if (!list.length) {
+        return [];
+    }
+
+    return Promise.all(
+        list.map((file) => compressImageFileForUpload(file, { ...options, maxBytes }))
+    );
+}
+
+export function computeScaledDimensions(width, height, maxDimension) {
+    if (!width || !height) {
+        return { width: 0, height: 0 };
+    }
+
+    if (width <= maxDimension && height <= maxDimension) {
+        return { width, height };
+    }
+
+    const scale = maxDimension / Math.max(width, height);
+
+    return {
+        width: Math.round(width * scale),
+        height: Math.round(height * scale)
+    };
+}
+
+function loadImageFromFile(file) {
+    return new Promise((resolve, reject) => {
+        const url = URL.createObjectURL(file);
+        const img = new Image();
+        img.onload = () => {
+            URL.revokeObjectURL(url);
+            resolve(img);
+        };
+        img.onerror = () => {
+            URL.revokeObjectURL(url);
+            reject(new Error('Failed to load image'));
+        };
+        img.src = url;
+    });
+}
+
+function canvasToJpegBlob(canvas, quality) {
+    return new Promise((resolve) => {
+        canvas.toBlob(resolve, 'image/jpeg', quality);
+    });
+}
+
+function buildCompressedFileName(file) {
+    const baseName = (file.name || 'image').replace(/\.[^.]+$/, '') || 'image';
+
+    return `${baseName}.jpg`;
+}
+
+export async function compressImageFileForUpload(file, options = {}) {
+    if (!file) {
+        throw new Error('Missing image file');
+    }
+
+    const maxBytes = options.maxBytes ?? DEFAULT_IMAGE_UPLOAD_MAX_BYTES;
+    const maxDimension = options.maxDimension ?? DEFAULT_COMPRESS_MAX_DIMENSION;
+    const mime = String(file.type || '').toLowerCase();
+
+    if (file.size <= maxBytes && /^image\/jpe?g$/.test(mime)) {
+        return file;
+    }
+
+    const img = await loadImageFromFile(file);
+    const { width, height } = computeScaledDimensions(
+        img.naturalWidth,
+        img.naturalHeight,
+        maxDimension
+    );
+
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+        throw new Error('Canvas not available');
+    }
+
+    ctx.drawImage(img, 0, 0, width, height);
+
+    let lastBlob = null;
+    for (const quality of QUALITY_STEPS) {
+        const blob = await canvasToJpegBlob(canvas, quality);
+        if (!blob) {
+            continue;
+        }
+
+        lastBlob = blob;
+        if (blob.size <= maxBytes) {
+            return new File([blob], buildCompressedFileName(file), {
+                type: 'image/jpeg',
+                lastModified: Date.now()
+            });
+        }
+    }
+
+    if (!lastBlob) {
+        throw new Error('Compression failed');
+    }
+
+    return new File([lastBlob], buildCompressedFileName(file), {
+        type: 'image/jpeg',
+        lastModified: Date.now()
+    });
+}

--- a/src/utils/imageUploadCompress.test.js
+++ b/src/utils/imageUploadCompress.test.js
@@ -1,11 +1,4 @@
 import { describe, expect, it, vi } from 'vitest';
-import {
-    computeScaledDimensions,
-    compressImageFilesForUpload,
-    DEFAULT_COMPRESS_MAX_DIMENSION,
-    NATIVE_UPLOAD_TARGET_BYTES,
-    resolveNativeUploadMaxBytes
-} from './imageUploadCompress.js';
 
 vi.mock('@capacitor/core', () => ({
     Capacitor: {
@@ -13,24 +6,28 @@ vi.mock('@capacitor/core', () => ({
     }
 }));
 
-import { Capacitor } from '@capacitor/core';
-
 describe('computeScaledDimensions', () => {
-    it('keeps dimensions when already within max', () => {
+    it('keeps dimensions when already within max', async () => {
+        const { computeScaledDimensions, DEFAULT_COMPRESS_MAX_DIMENSION } = await import('./imageUploadCompress.js');
+
         expect(computeScaledDimensions(800, 600, DEFAULT_COMPRESS_MAX_DIMENSION)).toEqual({
             width: 800,
             height: 600
         });
     });
 
-    it('scales down the longest edge to max dimension', () => {
+    it('scales down the longest edge to max dimension', async () => {
+        const { computeScaledDimensions, DEFAULT_COMPRESS_MAX_DIMENSION } = await import('./imageUploadCompress.js');
+
         expect(computeScaledDimensions(4032, 3024, DEFAULT_COMPRESS_MAX_DIMENSION)).toEqual({
             width: 3072,
             height: 2304
         });
     });
 
-    it('handles portrait photos', () => {
+    it('handles portrait photos', async () => {
+        const { computeScaledDimensions, DEFAULT_COMPRESS_MAX_DIMENSION } = await import('./imageUploadCompress.js');
+
         expect(computeScaledDimensions(3024, 4032, DEFAULT_COMPRESS_MAX_DIMENSION)).toEqual({
             width: 2304,
             height: 3072
@@ -39,13 +36,17 @@ describe('computeScaledDimensions', () => {
 });
 
 describe('resolveNativeUploadMaxBytes', () => {
-    it('uses config max on web', () => {
+    it('uses config max on web', async () => {
+        const { Capacitor } = await import('@capacitor/core');
+        const { resolveNativeUploadMaxBytes } = await import('./imageUploadCompress.js');
         Capacitor.isNativePlatform.mockReturnValue(false);
 
         expect(resolveNativeUploadMaxBytes({ image_upload_max_bytes: 5_000_000 })).toBe(5_000_000);
     });
 
-    it('caps native uploads at 3MB', () => {
+    it('caps native uploads at 3MB', async () => {
+        const { Capacitor } = await import('@capacitor/core');
+        const { resolveNativeUploadMaxBytes, NATIVE_UPLOAD_TARGET_BYTES } = await import('./imageUploadCompress.js');
         Capacitor.isNativePlatform.mockReturnValue(true);
 
         expect(resolveNativeUploadMaxBytes({ image_upload_max_bytes: 10_000_000 })).toBe(
@@ -56,6 +57,8 @@ describe('resolveNativeUploadMaxBytes', () => {
 
 describe('compressImageFilesForUpload', () => {
     it('returns empty array for no files', async () => {
+        const { compressImageFilesForUpload } = await import('./imageUploadCompress.js');
+
         await expect(compressImageFilesForUpload([], null)).resolves.toEqual([]);
     });
 });

--- a/src/utils/imageUploadCompress.test.js
+++ b/src/utils/imageUploadCompress.test.js
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    computeScaledDimensions,
+    compressImageFilesForUpload,
+    DEFAULT_COMPRESS_MAX_DIMENSION,
+    NATIVE_UPLOAD_TARGET_BYTES,
+    resolveNativeUploadMaxBytes
+} from './imageUploadCompress.js';
+
+vi.mock('@capacitor/core', () => ({
+    Capacitor: {
+        isNativePlatform: vi.fn(() => false)
+    }
+}));
+
+import { Capacitor } from '@capacitor/core';
+
+describe('computeScaledDimensions', () => {
+    it('keeps dimensions when already within max', () => {
+        expect(computeScaledDimensions(800, 600, DEFAULT_COMPRESS_MAX_DIMENSION)).toEqual({
+            width: 800,
+            height: 600
+        });
+    });
+
+    it('scales down the longest edge to max dimension', () => {
+        expect(computeScaledDimensions(4032, 3024, DEFAULT_COMPRESS_MAX_DIMENSION)).toEqual({
+            width: 3072,
+            height: 2304
+        });
+    });
+
+    it('handles portrait photos', () => {
+        expect(computeScaledDimensions(3024, 4032, DEFAULT_COMPRESS_MAX_DIMENSION)).toEqual({
+            width: 2304,
+            height: 3072
+        });
+    });
+});
+
+describe('resolveNativeUploadMaxBytes', () => {
+    it('uses config max on web', () => {
+        Capacitor.isNativePlatform.mockReturnValue(false);
+
+        expect(resolveNativeUploadMaxBytes({ image_upload_max_bytes: 5_000_000 })).toBe(5_000_000);
+    });
+
+    it('caps native uploads at 3MB', () => {
+        Capacitor.isNativePlatform.mockReturnValue(true);
+
+        expect(resolveNativeUploadMaxBytes({ image_upload_max_bytes: 10_000_000 })).toBe(
+            NATIVE_UPLOAD_TARGET_BYTES
+        );
+    });
+});
+
+describe('compressImageFilesForUpload', () => {
+    it('returns empty array for no files', async () => {
+        await expect(compressImageFilesForUpload([], null)).resolves.toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes intermittent image upload failures on iOS/Android for manual identity verification and support ticket attachments.

## Cause

On native apps, CapacitorHttp sends `FormData` file uploads as base64-encoded multipart payloads. Large gallery/camera photos (often PNG, several MB each) caused:

- **413** — POST body too large
- **422** — Laravel `uploaded` validation failure (`El front/back image falló al subir.`) when PHP did not receive one or more files (partial/truncated multipart)

Small JPEGs worked; 3 full-size iPhone photos failed consistently or intermittently.

## Fix (frontend)

- Added `imageUploadCompress.js` to resize, convert to JPEG, and cap file size before upload on native
- **Limits:** 3072px longest edge, 3MB per file on iOS/Android; web uses existing config max
- Applied before submit in:
  - Manual identity validation (`ManualIdentityValidation.vue`)
  - Support ticket create (`TicketNew.vue`)
  - Support ticket reply — user (`TicketDetail.vue`) and admin (`AdminSupportTicketDetail.vue`)

## Test plan

- [ ] iOS: manual identity validation with 3 gallery/camera photos → 201 success
- [ ] iOS: support ticket create/reply with 3 image attachments → success
- [ ] Android: same flows as iOS
- [ ] Web: uploads still work (compression only when needed)