### PR TITLE
Sellado tweaks

### DIFF
--- a/src/components/elements/OngoingTripCard.view.test.js
+++ b/src/components/elements/OngoingTripCard.view.test.js
@@ -25,4 +25,10 @@ describe('OngoingTripCard.vue', () => {
         expect(viewSource).toContain('shouldShowLiveLocationShare');
         expect(viewSource).toContain('showShareLocationLink');
     });
+
+    it('aligns neutral rating icon without extra top padding in the ongoing trip card', () => {
+        expect(viewSource).toMatch(
+            /\.ongoing-trip-card__driver-meta\s*:deep\(\.user-ratings-counts__icon-slot--neutral\)\s*\{[\s\S]*padding-top:\s*0/
+        );
+    });
 });

--- a/src/components/elements/OngoingTripCard.vue
+++ b/src/components/elements/OngoingTripCard.vue
@@ -250,6 +250,10 @@ export default {
     font-size: 0.9rem;
 }
 
+.ongoing-trip-card__driver-meta :deep(.user-ratings-counts__icon-slot--neutral) {
+    padding-top: 0;
+}
+
 .ongoing-trip-card__schedule {
     text-align: right;
     flex-shrink: 0;

--- a/src/components/elements/TripSeats.view.test.js
+++ b/src/components/elements/TripSeats.view.test.js
@@ -70,4 +70,21 @@ describe('TripSeats.vue invite friends placement', () => {
             /trip-seats__availability[\s\S]*?trip-invite-friends-trigger/
         );
     });
+
+    it('disables invite friends with sellado tooltip while payment is pending', () => {
+        expect(viewSource).toContain('isInviteFriendsBlockedByUnpaidSellado');
+        expect(viewSource).toContain("$t('invitarAmigosSelladoPendiente')");
+        expect(viewSource).toMatch(
+            /:disabled="inviteFriendsBlockedByUnpaidSellado"/
+        );
+        expect(viewSource).toMatch(
+            /:data-tooltip="\s*inviteFriendsBlockedByUnpaidSellado[\s\S]*invitarAmigosSelladoPendiente/
+        );
+    });
+
+    it('does not auto-open invite friends modal when sellado payment is pending', () => {
+        expect(viewSource).toMatch(
+            /maybeOpenInviteFriendsFromQuery[\s\S]*inviteFriendsBlockedByUnpaidSellado/
+        );
+    });
 });

--- a/src/components/elements/TripSeats.view.test.js
+++ b/src/components/elements/TripSeats.view.test.js
@@ -78,7 +78,10 @@ describe('TripSeats.vue invite friends placement', () => {
             /:disabled="inviteFriendsBlockedByUnpaidSellado"/
         );
         expect(viewSource).toMatch(
-            /:data-tooltip="\s*inviteFriendsBlockedByUnpaidSellado[\s\S]*invitarAmigosSelladoPendiente/
+            /:data-tooltip="inviteFriendsSelladoTooltip"/
+        );
+        expect(viewSource).toMatch(
+            /inviteFriendsSelladoTooltip\(\)[\s\S]*invitarAmigosSelladoPendiente/
         );
     });
 

--- a/src/components/elements/TripSeats.vue
+++ b/src/components/elements/TripSeats.vue
@@ -46,13 +46,23 @@
                         v-if="canInviteFriendsToTrip"
                         class="trip-invite-friends-trigger"
                     >
-                        <button
-                            type="button"
-                            class="btn btn-primary"
-                            @click="showInviteFriendsModal = true"
+                        <span
+                            class="tooltip-bottom trip-invite-friends-trigger__tooltip"
+                            :data-tooltip="
+                                inviteFriendsBlockedByUnpaidSellado
+                                    ? $t('invitarAmigosSelladoPendiente')
+                                    : null
+                            "
                         >
-                            {{ $t('invitarAmigosAlViaje') }}
-                        </button>
+                            <button
+                                type="button"
+                                class="btn btn-primary"
+                                :disabled="inviteFriendsBlockedByUnpaidSellado"
+                                @click="showInviteFriendsModal = true"
+                            >
+                                {{ $t('invitarAmigosAlViaje') }}
+                            </button>
+                        </span>
                     </div>
                 </div>
             </div>
@@ -97,13 +107,23 @@
                         v-if="canInviteFriendsToTrip"
                         class="trip-invite-friends-trigger"
                     >
-                        <button
-                            type="button"
-                            class="btn btn-primary"
-                            @click="showInviteFriendsModal = true"
+                        <span
+                            class="tooltip-bottom trip-invite-friends-trigger__tooltip"
+                            :data-tooltip="
+                                inviteFriendsBlockedByUnpaidSellado
+                                    ? $t('invitarAmigosSelladoPendiente')
+                                    : null
+                            "
                         >
-                            {{ $t('invitarAmigosAlViaje') }}
-                        </button>
+                            <button
+                                type="button"
+                                class="btn btn-primary"
+                                :disabled="inviteFriendsBlockedByUnpaidSellado"
+                                @click="showInviteFriendsModal = true"
+                            >
+                                {{ $t('invitarAmigosAlViaje') }}
+                            </button>
+                        </span>
                     </div>
                 </div>
             </div>
@@ -140,6 +160,7 @@ import {
     isAcceptedPassengerOnTrip
 } from '../../utils/tripCoPassengers.js';
 import { shouldShowRearComfortNote } from '../../utils/tripRearComfortSeats.js';
+import { isInviteFriendsBlockedByUnpaidSellado } from '../../utils/tripSelladoDisplay.js';
 
 export default {
     name: 'TripSeats',
@@ -185,6 +206,9 @@ export default {
             return (
                 this.owner && this.trip && isUpcomingTrip(this.trip, dayjs)
             );
+        },
+        inviteFriendsBlockedByUnpaidSellado() {
+            return isInviteFriendsBlockedByUnpaidSellado(this.trip);
         }
     },
     watch: {
@@ -200,7 +224,10 @@ export default {
             this.showInviteFriendsModal = false;
         },
         maybeOpenInviteFriendsFromQuery() {
-            if (!this.canInviteFriendsToTrip) {
+            if (
+                !this.canInviteFriendsToTrip ||
+                this.inviteFriendsBlockedByUnpaidSellado
+            ) {
                 return;
             }
             const query = this.$route && this.$route.query;

--- a/src/components/elements/TripSeats.vue
+++ b/src/components/elements/TripSeats.vue
@@ -48,11 +48,7 @@
                     >
                         <span
                             class="tooltip-bottom trip-invite-friends-trigger__tooltip"
-                            :data-tooltip="
-                                inviteFriendsBlockedByUnpaidSellado
-                                    ? $t('invitarAmigosSelladoPendiente')
-                                    : null
-                            "
+                            :data-tooltip="inviteFriendsSelladoTooltip"
                         >
                             <button
                                 type="button"
@@ -109,11 +105,7 @@
                     >
                         <span
                             class="tooltip-bottom trip-invite-friends-trigger__tooltip"
-                            :data-tooltip="
-                                inviteFriendsBlockedByUnpaidSellado
-                                    ? $t('invitarAmigosSelladoPendiente')
-                                    : null
-                            "
+                            :data-tooltip="inviteFriendsSelladoTooltip"
                         >
                             <button
                                 type="button"
@@ -209,6 +201,11 @@ export default {
         },
         inviteFriendsBlockedByUnpaidSellado() {
             return isInviteFriendsBlockedByUnpaidSellado(this.trip);
+        },
+        inviteFriendsSelladoTooltip() {
+            return this.inviteFriendsBlockedByUnpaidSellado
+                ? this.$t('invitarAmigosSelladoPendiente')
+                : null;
         }
     },
     watch: {
@@ -297,5 +294,9 @@ export default {
 
 .trip-invite-friends-trigger {
     margin-top: 0.25rem;
+}
+
+.trip-invite-friends-trigger__tooltip {
+    display: inline-block;
 }
 </style>

--- a/src/components/elements/UserRatingsCounts.view.test.js
+++ b/src/components/elements/UserRatingsCounts.view.test.js
@@ -15,6 +15,9 @@ describe('UserRatingsCounts.vue', () => {
         expect(viewSource).toContain('user-ratings-counts');
         expect(viewSource).toContain('user-ratings-counts__icon-slot');
         expect(viewSource).toContain('user-ratings-counts__icon-slot--neutral');
+        expect(viewSource).toMatch(
+            /\.user-ratings-counts__icon-slot--neutral[\s\S]*padding-top:\s*0\.6em/
+        );
         expect(viewSource).toContain('rate-neutral-icon');
         expect(viewSource).toContain('neutralRatingIconStyle');
         expect(viewSource).toContain('user-ratings-counts--inverse');

--- a/src/components/sections/Trip.view.test.js
+++ b/src/components/sections/Trip.view.test.js
@@ -24,6 +24,24 @@ describe('Trip public visibility tooltip', () => {
     });
 });
 
+describe('Trip sellado pending display', () => {
+    it('uses showSelladoPending instead of needs_sellado for card styling and legend', () => {
+        expect(source).toMatch(
+            /:class="\[tripCardCountClass, \{ 'trip-needs-sellado': showSelladoPending \}\]"/
+        );
+        expect(source).toMatch(/v-if="showSelladoPending"/);
+        expect(source).not.toMatch(
+            /:class="\[tripCardCountClass, \{ 'trip-needs-sellado': trip\.needs_sellado \}\]"/
+        );
+        expect(source).not.toMatch(/v-if="trip\.needs_sellado"/);
+    });
+
+    it('derives showSelladoPending from shouldShowSelladoPending helper', () => {
+        expect(source).toContain("from '../../utils/tripSelladoDisplay'");
+        expect(source).toMatch(/showSelladoPending\(\)\s*\{[\s\S]*shouldShowSelladoPending/);
+    });
+});
+
 describe('Trip clickModal', () => {
     it('declares clickModal as a boolean prop defaulting to false', () => {
         expect(source).toMatch(
@@ -33,7 +51,7 @@ describe('Trip clickModal', () => {
 
     it('opens modal from the trip card only, not the modal wrapper', () => {
         const wrapperOpen = source.match(
-            /:class="\[tripCardCountClass, \{ 'trip-needs-sellado': trip\.needs_sellado \}\]"\s*\n\s*v-on:click="clickModal/
+            /:class="\[tripCardCountClass, \{ 'trip-needs-sellado': showSelladoPending \}\]"\s*\n\s*v-on:click="clickModal/
         );
         expect(wrapperOpen).toBeNull();
 

--- a/src/components/sections/Trip.vue
+++ b/src/components/sections/Trip.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        :class="[tripCardCountClass, { 'trip-needs-sellado': trip.needs_sellado }]"
+        :class="[tripCardCountClass, { 'trip-needs-sellado': showSelladoPending }]"
     >
         <tripDisplay
             v-if="showTrip && clickModal"
@@ -175,7 +175,7 @@
                         </div>
                     </template>
                     <div
-                        v-if="trip.needs_sellado"
+                        v-if="showSelladoPending"
                         class="trip-legend-sellado"
                     >
                         {{ $t('faltaPagarSellado') }}
@@ -617,6 +617,7 @@ import dayjs from '../../dayjs';
 import SvgItem from '../SvgItem';
 import { googleInfoClean } from '../../filters';
 import { sumUserRatings } from '../../utils/tripRating';
+import { shouldShowSelladoPending } from '../../utils/tripSelladoDisplay';
 
 export default {
     name: 'trip',
@@ -817,6 +818,9 @@ export default {
         },
         tripCardTheme() {
             return this.config ? this.config.trip_card_design : '';
+        },
+        showSelladoPending() {
+            return shouldShowSelladoPending(this.trip, this.user);
         },
         getUserImage() {
             if (!this.trip || !this.trip.user) {

--- a/src/language/friendsOverhaul.test.js
+++ b/src/language/friendsOverhaul.test.js
@@ -15,6 +15,8 @@ const FRIENDS_OVERHAUL_LABELS_ES = {
     queresInvitarTusAmigos: '¿Querés invitar a tus amigos a este viaje?',
     invitarATodosMisAmigos: 'Invitar a todos mis amigos',
     invitarAmigosAlViaje: 'Invitar amigos al viaje',
+    invitarAmigosSelladoPendiente:
+        'Una vez que pagues el sellado vas a poder invitar a tus amigos',
     viajesDeMisAmigos: 'Viajes de mis amigos',
     otrosViajes: 'Otros viajes',
     tenesInvitacionesAmigosClickParaVerlas:
@@ -46,6 +48,8 @@ const FRIENDS_OVERHAUL_LABELS_BY_LOCALE = {
         queresInvitarTusAmigos: 'Do you want to invite your friends to this trip?',
         invitarATodosMisAmigos: 'Invite all my friends',
         invitarAmigosAlViaje: 'Invite friends to the trip',
+        invitarAmigosSelladoPendiente:
+            "Once you pay the sellado you'll be able to invite your friends",
         viajesDeMisAmigos: 'My friends trips',
         otrosViajes: 'Other trips',
         tenesInvitacionesAmigosClickParaVerlas:

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -529,6 +529,8 @@ const messages = {
         queresInvitarTusAmigos: '¿Querés invitar a tus amigos a este viaje?',
         invitarATodosMisAmigos: 'Invitar a todos mis amigos',
         invitarAmigosAlViaje: 'Invitar amigos al viaje',
+        invitarAmigosSelladoPendiente:
+            'Una vez que pagues el sellado vas a poder invitar a tus amigos',
         viajesDeMisAmigos: 'Viajes de mis amigos',
         otrosViajes: 'Otros viajes',
         tenesInvitacionesAmigosClickParaVerlas:
@@ -2371,6 +2373,8 @@ const messages = {
         queresInvitarTusAmigos: '¿Querés invitar a tus amigos a este viaje?',
         invitarATodosMisAmigos: 'Invitar a todos mis amigos',
         invitarAmigosAlViaje: 'Invitar amigos al viaje',
+        invitarAmigosSelladoPendiente:
+            'Una vez que pagues el sellado vas a poder invitar a tus amigos',
         viajesDeMisAmigos: 'Viajes de mis amigos',
         otrosViajes: 'Otros viajes',
         tenesInvitacionesAmigosClickParaVerlas:
@@ -3410,6 +3414,8 @@ const messages = {
             'Do you want to invite your friends to this trip?',
         invitarATodosMisAmigos: 'Invite all my friends',
         invitarAmigosAlViaje: 'Invite friends to the trip',
+        invitarAmigosSelladoPendiente:
+            "Once you pay the sellado you'll be able to invite your friends",
         viajesDeMisAmigos: 'My friends trips',
         otrosViajes: 'Other trips',
         tenesInvitacionesAmigosClickParaVerlas:

--- a/src/utils/tripSelladoDisplay.js
+++ b/src/utils/tripSelladoDisplay.js
@@ -12,6 +12,10 @@ export function isSelladoPending(trip) {
     return Boolean(trip.needs_sellado) && trip.state !== TRIP_STATE_READY;
 }
 
+export function isInviteFriendsBlockedByUnpaidSellado(trip) {
+    return isSelladoPending(trip);
+}
+
 export function shouldShowSelladoPending(trip, currentUser) {
     if (!isSelladoPending(trip)) {
         return false;

--- a/src/utils/tripSelladoDisplay.js
+++ b/src/utils/tripSelladoDisplay.js
@@ -1,3 +1,5 @@
+export const TRIP_STATE_READY = 'ready';
+
 export function isSelladoPending(trip) {
     if (!trip) {
         return false;
@@ -7,7 +9,7 @@ export function isSelladoPending(trip) {
         return Boolean(trip.sellado_pending);
     }
 
-    return Boolean(trip.needs_sellado) && trip.state !== 'ready';
+    return Boolean(trip.needs_sellado) && trip.state !== TRIP_STATE_READY;
 }
 
 export function shouldShowSelladoPending(trip, currentUser) {

--- a/src/utils/tripSelladoDisplay.js
+++ b/src/utils/tripSelladoDisplay.js
@@ -1,0 +1,23 @@
+export function isSelladoPending(trip) {
+    if (!trip) {
+        return false;
+    }
+
+    if (trip.sellado_pending != null) {
+        return Boolean(trip.sellado_pending);
+    }
+
+    return Boolean(trip.needs_sellado) && trip.state !== 'ready';
+}
+
+export function shouldShowSelladoPending(trip, currentUser) {
+    if (!isSelladoPending(trip)) {
+        return false;
+    }
+
+    if (!currentUser?.id || !trip.user?.id) {
+        return false;
+    }
+
+    return currentUser.id === trip.user.id;
+}

--- a/src/utils/tripSelladoDisplay.test.js
+++ b/src/utils/tripSelladoDisplay.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { shouldShowSelladoPending } from './tripSelladoDisplay';
+
+describe('shouldShowSelladoPending', () => {
+    const owner = { id: 10 };
+    const otherUser = { id: 20 };
+
+    it('returns false for paid sellado trips even when needs_sellado is true', () => {
+        const trip = {
+            needs_sellado: true,
+            sellado_pending: false,
+            state: 'ready',
+            user: { id: owner.id }
+        };
+
+        expect(shouldShowSelladoPending(trip, owner)).toBe(false);
+        expect(shouldShowSelladoPending(trip, otherUser)).toBe(false);
+        expect(shouldShowSelladoPending(trip, null)).toBe(false);
+    });
+
+    it('returns true only for the trip owner when sellado is still pending', () => {
+        const trip = {
+            needs_sellado: true,
+            sellado_pending: true,
+            state: 'awaiting_payment',
+            user: { id: owner.id }
+        };
+
+        expect(shouldShowSelladoPending(trip, owner)).toBe(true);
+        expect(shouldShowSelladoPending(trip, otherUser)).toBe(false);
+        expect(shouldShowSelladoPending(trip, null)).toBe(false);
+    });
+
+    it('falls back to needs_sellado and non-ready state when sellado_pending is missing', () => {
+        const trip = {
+            needs_sellado: true,
+            state: 'awaiting_payment',
+            user: { id: owner.id }
+        };
+
+        expect(shouldShowSelladoPending(trip, owner)).toBe(true);
+        expect(shouldShowSelladoPending(trip, otherUser)).toBe(false);
+    });
+
+    it('returns false when the ready-state fallback would hide pending styling', () => {
+        const trip = {
+            needs_sellado: true,
+            state: 'ready',
+            user: { id: owner.id }
+        };
+
+        expect(shouldShowSelladoPending(trip, owner)).toBe(false);
+    });
+});

--- a/src/utils/tripSelladoDisplay.test.js
+++ b/src/utils/tripSelladoDisplay.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+    isInviteFriendsBlockedByUnpaidSellado,
     isSelladoPending,
     shouldShowSelladoPending
 } from './tripSelladoDisplay';
@@ -80,5 +81,27 @@ describe('shouldShowSelladoPending', () => {
         };
 
         expect(shouldShowSelladoPending(trip, owner)).toBe(false);
+    });
+});
+
+describe('isInviteFriendsBlockedByUnpaidSellado', () => {
+    it('blocks invite friends while sellado is unpaid', () => {
+        expect(
+            isInviteFriendsBlockedByUnpaidSellado({
+                needs_sellado: true,
+                sellado_pending: true,
+                state: 'awaiting_payment'
+            })
+        ).toBe(true);
+    });
+
+    it('allows invite friends once sellado is paid', () => {
+        expect(
+            isInviteFriendsBlockedByUnpaidSellado({
+                needs_sellado: true,
+                sellado_pending: false,
+                state: 'ready'
+            })
+        ).toBe(false);
     });
 });

--- a/src/utils/tripSelladoDisplay.test.js
+++ b/src/utils/tripSelladoDisplay.test.js
@@ -1,5 +1,35 @@
 import { describe, expect, it } from 'vitest';
-import { shouldShowSelladoPending } from './tripSelladoDisplay';
+import {
+    isSelladoPending,
+    shouldShowSelladoPending
+} from './tripSelladoDisplay';
+
+describe('isSelladoPending', () => {
+    it('prefers sellado_pending from the API when present', () => {
+        expect(
+            isSelladoPending({
+                needs_sellado: true,
+                sellado_pending: false,
+                state: 'awaiting_payment'
+            })
+        ).toBe(false);
+    });
+
+    it('derives pending state from needs_sellado when sellado_pending is missing', () => {
+        expect(
+            isSelladoPending({
+                needs_sellado: true,
+                state: 'awaiting_payment'
+            })
+        ).toBe(true);
+        expect(
+            isSelladoPending({
+                needs_sellado: true,
+                state: 'ready'
+            })
+        ).toBe(false);
+    });
+});
 
 describe('shouldShowSelladoPending', () => {
     const owner = { id: 10 };


### PR DESCRIPTION
## Summary

Sellado-related visibility and UX fixes across trip search, trip cards, ongoing trip card, and invite-friends flow.

### Frontend (`carpoolear` — `sellado-tweaks`)

**1. Trip card “Falta pagar Sellado” styling**

- **Cause:** Cards used `needs_sellado`, which stays `true` after payment. Paid sellado trips looked unpaid to everyone.
- **Fix:** Use `sellado_pending` (with ready-state fallback) via `tripSelladoDisplay.js`. Pending styling/label only for the trip owner.

**2. Ongoing trip card neutral rating icon**

- **Cause:** Neutral icon had extra top padding in `UserRatingsCounts`, misaligning it in the red-bordered ongoing trip card on `/trips`.
- **Fix:** Scoped override in `OngoingTripCard.vue` only; other usages unchanged.

**3. Invite friends until sellado is paid**

- **Cause:** “Invitar amigos al viaje” stayed enabled while sellado was unpaid.
- **Fix:** Disable the button when sellado is pending; tooltip: *“Una vez que pagues el sellado vas a poder invitar a tus amigos”* (i18n). Skip auto-opening the invite modal from `?inviteFriends=1` while payment is pending.

## Test plan

- [ ] Logged out on `/trips`: unpaid sellado trips hidden; paid sellado trips look normal
- [ ] Trip owner: unpaid trip shows sellado pending styling; paid trip does not
- [ ] Ongoing trip card: neutral rating icon aligned with thumbs up/down
- [ ] Trip detail (owner, unpaid sellado): invite friends disabled with tooltip; enabled after payment
- [ ] Backend: `php artisan test`
- [ ] Frontend: `npm run lint` + sellado-related unit tests