### PR TITLE
Admin manual verification sort columns

### DIFF
--- a/src/components/views/AdminManualIdentityValidations.view.test.js
+++ b/src/components/views/AdminManualIdentityValidations.view.test.js
@@ -26,18 +26,13 @@ describe('AdminManualIdentityValidations view', () => {
     });
 
     it('renders sortable column headers for manual validation rows', () => {
+        expect(viewSource).toContain('MANUAL_IDENTITY_VALIDATION_SORT_COLUMNS');
         expect(viewSource).toContain('sortManualIdentityValidationsList');
         expect(viewSource).toContain('getNextManualIdentityValidationSortState');
         expect(viewSource).toContain('toggleSort(');
         expect(viewSource).toContain('admin-manual-th-sort');
-        expect(viewSource).toContain('sortKey ===');
-        expect(viewSource).toContain("@click=\"toggleSort('id')\"");
-        expect(viewSource).toContain("@click=\"toggleSort('user_name')\"");
-        expect(viewSource).toContain("@click=\"toggleSort('paid_at')\"");
-        expect(viewSource).toContain("@click=\"toggleSort('submitted_at')\"");
-        expect(viewSource).toContain("@click=\"toggleSort('waiting_time')\"");
-        expect(viewSource).toContain("@click=\"toggleSort('paid')\"");
-        expect(viewSource).toContain("@click=\"toggleSort('review_status')\"");
+        expect(viewSource).toContain('sortKey === column.key');
+        expect(viewSource).toContain('toggleSort(column.key)');
         expect(viewSource).not.toContain("@click=\"toggleSort('acciones')\"");
     });
 });

--- a/src/components/views/AdminManualIdentityValidations.view.test.js
+++ b/src/components/views/AdminManualIdentityValidations.view.test.js
@@ -24,4 +24,20 @@ describe('AdminManualIdentityValidations view', () => {
         expect(viewSource).toContain(':data="displayedList"');
         expect(viewSource).toContain('v-for="item in displayedList"');
     });
+
+    it('renders sortable column headers for manual validation rows', () => {
+        expect(viewSource).toContain('sortManualIdentityValidationsList');
+        expect(viewSource).toContain('getNextManualIdentityValidationSortState');
+        expect(viewSource).toContain('toggleSort(');
+        expect(viewSource).toContain('admin-manual-th-sort');
+        expect(viewSource).toContain('sortKey ===');
+        expect(viewSource).toContain("@click=\"toggleSort('id')\"");
+        expect(viewSource).toContain("@click=\"toggleSort('user_name')\"");
+        expect(viewSource).toContain("@click=\"toggleSort('paid_at')\"");
+        expect(viewSource).toContain("@click=\"toggleSort('submitted_at')\"");
+        expect(viewSource).toContain("@click=\"toggleSort('waiting_time')\"");
+        expect(viewSource).toContain("@click=\"toggleSort('paid')\"");
+        expect(viewSource).toContain("@click=\"toggleSort('review_status')\"");
+        expect(viewSource).not.toContain("@click=\"toggleSort('acciones')\"");
+    });
 });

--- a/src/components/views/AdminManualIdentityValidations.vue
+++ b/src/components/views/AdminManualIdentityValidations.vue
@@ -13,13 +13,83 @@
                     <table class="table table-hover table-bordered">
                         <thead>
                             <tr>
-                                <th scope="col">{{ $t('id') }}</th>
-                                <th scope="col">{{ $t('nombre') }}</th>
-                                <th scope="col">{{ $t('fechaPago') }}</th>
-                                <th scope="col">{{ $t('fechaEnvio') }}</th>
-                                <th scope="col">{{ $t('tiempoDeEspera') }}</th>
-                                <th scope="col">{{ $t('pagado') }}</th>
-                                <th scope="col">{{ $t('estado') }}</th>
+                                <th
+                                    scope="col"
+                                    class="admin-manual-th-sort"
+                                    @click="toggleSort('id')"
+                                >
+                                    {{ $t('id') }}
+                                    <span
+                                        v-if="sortKey === 'id'"
+                                        class="admin-manual-sort-hint"
+                                    >{{ sortDir === 'asc' ? '▲' : '▼' }}</span>
+                                </th>
+                                <th
+                                    scope="col"
+                                    class="admin-manual-th-sort"
+                                    @click="toggleSort('user_name')"
+                                >
+                                    {{ $t('nombre') }}
+                                    <span
+                                        v-if="sortKey === 'user_name'"
+                                        class="admin-manual-sort-hint"
+                                    >{{ sortDir === 'asc' ? '▲' : '▼' }}</span>
+                                </th>
+                                <th
+                                    scope="col"
+                                    class="admin-manual-th-sort"
+                                    @click="toggleSort('paid_at')"
+                                >
+                                    {{ $t('fechaPago') }}
+                                    <span
+                                        v-if="sortKey === 'paid_at'"
+                                        class="admin-manual-sort-hint"
+                                    >{{ sortDir === 'asc' ? '▲' : '▼' }}</span>
+                                </th>
+                                <th
+                                    scope="col"
+                                    class="admin-manual-th-sort"
+                                    @click="toggleSort('submitted_at')"
+                                >
+                                    {{ $t('fechaEnvio') }}
+                                    <span
+                                        v-if="sortKey === 'submitted_at'"
+                                        class="admin-manual-sort-hint"
+                                    >{{ sortDir === 'asc' ? '▲' : '▼' }}</span>
+                                </th>
+                                <th
+                                    scope="col"
+                                    class="admin-manual-th-sort"
+                                    @click="toggleSort('waiting_time')"
+                                >
+                                    {{ $t('tiempoDeEspera') }}
+                                    <span
+                                        v-if="sortKey === 'waiting_time'"
+                                        class="admin-manual-sort-hint"
+                                    >{{ sortDir === 'asc' ? '▲' : '▼' }}</span>
+                                </th>
+                                <th
+                                    scope="col"
+                                    class="admin-manual-th-sort"
+                                    @click="toggleSort('paid')"
+                                >
+                                    {{ $t('pagado') }}
+                                    <span
+                                        v-if="sortKey === 'paid'"
+                                        class="admin-manual-sort-hint"
+                                    >{{ sortDir === 'asc' ? '▲' : '▼' }}</span>
+                                </th>
+                                <th
+                                    scope="col"
+                                    class="admin-manual-th-sort"
+                                    @click="toggleSort('review_status')"
+                                >
+                                    {{ $t('estado') }}
+                                    <span
+                                        v-if="sortKey === 'review_status'"
+                                        class="admin-manual-sort-hint"
+                                    >{{ sortDir === 'asc' ? '▲' : '▼' }}</span>
+                                </th>
                                 <th scope="col">{{ $t('acciones') }}</th>
                             </tr>
                         </thead>
@@ -81,8 +151,10 @@ import { AdminApi } from '../../services/api';
 import { getAdminUserProfileRoute } from '../../utils/adminProfileRoute';
 import {
     filterManualIdentityValidationsList,
+    getNextManualIdentityValidationSortState,
     getShowResolvedManualIdentityValidations,
-    saveShowResolvedManualIdentityValidations
+    saveShowResolvedManualIdentityValidations,
+    sortManualIdentityValidationsList
 } from '../../utils/adminManualIdentityValidationsList';
 import {
     formatManualIdentityValidationWaitingTime,
@@ -95,7 +167,9 @@ export default {
     data() {
         return {
             list: null,
-            showResolved: getShowResolvedManualIdentityValidations()
+            showResolved: getShowResolvedManualIdentityValidations(),
+            sortKey: null,
+            sortDir: 'asc'
         };
     },
     computed: {
@@ -104,7 +178,9 @@ export default {
                 return this.list;
             }
 
-            return filterManualIdentityValidationsList(this.list, this.showResolved);
+            const filtered = filterManualIdentityValidationsList(this.list, this.showResolved);
+
+            return sortManualIdentityValidationsList(filtered, this.sortKey, this.sortDir);
         }
     },
     watch: {
@@ -132,6 +208,16 @@ export default {
             const approved = status === 'approved' || status === 'approve';
             return approved && item.has_images === true;
         },
+        toggleSort(column) {
+            const next = getNextManualIdentityValidationSortState(
+                this.sortKey,
+                this.sortDir,
+                column
+            );
+
+            this.sortKey = next.sortKey;
+            this.sortDir = next.sortDir;
+        },
         fetchList() {
             const api = new AdminApi();
             return api.getManualIdentityValidations().then((res) => {
@@ -158,5 +244,21 @@ export default {
 
 .pending-images-pill {
     margin-left: 6px;
+}
+
+.admin-manual-th-sort {
+    cursor: pointer;
+    user-select: none;
+    white-space: nowrap;
+}
+
+.admin-manual-th-sort:hover {
+    background: #f5f5f5;
+}
+
+.admin-manual-sort-hint {
+    color: #666;
+    margin-left: 4px;
+    font-size: 12px;
 }
 </style>

--- a/src/components/views/AdminManualIdentityValidations.vue
+++ b/src/components/views/AdminManualIdentityValidations.vue
@@ -14,79 +14,15 @@
                         <thead>
                             <tr>
                                 <th
+                                    v-for="column in sortableColumns"
+                                    :key="column.key"
                                     scope="col"
                                     class="admin-manual-th-sort"
-                                    @click="toggleSort('id')"
+                                    @click="toggleSort(column.key)"
                                 >
-                                    {{ $t('id') }}
+                                    {{ $t(column.labelKey) }}
                                     <span
-                                        v-if="sortKey === 'id'"
-                                        class="admin-manual-sort-hint"
-                                    >{{ sortDir === 'asc' ? '▲' : '▼' }}</span>
-                                </th>
-                                <th
-                                    scope="col"
-                                    class="admin-manual-th-sort"
-                                    @click="toggleSort('user_name')"
-                                >
-                                    {{ $t('nombre') }}
-                                    <span
-                                        v-if="sortKey === 'user_name'"
-                                        class="admin-manual-sort-hint"
-                                    >{{ sortDir === 'asc' ? '▲' : '▼' }}</span>
-                                </th>
-                                <th
-                                    scope="col"
-                                    class="admin-manual-th-sort"
-                                    @click="toggleSort('paid_at')"
-                                >
-                                    {{ $t('fechaPago') }}
-                                    <span
-                                        v-if="sortKey === 'paid_at'"
-                                        class="admin-manual-sort-hint"
-                                    >{{ sortDir === 'asc' ? '▲' : '▼' }}</span>
-                                </th>
-                                <th
-                                    scope="col"
-                                    class="admin-manual-th-sort"
-                                    @click="toggleSort('submitted_at')"
-                                >
-                                    {{ $t('fechaEnvio') }}
-                                    <span
-                                        v-if="sortKey === 'submitted_at'"
-                                        class="admin-manual-sort-hint"
-                                    >{{ sortDir === 'asc' ? '▲' : '▼' }}</span>
-                                </th>
-                                <th
-                                    scope="col"
-                                    class="admin-manual-th-sort"
-                                    @click="toggleSort('waiting_time')"
-                                >
-                                    {{ $t('tiempoDeEspera') }}
-                                    <span
-                                        v-if="sortKey === 'waiting_time'"
-                                        class="admin-manual-sort-hint"
-                                    >{{ sortDir === 'asc' ? '▲' : '▼' }}</span>
-                                </th>
-                                <th
-                                    scope="col"
-                                    class="admin-manual-th-sort"
-                                    @click="toggleSort('paid')"
-                                >
-                                    {{ $t('pagado') }}
-                                    <span
-                                        v-if="sortKey === 'paid'"
-                                        class="admin-manual-sort-hint"
-                                    >{{ sortDir === 'asc' ? '▲' : '▼' }}</span>
-                                </th>
-                                <th
-                                    scope="col"
-                                    class="admin-manual-th-sort"
-                                    @click="toggleSort('review_status')"
-                                >
-                                    {{ $t('estado') }}
-                                    <span
-                                        v-if="sortKey === 'review_status'"
+                                        v-if="sortKey === column.key"
                                         class="admin-manual-sort-hint"
                                     >{{ sortDir === 'asc' ? '▲' : '▼' }}</span>
                                 </th>
@@ -153,6 +89,7 @@ import {
     filterManualIdentityValidationsList,
     getNextManualIdentityValidationSortState,
     getShowResolvedManualIdentityValidations,
+    MANUAL_IDENTITY_VALIDATION_SORT_COLUMNS,
     saveShowResolvedManualIdentityValidations,
     sortManualIdentityValidationsList
 } from '../../utils/adminManualIdentityValidationsList';
@@ -169,7 +106,8 @@ export default {
             list: null,
             showResolved: getShowResolvedManualIdentityValidations(),
             sortKey: null,
-            sortDir: 'asc'
+            sortDir: 'asc',
+            sortableColumns: MANUAL_IDENTITY_VALIDATION_SORT_COLUMNS
         };
     },
     computed: {

--- a/src/utils/adminManualIdentityValidationsList.js
+++ b/src/utils/adminManualIdentityValidationsList.js
@@ -99,6 +99,7 @@ function compareDates(a, b, direction) {
 }
 
 function getManualIdentityValidationWaitingTimeMs(item, now = Date.now()) {
+    /* eslint-disable camelcase -- manual validation API uses snake_case */
     if (!item?.submitted_at) {
         return null;
     }
@@ -107,6 +108,7 @@ function getManualIdentityValidationWaitingTimeMs(item, now = Date.now()) {
     const end = item.manual_validation_started_at
         ? new Date(item.manual_validation_started_at).getTime()
         : now;
+    /* eslint-enable camelcase */
 
     return Math.max(0, end - submitted);
 }

--- a/src/utils/adminManualIdentityValidationsList.js
+++ b/src/utils/adminManualIdentityValidationsList.js
@@ -55,17 +55,111 @@ export function filterManualIdentityValidationsList(list, showResolved = false) 
     return list.filter((item) => !isManualIdentityValidationResolved(item));
 }
 
-export function sortManualIdentityValidationsList(list, sortKey, sortDir = 'asc') {
+function compareNumbers(a, b, direction) {
+    return direction * (a - b);
+}
+
+function compareNullableValues(a, b, direction, comparePresent) {
+    if (a == null && b == null) {
+        return 0;
+    }
+
+    if (a == null) {
+        return 1;
+    }
+
+    if (b == null) {
+        return -1;
+    }
+
+    return direction * comparePresent(a, b);
+}
+
+function compareStrings(a, b, direction) {
+    return direction * String(a).localeCompare(String(b), undefined, { sensitivity: 'base' });
+}
+
+function compareDates(a, b, direction) {
+    return compareNullableValues(
+        a,
+        b,
+        direction,
+        (left, right) => new Date(left).getTime() - new Date(right).getTime()
+    );
+}
+
+function getManualIdentityValidationWaitingTimeMs(item, now = Date.now()) {
+    if (!item?.submitted_at) {
+        return null;
+    }
+
+    const submitted = new Date(item.submitted_at).getTime();
+    const end = item.manual_validation_started_at
+        ? new Date(item.manual_validation_started_at).getTime()
+        : now;
+
+    return Math.max(0, end - submitted);
+}
+
+const REVIEW_STATUS_SORT_ORDER = {
+    unpaid: 0,
+    pending: 1,
+    approved: 2,
+    approve: 2,
+    rejected: 3,
+    reject: 3
+};
+
+function getReviewStatusSortRank(item) {
+    if (!item?.paid) {
+        return REVIEW_STATUS_SORT_ORDER.unpaid;
+    }
+
+    const status = item.review_status;
+
+    if (status == null || status === '') {
+        return REVIEW_STATUS_SORT_ORDER.pending;
+    }
+
+    return REVIEW_STATUS_SORT_ORDER[status] ?? REVIEW_STATUS_SORT_ORDER.pending;
+}
+
+const SORT_COMPARATORS = {
+    id: (a, b, direction) => compareNumbers(a.id ?? 0, b.id ?? 0, direction),
+    user_name: (a, b, direction) => compareNullableValues(
+        a.user_name,
+        b.user_name,
+        direction,
+        (left, right) => compareStrings(left, right, 1)
+    ),
+    paid_at: (a, b, direction) => compareDates(a.paid_at, b.paid_at, direction),
+    submitted_at: (a, b, direction) => compareDates(a.submitted_at, b.submitted_at, direction),
+    waiting_time: (a, b, direction, now) => compareNullableValues(
+        getManualIdentityValidationWaitingTimeMs(a, now),
+        getManualIdentityValidationWaitingTimeMs(b, now),
+        direction,
+        (left, right) => compareNumbers(left, right, 1)
+    ),
+    paid: (a, b, direction) => compareNumbers(Number(Boolean(a.paid)), Number(Boolean(b.paid)), direction),
+    review_status: (a, b, direction) => compareNumbers(
+        getReviewStatusSortRank(a),
+        getReviewStatusSortRank(b),
+        direction
+    )
+};
+
+export function sortManualIdentityValidationsList(list, sortKey, sortDir = 'asc', now = Date.now()) {
     if (!sortKey) {
         return list;
     }
 
-    const direction = sortDir === 'desc' ? -1 : 1;
-    const sorted = [...list];
+    const compare = SORT_COMPARATORS[sortKey];
 
-    if (sortKey === 'id') {
-        sorted.sort((a, b) => direction * ((a.id ?? 0) - (b.id ?? 0)));
+    if (!compare) {
+        return list;
     }
 
-    return sorted;
+    const direction = sortDir === 'desc' ? -1 : 1;
+
+    return [...list].sort((a, b) => compare(a, b, direction, now) || compareNumbers(a.id ?? 0, b.id ?? 0, 1));
 }

--- a/src/utils/adminManualIdentityValidationsList.js
+++ b/src/utils/adminManualIdentityValidationsList.js
@@ -54,3 +54,18 @@ export function filterManualIdentityValidationsList(list, showResolved = false) 
 
     return list.filter((item) => !isManualIdentityValidationResolved(item));
 }
+
+export function sortManualIdentityValidationsList(list, sortKey, sortDir = 'asc') {
+    if (!sortKey) {
+        return list;
+    }
+
+    const direction = sortDir === 'desc' ? -1 : 1;
+    const sorted = [...list];
+
+    if (sortKey === 'id') {
+        sorted.sort((a, b) => direction * ((a.id ?? 0) - (b.id ?? 0)));
+    }
+
+    return sorted;
+}

--- a/src/utils/adminManualIdentityValidationsList.js
+++ b/src/utils/adminManualIdentityValidationsList.js
@@ -1,6 +1,16 @@
 export const ADMIN_MANUAL_IDENTITY_VALIDATIONS_SHOW_RESOLVED_KEY =
     'adminManualIdentityValidationsShowResolved';
 
+export const MANUAL_IDENTITY_VALIDATION_SORT_COLUMNS = [
+    { key: 'id', labelKey: 'id' },
+    { key: 'user_name', labelKey: 'nombre' },
+    { key: 'paid_at', labelKey: 'fechaPago' },
+    { key: 'submitted_at', labelKey: 'fechaEnvio' },
+    { key: 'waiting_time', labelKey: 'tiempoDeEspera' },
+    { key: 'paid', labelKey: 'pagado' },
+    { key: 'review_status', labelKey: 'estado' }
+];
+
 function createMemoryStorage() {
     const values = new Map();
 

--- a/src/utils/adminManualIdentityValidationsList.js
+++ b/src/utils/adminManualIdentityValidationsList.js
@@ -163,3 +163,17 @@ export function sortManualIdentityValidationsList(list, sortKey, sortDir = 'asc'
 
     return [...list].sort((a, b) => compare(a, b, direction, now) || compareNumbers(a.id ?? 0, b.id ?? 0, 1));
 }
+
+export function getNextManualIdentityValidationSortState(currentKey, currentDir, column) {
+    if (currentKey === column) {
+        return {
+            sortKey: column,
+            sortDir: currentDir === 'asc' ? 'desc' : 'asc'
+        };
+    }
+
+    return {
+        sortKey: column,
+        sortDir: column === 'id' ? 'desc' : 'asc'
+    };
+}

--- a/src/utils/adminManualIdentityValidationsList.test.js
+++ b/src/utils/adminManualIdentityValidationsList.test.js
@@ -4,7 +4,8 @@ import {
     filterManualIdentityValidationsList,
     getShowResolvedManualIdentityValidations,
     isManualIdentityValidationResolved,
-    saveShowResolvedManualIdentityValidations
+    saveShowResolvedManualIdentityValidations,
+    sortManualIdentityValidationsList
 } from './adminManualIdentityValidationsList.js';
 
 describe('adminManualIdentityValidationsList', () => {
@@ -34,6 +35,19 @@ describe('adminManualIdentityValidationsList', () => {
 
         it('shows all cases when showResolved is true', () => {
             expect(filterManualIdentityValidationsList(list, true)).toEqual(list);
+        });
+    });
+
+    describe('sortManualIdentityValidationsList', () => {
+        const unsorted = [
+            { id: 3, user_name: 'Charlie' },
+            { id: 1, user_name: 'Alice' },
+            { id: 2, user_name: 'Bob' }
+        ];
+
+        it('sorts by id ascending', () => {
+            expect(sortManualIdentityValidationsList(unsorted, 'id', 'asc').map((item) => item.id))
+                .toEqual([1, 2, 3]);
         });
     });
 

--- a/src/utils/adminManualIdentityValidationsList.test.js
+++ b/src/utils/adminManualIdentityValidationsList.test.js
@@ -136,12 +136,12 @@ describe('adminManualIdentityValidationsList', () => {
                 .toEqual([2, 1, 3]);
         });
 
-        it('sorts by review status with pending before approved and rejected', () => {
+        it('sorts by review status with unpaid first, then pending, approved and rejected', () => {
             const list = [
-                { id: 1, review_status: 'approved' },
-                { id: 2, review_status: 'pending' },
-                { id: 3, review_status: 'rejected' },
-                { id: 4, review_status: null, paid: false }
+                { id: 1, paid: true, review_status: 'approved' },
+                { id: 2, paid: true, review_status: 'pending' },
+                { id: 3, paid: true, review_status: 'rejected' },
+                { id: 4, paid: false, review_status: null }
             ];
 
             expect(sortManualIdentityValidationsList(list, 'review_status', 'asc').map((item) => item.id))

--- a/src/utils/adminManualIdentityValidationsList.test.js
+++ b/src/utils/adminManualIdentityValidationsList.test.js
@@ -5,7 +5,8 @@ import {
     getShowResolvedManualIdentityValidations,
     isManualIdentityValidationResolved,
     saveShowResolvedManualIdentityValidations,
-    sortManualIdentityValidationsList
+    sortManualIdentityValidationsList,
+    getNextManualIdentityValidationSortState
 } from './adminManualIdentityValidationsList.js';
 
 describe('adminManualIdentityValidationsList', () => {
@@ -146,6 +147,29 @@ describe('adminManualIdentityValidationsList', () => {
 
             expect(sortManualIdentityValidationsList(list, 'review_status', 'asc').map((item) => item.id))
                 .toEqual([4, 2, 1, 3]);
+        });
+    });
+
+    describe('getNextManualIdentityValidationSortState', () => {
+        it('toggles direction when clicking the active column', () => {
+            expect(getNextManualIdentityValidationSortState('id', 'desc', 'id')).toEqual({
+                sortKey: 'id',
+                sortDir: 'asc'
+            });
+        });
+
+        it('defaults to descending when selecting id for the first time', () => {
+            expect(getNextManualIdentityValidationSortState(null, 'asc', 'id')).toEqual({
+                sortKey: 'id',
+                sortDir: 'desc'
+            });
+        });
+
+        it('defaults to ascending when selecting other columns for the first time', () => {
+            expect(getNextManualIdentityValidationSortState(null, 'asc', 'user_name')).toEqual({
+                sortKey: 'user_name',
+                sortDir: 'asc'
+            });
         });
     });
 

--- a/src/utils/adminManualIdentityValidationsList.test.js
+++ b/src/utils/adminManualIdentityValidationsList.test.js
@@ -49,6 +49,104 @@ describe('adminManualIdentityValidationsList', () => {
             expect(sortManualIdentityValidationsList(unsorted, 'id', 'asc').map((item) => item.id))
                 .toEqual([1, 2, 3]);
         });
+
+        it('sorts by id descending', () => {
+            expect(sortManualIdentityValidationsList(unsorted, 'id', 'desc').map((item) => item.id))
+                .toEqual([3, 2, 1]);
+        });
+
+        it('returns the original order when sortKey is empty', () => {
+            expect(sortManualIdentityValidationsList(unsorted, null)).toEqual(unsorted);
+            expect(sortManualIdentityValidationsList(unsorted, '')).toEqual(unsorted);
+        });
+
+        it('does not mutate the input list', () => {
+            const input = [...unsorted];
+
+            sortManualIdentityValidationsList(input, 'id', 'asc');
+
+            expect(input).toEqual(unsorted);
+        });
+
+        it('sorts by user name case-insensitively', () => {
+            const list = [
+                { id: 1, user_name: 'charlie' },
+                { id: 2, user_name: 'Alice' },
+                { id: 3, user_name: null }
+            ];
+
+            expect(sortManualIdentityValidationsList(list, 'user_name', 'asc').map((item) => item.id))
+                .toEqual([2, 1, 3]);
+        });
+
+        it('sorts by paid_at with null values last', () => {
+            const list = [
+                { id: 1, paid_at: '2026-06-03 10:00:00' },
+                { id: 2, paid_at: null },
+                { id: 3, paid_at: '2026-06-01 10:00:00' }
+            ];
+
+            expect(sortManualIdentityValidationsList(list, 'paid_at', 'asc').map((item) => item.id))
+                .toEqual([3, 1, 2]);
+        });
+
+        it('sorts by submitted_at with null values last', () => {
+            const list = [
+                { id: 1, submitted_at: '2026-06-03 10:00:00' },
+                { id: 2, submitted_at: null },
+                { id: 3, submitted_at: '2026-06-01 10:00:00' }
+            ];
+
+            expect(sortManualIdentityValidationsList(list, 'submitted_at', 'asc').map((item) => item.id))
+                .toEqual([3, 1, 2]);
+        });
+
+        it('sorts by waiting time in milliseconds', () => {
+            const now = new Date('2026-06-18 12:00:00').getTime();
+            const list = [
+                {
+                    id: 1,
+                    submitted_at: '2026-06-18 10:00:00',
+                    manual_validation_started_at: '2026-06-18 11:00:00'
+                },
+                {
+                    id: 2,
+                    submitted_at: null
+                },
+                {
+                    id: 3,
+                    submitted_at: '2026-06-18 09:00:00',
+                    manual_validation_started_at: null
+                }
+            ];
+
+            expect(
+                sortManualIdentityValidationsList(list, 'waiting_time', 'asc', now).map((item) => item.id)
+            ).toEqual([1, 3, 2]);
+        });
+
+        it('sorts by paid flag with unpaid rows first when ascending', () => {
+            const list = [
+                { id: 1, paid: true },
+                { id: 2, paid: false },
+                { id: 3, paid: true }
+            ];
+
+            expect(sortManualIdentityValidationsList(list, 'paid', 'asc').map((item) => item.id))
+                .toEqual([2, 1, 3]);
+        });
+
+        it('sorts by review status with pending before approved and rejected', () => {
+            const list = [
+                { id: 1, review_status: 'approved' },
+                { id: 2, review_status: 'pending' },
+                { id: 3, review_status: 'rejected' },
+                { id: 4, review_status: null, paid: false }
+            ];
+
+            expect(sortManualIdentityValidationsList(list, 'review_status', 'asc').map((item) => item.id))
+                .toEqual([4, 2, 1, 3]);
+        });
     });
 
     describe('showResolved persistence', () => {

--- a/src/utils/adminManualIdentityValidationsList.test.js
+++ b/src/utils/adminManualIdentityValidationsList.test.js
@@ -2,11 +2,12 @@ import { describe, expect, it, vi } from 'vitest';
 import {
     ADMIN_MANUAL_IDENTITY_VALIDATIONS_SHOW_RESOLVED_KEY,
     filterManualIdentityValidationsList,
+    getNextManualIdentityValidationSortState,
     getShowResolvedManualIdentityValidations,
     isManualIdentityValidationResolved,
+    MANUAL_IDENTITY_VALIDATION_SORT_COLUMNS,
     saveShowResolvedManualIdentityValidations,
-    sortManualIdentityValidationsList,
-    getNextManualIdentityValidationSortState
+    sortManualIdentityValidationsList
 } from './adminManualIdentityValidationsList.js';
 
 describe('adminManualIdentityValidationsList', () => {
@@ -147,6 +148,20 @@ describe('adminManualIdentityValidationsList', () => {
 
             expect(sortManualIdentityValidationsList(list, 'review_status', 'asc').map((item) => item.id))
                 .toEqual([4, 2, 1, 3]);
+        });
+    });
+
+    describe('MANUAL_IDENTITY_VALIDATION_SORT_COLUMNS', () => {
+        it('lists every sortable table column except actions', () => {
+            expect(MANUAL_IDENTITY_VALIDATION_SORT_COLUMNS.map((column) => column.key)).toEqual([
+                'id',
+                'user_name',
+                'paid_at',
+                'submitted_at',
+                'waiting_time',
+                'paid',
+                'review_status'
+            ]);
         });
     });
 


### PR DESCRIPTION
## Summary

Add sortable columns to the admin manual identity validations list page.

## Cause

Admins reviewing manual verifications could not reorder the table by column. The list always followed the API’s default ordering (paid first, then by submission/review priority), which made it harder to find specific cases when working through the queue.

## Fix

### Frontend

- Added client-side sorting utilities in `adminManualIdentityValidationsList.js`:
  - `sortManualIdentityValidationsList()` — sorts by id, user name, paid date, submitted date, waiting time, paid flag, and review status
  - `getNextManualIdentityValidationSortState()` — toggles sort direction on repeated clicks
  - `MANUAL_IDENTITY_VALIDATION_SORT_COLUMNS` — shared config for sortable headers
- Updated `AdminManualIdentityValidations.vue` with clickable column headers, sort direction indicators (▲/▼), and hover styles consistent with `AdminUsersList`
- Sorting applies after the existing “show resolved” filter; default order is preserved until an admin clicks a column
- Actions column remains non-sortable

## Test plan

- [ ] Open admin → Manual verifications list
- [ ] Confirm default order matches API order before clicking any header
- [ ] Click each sortable column and verify rows reorder correctly
- [ ] Click the same column again and confirm direction toggles (asc ↔ desc)
- [ ] Toggle “Show resolved” and confirm sorting still works on the filtered list
- [ ] Confirm the Actions column is not sortable