### PR TITLE
Fix build errors

### DIFF
--- a/src/components/elements/TripLocation.vue
+++ b/src/components/elements/TripLocation.vue
@@ -2,7 +2,10 @@
     <div class="trip_location">
         <template v-if="trip.points.length >= 2">
             <TripSeats v-if="tripCardTheme === 'light' && isMobile" />
-            <div class="row trip_location_from">
+            <div
+                class="row trip_location_from"
+                :class="{ 'trip_location_from--has-point-detail': trip.punto_partida }"
+            >
                 <div class="col-xs-4" v-if="tripCardTheme === 'light'">
                     <span class="trip_from_time">{{
                         dayjs(trip.trip_date).format('HH:mm')
@@ -72,13 +75,14 @@
             </div>
             <div
                 class="row trip_location_to"
-                :class="
+                :class="[
                     tripCardTheme !== 'light' &&
                     trip.points.length &&
                     trip.points.length > 2
                         ? 'has_points'
-                        : ''
-                "
+                        : '',
+                    { 'trip_location_to--has-point-detail': trip.punto_llegada }
+                ]"
             >
                 <div class="col-xs-4" v-if="tripCardTheme === 'light'">
                     <span class="trip_to_time">{{
@@ -128,7 +132,10 @@
             </div>
         </template>
         <template v-else>
-            <div class="row trip_location_from">
+            <div
+                class="row trip_location_from"
+                :class="{ 'trip_location_from--has-point-detail': trip.punto_partida }"
+            >
                 <div class="col-xs-4 text-right">
                     <i class="fa fa-map-marker" aria-hidden="true"></i>
                 </div>
@@ -145,7 +152,7 @@
                     </div>
                 </div>
             </div>
-            <div class="row trip_location_to">
+            <div class="row trip_location_to" :class="{ 'trip_location_to--has-point-detail': trip.punto_llegada }">
                 <div class="col-xs-4 text-right">
                     <i class="fa fa-map-marker" aria-hidden="true"></i>
                 </div>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1411,10 +1411,10 @@
       .trip-detail-component .trip-location-point-detail--llegada {
           margin-bottom: 1.25rem;
       }
-      .trip-detail-component .trip_location_from:has(.trip-location-point-detail--partida) {
+      .trip-detail-component .trip_location_from--has-point-detail {
           margin-bottom: 0.5rem;
       }
-      .trip-detail-component .trip_location_to:has(.trip-location-point-detail--llegada) {
+      .trip-detail-component .trip_location_to--has-point-detail {
           margin-bottom: 0.5rem;
       }
   }


### PR DESCRIPTION
## Summary

Fixes a production build failure caused by CSS minification of `:has()` selectors in trip detail mobile spacing rules.

## Frontend

**Cause:** Vite's `lightningcss` minifier throws on `:has()` attribute selectors in `base.css` (e.g. `.trip_location_from:has(.trip-location-point-detail--partida)`), breaking `npm run build`.

**Fix:** Replace `:has()` with explicit modifier classes on `TripLocation.vue` rows:
- `trip_location_from--has-point-detail` when `punto_partida` is present
- `trip_location_to--has-point-detail` when `punto_llegada` is present

Mobile spacing behavior is unchanged; only the selector strategy changed for minifier compatibility.

## Test plan

- [ ] `npm run build` completes successfully
- [ ] Trip detail view on mobile shows correct spacing when punto de partida/llegada are present
- [ ] Trip detail view on mobile shows correct spacing when punto fields are absent