### PR TITLE
Notifications text locale

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -139,14 +139,12 @@ export default {
             fbLogin: 'facebookLogin'
         }),
         ...mapActions(useAuthStore, {
-            getConfig: 'getConfig'
+            getConfig: 'getConfig',
+            applyUserLocaleToI18n: 'applyUserLocaleToI18n'
         })
     },
     created() {
-        const stored = localStorage.getItem('app_locale');
-        if (stored) {
-            this.$i18n.locale = stored;
-        }
+        this.applyUserLocaleToI18n(this.$i18n);
     },
     beforeMount() {
         this.getConfig();
@@ -293,8 +291,8 @@ export default {
             }
         },
         appConfig(value) {
-            if (value && value.locale && !localStorage.getItem('app_locale')) {
-                this.$root.$i18n.locale = value.locale;
+            if (value) {
+                this.applyUserLocaleToI18n(this.$root.$i18n);
             }
             if (value && !value.__isLocal) {
                 this.runVersionCheck(value);

--- a/src/components/sections/HeaderApp.vue
+++ b/src/components/sections/HeaderApp.vue
@@ -330,6 +330,13 @@ import IdentityValidationCountdownBanner from '../IdentityValidationCountdownBan
 import UserRatingsCounts from '../elements/UserRatingsCounts.vue';
 import PendingRatingsBanner from '../PendingRatingsBanner.vue';
 import { shouldHideDonationOnIOSCapacitor } from '../../services/capacitor.js';
+import { UserApi } from '../../services/api';
+import {
+    persistLocaleChoice,
+    syncLocaleToBackend,
+} from '../../utils/userLocale.js';
+
+const userApi = new UserApi();
 
 export default {
     name: 'headerApp',
@@ -449,7 +456,8 @@ export default {
 
         setLocale(locale) {
             this.$root.$i18n.locale = locale;
-            localStorage.setItem('app_locale', locale);
+            persistLocaleChoice(locale);
+            syncLocaleToBackend(userApi, locale, this.logged).catch(() => {});
         }
     },
     watch: {

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -2,6 +2,8 @@ import { defineStore } from 'pinia';
 import { AuthApi, UserApi } from '../services/api';
 import cache, { keys } from '../services/cache';
 import localConfig from '../../config/conf';
+import { resolveInitialLocale, applyResolvedLocale } from '../utils/userLocale.js';
+import i18n from '../i18n.js';
 import { completeSessionIfRegistrationReturnsToken } from '../utils/registrationAutoLogin';
 import { getLazyRouter } from '../utils/routerLazy.js';
 import { hasRequiredProfileFields } from '../utils/profileRequirements';
@@ -38,6 +40,16 @@ export const useAuthStore = defineStore('auth', {
         setUser(user) {
             this.user = user;
             cache.setItem(keys.USER_KEY, user);
+        },
+
+        applyUserLocaleToI18n(i18nInstance = i18n.global) {
+            const locale = resolveInitialLocale({
+                storedLocale: localStorage.getItem('app_locale'),
+                userLocale: this.user?.locale,
+                appLocale: this.appConfig?.locale,
+            });
+
+            applyResolvedLocale(i18nInstance, locale);
         },
 
         doLogout() {
@@ -189,6 +201,7 @@ export const useAuthStore = defineStore('auth', {
                 .show()
                 .then((response) => {
                     this.setUser(response.data);
+                    this.applyUserLocaleToI18n();
                 })
                 .catch(() => {});
         },

--- a/src/utils/userLocale.js
+++ b/src/utils/userLocale.js
@@ -1,0 +1,41 @@
+export const LOCALE_STORAGE_KEY = 'app_locale';
+
+export function resolveInitialLocale({ storedLocale, userLocale, appLocale }) {
+    if (storedLocale) {
+        return storedLocale;
+    }
+
+    if (userLocale) {
+        return userLocale;
+    }
+
+    return appLocale || 'arg';
+}
+
+export function buildLocaleUpdateFormData(locale) {
+    const formData = new FormData();
+    formData.append('locale', locale);
+    formData.append('_method', 'PUT');
+
+    return formData;
+}
+
+export function persistLocaleChoice(locale) {
+    localStorage.setItem(LOCALE_STORAGE_KEY, locale);
+}
+
+export async function syncLocaleToBackend(userApi, locale, isLoggedIn) {
+    if (!isLoggedIn || !locale) {
+        return;
+    }
+
+    await userApi.update(buildLocaleUpdateFormData(locale));
+}
+
+export function applyResolvedLocale(i18n, locale) {
+    if (!i18n || !locale) {
+        return;
+    }
+
+    i18n.locale = locale;
+}

--- a/src/utils/userLocale.test.js
+++ b/src/utils/userLocale.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+    LOCALE_STORAGE_KEY,
+    buildLocaleUpdateFormData,
+    persistLocaleChoice,
+    resolveInitialLocale,
+    syncLocaleToBackend,
+} from './userLocale.js';
+
+describe('userLocale', () => {
+    it('resolveInitialLocale prefers stored locale over profile and app defaults', () => {
+        expect(
+            resolveInitialLocale({
+                storedLocale: 'en',
+                userLocale: 'arg',
+                appLocale: 'chl',
+            })
+        ).toBe('en');
+    });
+
+    it('resolveInitialLocale uses profile locale when nothing is stored locally', () => {
+        expect(
+            resolveInitialLocale({
+                storedLocale: null,
+                userLocale: 'en',
+                appLocale: 'arg',
+            })
+        ).toBe('en');
+    });
+
+    it('resolveInitialLocale falls back to app locale when profile locale is missing', () => {
+        expect(
+            resolveInitialLocale({
+                storedLocale: null,
+                userLocale: null,
+                appLocale: 'arg',
+            })
+        ).toBe('arg');
+    });
+
+    it('buildLocaleUpdateFormData includes locale for profile update', () => {
+        const formData = buildLocaleUpdateFormData('en');
+
+        expect(formData.get('locale')).toBe('en');
+        expect(formData.get('_method')).toBe('PUT');
+    });
+
+    it('persistLocaleChoice stores locale in localStorage', () => {
+        const storage = {};
+        vi.stubGlobal('localStorage', {
+            setItem: (key, value) => {
+                storage[key] = value;
+            },
+            getItem: (key) => storage[key] ?? null,
+        });
+
+        persistLocaleChoice('en');
+
+        expect(storage[LOCALE_STORAGE_KEY]).toBe('en');
+        vi.unstubAllGlobals();
+    });
+
+    it('syncLocaleToBackend updates profile when user is logged in', async () => {
+        const update = vi.fn().mockResolvedValue({ data: {} });
+        const userApi = { update };
+
+        await syncLocaleToBackend(userApi, 'en', true);
+
+        expect(update).toHaveBeenCalledTimes(1);
+        expect(update.mock.calls[0][0].get('locale')).toBe('en');
+    });
+
+    it('syncLocaleToBackend skips API call when user is logged out', async () => {
+        const update = vi.fn();
+        const userApi = { update };
+
+        await syncLocaleToBackend(userApi, 'en', false);
+
+        expect(update).not.toHaveBeenCalled();
+    });
+});

--- a/src/utils/userLocale.views.test.js
+++ b/src/utils/userLocale.views.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const headerSource = fs.readFileSync(
+    path.resolve(__dirname, '../components/sections/HeaderApp.vue'),
+    'utf8'
+);
+
+describe('HeaderApp locale preference', () => {
+    it('persists locale locally and syncs it to the user profile when logged in', () => {
+        expect(headerSource).toContain('persistLocaleChoice');
+        expect(headerSource).toContain('syncLocaleToBackend');
+        expect(headerSource).toMatch(
+            /setLocale\(locale\)[\s\S]*syncLocaleToBackend\(userApi, locale, this\.logged\)/
+        );
+    });
+});


### PR DESCRIPTION
## Summary

Notification text (list API, push, and email) is now resolved in each recipient's language instead of always using the server default.

### Cause
- Laravel notifications already use `__()` translations, but locale was never set per user when listing or delivering notifications.
- The Vue app stored language choice only in `localStorage`, so the backend had no user locale to use.
- NestJS API (`carpoolear-nx`) still has hardcoded Spanish strings — out of scope for this branch (production uses Laravel).

### Frontend (`carpoolear`)
- Added `userLocale` utility: resolve initial locale (stored → profile → app config), persist choice, sync to profile via `PUT /api/users`.
- `HeaderApp.setLocale()` saves locally and syncs to backend when logged in.
- `App.vue` / auth store apply profile locale on load and after `fetchUser()`.

## Test plan
- [ ] Run migration: `php artisan migrate`
- [ ] User with `locale = en` receives English notification text in `/api/notifications`
- [ ] User without `locale` gets text in `APP_LOCALE` (e.g. `arg`)
- [ ] Change language in header → profile `locale` updates → notifications reflect new language
- [ ] Push notification message matches user's locale
- [ ] Existing users without `locale` continue to see default-language notifications