### PR TITLE
Punto origen salida  - edit

### DIFF
--- a/src/components/views/NewTrip.view.test.js
+++ b/src/components/views/NewTrip.view.test.js
@@ -97,6 +97,14 @@ describe('NewTrip.vue punto partida and punto llegada', () => {
         expect(viewSource).toContain('puntoPartidaError');
         expect(viewSource).toContain('puntoLlegadaError');
     });
+
+    it('restores punto partida and punto llegada when loading a trip for edit', () => {
+        expect(viewSource).toContain("from '../../utils/tripPointDetailPrefill.js'");
+        expect(viewSource).toContain('restoreTripPointDetailsFromTrip');
+        expect(viewSource).toMatch(
+            /restoreData\(trip\)[\s\S]*?restoreTripPointDetailsFromTrip\(this\.trip, trip\)/s
+        );
+    });
 });
 
 describe('NewTrip.vue rear seat comfort preference', () => {

--- a/src/components/views/NewTrip.view.test.js
+++ b/src/components/views/NewTrip.view.test.js
@@ -105,6 +105,16 @@ describe('NewTrip.vue punto partida and punto llegada', () => {
             /restoreData\(trip\)[\s\S]*?restoreTripPointDetailsFromTrip\(this\.trip, trip\)/s
         );
     });
+
+    it('prefills inverted punto details on return trips from outbound values', () => {
+        expect(viewSource).toContain('syncReturnTripPointDetailsFromOutbound');
+        expect(viewSource).toMatch(
+            /showReturnTrip\(value\)[\s\S]*?syncReturnTripPointDetailsFromOutbound\([\s\S]*?this\.trip,[\s\S]*?this\.otherTrip\.trip/s
+        );
+        expect(viewSource).toMatch(
+            /getPlace\(i, data, type\)[\s\S]*?syncReturnTripPointDetailsFromOutbound\([\s\S]*?this\.trip,[\s\S]*?this\.otherTrip\.trip/s
+        );
+    });
 });
 
 describe('NewTrip.vue rear seat comfort preference', () => {

--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -2091,7 +2091,10 @@ import {
     shouldShowTripPointDetailInputs,
     applyTripPointDetailValidation
 } from '../../utils/tripPointDetailValidation.js';
-import { restoreTripPointDetailsFromTrip } from '../../utils/tripPointDetailPrefill.js';
+import {
+    restoreTripPointDetailsFromTrip,
+    syncReturnTripPointDetailsFromOutbound
+} from '../../utils/tripPointDetailPrefill.js';
 import {
     activeCarsWithPlate,
     hasDriverPlate,
@@ -2462,6 +2465,30 @@ export default {
         'trip.friendship_type_id': function () {
             this.otherTrip.trip.friendship_type_id =
                 this.trip.friendship_type_id;
+        },
+        showReturnTrip(value) {
+            if (value) {
+                syncReturnTripPointDetailsFromOutbound(
+                    this.trip,
+                    this.otherTrip.trip
+                );
+            }
+        },
+        'trip.punto_partida'() {
+            if (this.showReturnTrip) {
+                syncReturnTripPointDetailsFromOutbound(
+                    this.trip,
+                    this.otherTrip.trip
+                );
+            }
+        },
+        'trip.punto_llegada'() {
+            if (this.showReturnTrip) {
+                syncReturnTripPointDetailsFromOutbound(
+                    this.trip,
+                    this.otherTrip.trip
+                );
+            }
         },
         'trip.is_passenger': function () {
             this.preselectDriverCar();
@@ -3376,6 +3403,11 @@ export default {
                     error: new Error(),
                     id: point.id  // Preserve the original ID
                 }));
+
+                syncReturnTripPointDetailsFromOutbound(
+                    this.trip,
+                    this.otherTrip.trip
+                );
                 
                 // Update the center to the first point of the return trip
                 this.otherTrip.center = this.otherTrip.points[0].location;

--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -2091,6 +2091,7 @@ import {
     shouldShowTripPointDetailInputs,
     applyTripPointDetailValidation
 } from '../../utils/tripPointDetailValidation.js';
+import { restoreTripPointDetailsFromTrip } from '../../utils/tripPointDetailPrefill.js';
 import {
     activeCarsWithPlate,
     hasDriverPlate,
@@ -2667,8 +2668,7 @@ export default {
         this.trip.friendship_type_id = trip.friendship_type_id;
         this.trip.distance = trip.distance;
         this.trip.description = trip.description;
-        this.trip.punto_partida = trip.punto_partida || '';
-        this.trip.punto_llegada = trip.punto_llegada || '';
+        restoreTripPointDetailsFromTrip(this.trip, trip);
         
         this.trip.allow_kids = Number(trip.allow_kids) > 0;
         this.trip.allow_animals = Number(trip.allow_animals) > 0;

--- a/src/utils/tripPointDetailPrefill.js
+++ b/src/utils/tripPointDetailPrefill.js
@@ -3,3 +3,9 @@ export function restoreTripPointDetailsFromTrip(targetTrip, sourceTrip) {
     targetTrip.punto_llegada = sourceTrip?.punto_llegada || '';
     return targetTrip;
 }
+
+export function syncReturnTripPointDetailsFromOutbound(outboundTrip, returnTrip) {
+    returnTrip.punto_partida = outboundTrip?.punto_llegada || '';
+    returnTrip.punto_llegada = outboundTrip?.punto_partida || '';
+    return returnTrip;
+}

--- a/src/utils/tripPointDetailPrefill.js
+++ b/src/utils/tripPointDetailPrefill.js
@@ -1,0 +1,5 @@
+export function restoreTripPointDetailsFromTrip(targetTrip, sourceTrip) {
+    targetTrip.punto_partida = sourceTrip?.punto_partida || '';
+    targetTrip.punto_llegada = sourceTrip?.punto_llegada || '';
+    return targetTrip;
+}

--- a/src/utils/tripPointDetailPrefill.js
+++ b/src/utils/tripPointDetailPrefill.js
@@ -1,11 +1,15 @@
 export function restoreTripPointDetailsFromTrip(targetTrip, sourceTrip) {
+    /* eslint-disable camelcase -- trip API fields use snake_case */
     targetTrip.punto_partida = sourceTrip?.punto_partida || '';
     targetTrip.punto_llegada = sourceTrip?.punto_llegada || '';
+    /* eslint-enable camelcase */
     return targetTrip;
 }
 
 export function syncReturnTripPointDetailsFromOutbound(outboundTrip, returnTrip) {
+    /* eslint-disable camelcase -- trip API fields use snake_case */
     returnTrip.punto_partida = outboundTrip?.punto_llegada || '';
     returnTrip.punto_llegada = outboundTrip?.punto_partida || '';
+    /* eslint-enable camelcase */
     return returnTrip;
 }

--- a/src/utils/tripPointDetailPrefill.test.js
+++ b/src/utils/tripPointDetailPrefill.test.js
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { restoreTripPointDetailsFromTrip } from './tripPointDetailPrefill.js';
+import {
+    restoreTripPointDetailsFromTrip,
+    syncReturnTripPointDetailsFromOutbound
+} from './tripPointDetailPrefill.js';
 
 describe('restoreTripPointDetailsFromTrip', () => {
     it('copies punto partida and punto llegada from the saved trip into the form trip', () => {
@@ -23,6 +26,40 @@ describe('restoreTripPointDetailsFromTrip', () => {
         restoreTripPointDetailsFromTrip(formTrip, {});
 
         expect(formTrip).toEqual({
+            punto_partida: '',
+            punto_llegada: ''
+        });
+    });
+});
+
+describe('syncReturnTripPointDetailsFromOutbound', () => {
+    it('inverts punto partida and punto llegada on the return trip', () => {
+        const outboundTrip = {
+            punto_partida: 'Terminal de Ómnibus',
+            punto_llegada: 'Plaza Principal'
+        };
+        const returnTrip = {
+            punto_partida: '',
+            punto_llegada: ''
+        };
+
+        syncReturnTripPointDetailsFromOutbound(outboundTrip, returnTrip);
+
+        expect(returnTrip).toEqual({
+            punto_partida: 'Plaza Principal',
+            punto_llegada: 'Terminal de Ómnibus'
+        });
+    });
+
+    it('defaults missing outbound values to empty strings on the return trip', () => {
+        const returnTrip = {
+            punto_partida: 'old',
+            punto_llegada: 'old'
+        };
+
+        syncReturnTripPointDetailsFromOutbound({}, returnTrip);
+
+        expect(returnTrip).toEqual({
             punto_partida: '',
             punto_llegada: ''
         });

--- a/src/utils/tripPointDetailPrefill.test.js
+++ b/src/utils/tripPointDetailPrefill.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { restoreTripPointDetailsFromTrip } from './tripPointDetailPrefill.js';
+
+describe('restoreTripPointDetailsFromTrip', () => {
+    it('copies punto partida and punto llegada from the saved trip into the form trip', () => {
+        const formTrip = { punto_partida: '', punto_llegada: '' };
+        const savedTrip = {
+            punto_partida: 'Terminal de Ómnibus',
+            punto_llegada: 'Plaza Principal'
+        };
+
+        restoreTripPointDetailsFromTrip(formTrip, savedTrip);
+
+        expect(formTrip).toEqual({
+            punto_partida: 'Terminal de Ómnibus',
+            punto_llegada: 'Plaza Principal'
+        });
+    });
+
+    it('defaults missing values to empty strings', () => {
+        const formTrip = { punto_partida: 'old', punto_llegada: 'old' };
+
+        restoreTripPointDetailsFromTrip(formTrip, {});
+
+        expect(formTrip).toEqual({
+            punto_partida: '',
+            punto_llegada: ''
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Pre-fill **punto de partida** and **punto de llegada** (barrio / punto de encuentro público) when editing a trip, and auto-fill them inverted on return trips.

## Cause

- **Edit:** The form had the fields but restoration was inline and not covered by dedicated tests; behavior was fragile and easy to miss.
- **Return trip:** Outbound origin/destination were mirrored when selecting locations, but `punto_partida` / `punto_llegada` were never swapped onto the return trip.

## Fix

### Frontend (`carpoolear`)

- Added `src/utils/tripPointDetailPrefill.js`:
  - `restoreTripPointDetailsFromTrip()` — copies saved trip values into the edit form
  - `syncReturnTripPointDetailsFromOutbound()` — inverts outbound → return (`partida` ↔ `llegada`)
- **`NewTrip.vue`:**
  - Uses `restoreTripPointDetailsFromTrip` in `restoreData()` when loading a trip for edit
  - Syncs inverted point details on return trips when:
    - outbound locations change (`getPlace`)
    - return trip checkbox is enabled
    - outbound punto fields change (watchers)
- View/source contract tests in `NewTrip.view.test.js`

## Test plan

- [ ] Edit an existing trip with saved punto partida/llegada → fields pre-filled in the form
- [ ] Create a trip with return trip enabled → return punto partida = outbound punto llegada (and vice versa)
- [ ] Change outbound punto fields with return trip enabled → return fields update inverted
- [ ] Save edited trip → punto values persist after reload