### PR TITLE
Profile saving changes

### DIFF
--- a/src/components/sections/UpdateProfile.view.test.js
+++ b/src/components/sections/UpdateProfile.view.test.js
@@ -22,6 +22,13 @@ describe('UpdateProfile save error feedback', () => {
     });
 });
 
+describe('UpdateProfile draft isolation', () => {
+    it('keeps form edits in a local clone instead of mutating the auth store', () => {
+        expect(viewSource).toContain('cloneProfileUser');
+        expect(viewSource).not.toMatch(/this\.user\s*=\s*this\.userData;/);
+    });
+});
+
 describe('UpdateProfile name editing', () => {
     it('locks the name field when identity is validated', () => {
         expect(viewSource).toContain('isNameLockedByValidation');

--- a/src/components/sections/UpdateProfile.vue
+++ b/src/components/sections/UpdateProfile.vue
@@ -656,6 +656,7 @@ import {
     IMAGE_UPLOAD_ACCEPT
 } from '../../utils/imageUpload';
 import { applyImageUploadSelection } from '../../utils/imageUploadSelection';
+import { cloneProfileUser } from '../../utils/profileUserClone';
 
 class Error {
     constructor(state = false, message = '') {
@@ -790,6 +791,15 @@ export default {
             const normalized = normalizeFacebookProfileUrl(this.user.facebook_profile_url);
             if (normalized) {
                 this.user.facebook_profile_url = normalized;
+            }
+        },
+        syncProfileDraftFromStore() {
+            this.user = cloneProfileUser(this.userData);
+            if (this.user && this.user.nro_doc) {
+                this.user.nro_doc = formatId(
+                    this.user.nro_doc,
+                    this.config.profile_id_format
+                );
             }
         },
         jumpToError() {
@@ -1185,11 +1195,7 @@ export default {
         },
         userData: function () {
             console.log('userData', this.userData);
-            this.user = this.userData;
-            // Format nro_doc with pattern when loaded from backend
-            if (this.user && this.user.nro_doc) {
-                this.user.nro_doc = formatId(this.user.nro_doc, this.config.profile_id_format);
-            }
+            this.syncProfileDraftFromStore();
         },
         iptUser() {
             this.nombreError.state = false;
@@ -1227,11 +1233,7 @@ export default {
         this.redirectMissingPatenteToAutos();
         this.scrollToAutosLinkIfNeeded();
         bus.on('date-change', this.dateChange);
-        this.user = this.userData;
-        // Format nro_doc with pattern when page loads
-        if (this.user && this.user.nro_doc) {
-            this.user.nro_doc = formatId(this.user.nro_doc, this.config.profile_id_format);
-        }
+        this.syncProfileDraftFromStore();
         console.log('USUARIO', this.userData);
         if (
             Array.isArray(this.user.driver_data_docs) &&

--- a/src/components/views/NewTrip.create.view.test.js
+++ b/src/components/views/NewTrip.create.view.test.js
@@ -17,6 +17,6 @@ describe('NewTrip incomplete profile handling', () => {
     it('redirects to profile update when trip create returns profile_required', () => {
         expect(newTripViewSource).toContain('isProfileRequiredTripError');
         expect(newTripViewSource).toContain('redirectToIncompleteProfileForTripCreate');
-        expect(newTripViewSource).toContain("completaPerfilParaCrearViaje");
+        expect(newTripViewSource).toContain('completaPerfilParaCrearViaje');
     });
 });

--- a/src/components/views/NewTrip.create.view.test.js
+++ b/src/components/views/NewTrip.create.view.test.js
@@ -12,3 +12,11 @@ describe('NewTrip duplicate create handling', () => {
         expect(newTripViewSource).toContain('t.existing');
     });
 });
+
+describe('NewTrip incomplete profile handling', () => {
+    it('redirects to profile update when trip create returns profile_required', () => {
+        expect(newTripViewSource).toContain('isProfileRequiredTripError');
+        expect(newTripViewSource).toContain('redirectToIncompleteProfileForTripCreate');
+        expect(newTripViewSource).toContain("completaPerfilParaCrearViaje");
+    });
+});

--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -2076,6 +2076,10 @@ import TripCarsModal from '../elements/TripCarsModal.vue';
 import TripPointDetailFields from '../elements/TripPointDetailFields';
 import bus from '../../services/bus-event.js';
 import { tripDetailRouteAfterCreate } from '../../utils/tripCreateRedirect.js';
+import {
+    isProfileRequiredTripError,
+    redirectToIncompleteProfileForTripCreate
+} from '../../utils/tripCreateErrors.js';
 import { getMaxContributionExceededMessage } from '../../utils/maxContributionExceededMessage.js';
 import { rememberMaxContributionWarning } from '../../utils/maxContributionWarningState.js';
 import {
@@ -3332,6 +3336,12 @@ export default {
                         } else if (this.$checkError(err, 'routing_service_unavailable')) {
                             dialogs.message(this.$t('routingServiceTemporaryError'), {
                                 estado: 'error'
+                            });
+                        } else if (isProfileRequiredTripError(err)) {
+                            redirectToIncompleteProfileForTripCreate(this.$router);
+                            dialogs.message(this.$t('completaPerfilParaCrearViaje'), {
+                                estado: 'error',
+                                duration: 10
                             });
                         } else {
                             dialogs.message(

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -561,6 +561,8 @@ const messages = {
         validacionIdentidadRemovida: 'Verificación de cuenta removida.',
         debesValidarIdentidadParaAccion:
             'Debes verificar tu cuenta para realizar esta acción.',
+        completaPerfilParaCrearViaje:
+            'Tenés que completar y guardar tu perfil antes de publicar un viaje.',
         validacionProntoBanner:
             'Verificá tu cuenta o no podrás publicar viajes ni enviar mensajes. Tiempo restante: {countdown}',
         validacionProntoBannerTiempoCumplido:
@@ -2060,6 +2062,8 @@ const messages = {
         validacionIdentidadRemovida: 'Verificación de cuenta removida.',
         debesValidarIdentidadParaAccion:
             'Debes verificar tu cuenta para realizar esta acción.',
+        completaPerfilParaCrearViaje:
+            'Tenés que completar y guardar tu perfil antes de publicar un viaje.',
         validacionProntoBanner:
             'Verificá tu cuenta o no podrás publicar viajes ni enviar mensajes. Tiempo restante: {countdown}',
         validacionProntoBannerTiempoCumplido:
@@ -3643,6 +3647,8 @@ const messages = {
         validacionIdentidadRemovida: 'Account verification removed.',
         debesValidarIdentidadParaAccion:
             'You must verify your account to perform this action.',
+        completaPerfilParaCrearViaje:
+            'You need to complete and save your profile before posting a trip.',
         validacionProntoBanner:
             "Verify your account or you won't be able to post trips or send messages. Time remaining: {countdown}",
         validacionProntoBannerTiempoCumplido:

--- a/src/language/tripCreateProfileI18n.test.js
+++ b/src/language/tripCreateProfileI18n.test.js
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import messages from './i18n';
+
+describe('completaPerfilParaCrearViaje i18n', () => {
+    it.each(['arg', 'chl'])('%s locale defines trip create profile message', (locale) => {
+        expect(messages[locale].completaPerfilParaCrearViaje).toBeTruthy();
+    });
+
+    it('en locale defines trip create profile message', () => {
+        expect(messages.en.completaPerfilParaCrearViaje).toBe(
+            'You need to complete and save your profile before posting a trip.'
+        );
+    });
+});

--- a/src/router/middleware.js
+++ b/src/router/middleware.js
@@ -3,6 +3,7 @@ import router from '../router';
 import { useAuthStore } from '../stores/auth';
 import { useRatesStore } from '../stores/rates';
 import { hasRequiredProfileFields } from '../utils/profileRequirements';
+import { INCOMPLETE_PROFILE_UPDATE_ROUTE } from '../utils/tripCreateErrors';
 import {
     PENDING_RATINGS_REDIRECT_ROUTE,
     shouldRedirectForPendingRatings
@@ -121,7 +122,7 @@ export function profileComplete(to, from, next) {
         };
         console.log('problem');
         next(false);
-        router.replace({ name: 'profile_update', query: { incompleteProfile: 'true' } });
+        router.replace(INCOMPLETE_PROFILE_UPDATE_ROUTE);
     } else {
         next();
     }

--- a/src/router/middleware.profileRoute.test.js
+++ b/src/router/middleware.profileRoute.test.js
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const middlewareSource = fs.readFileSync(
+    path.resolve(__dirname, 'middleware.js'),
+    'utf8'
+);
+
+describe('profileComplete middleware', () => {
+    it('uses the shared incomplete profile route constant', () => {
+        expect(middlewareSource).toContain('INCOMPLETE_PROFILE_UPDATE_ROUTE');
+        expect(middlewareSource).not.toContain(
+            "query: { incompleteProfile: 'true' }"
+        );
+    });
+});

--- a/src/utils/profileUserClone.js
+++ b/src/utils/profileUserClone.js
@@ -1,0 +1,7 @@
+export function cloneProfileUser(user) {
+    if (!user || typeof user !== 'object') {
+        return null;
+    }
+
+    return JSON.parse(JSON.stringify(user));
+}

--- a/src/utils/profileUserClone.test.js
+++ b/src/utils/profileUserClone.test.js
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { cloneProfileUser } from './profileUserClone.js';
+
+describe('cloneProfileUser', () => {
+    it('returns a deep copy that does not mutate the auth store user', () => {
+        const source = {
+            name: 'Ana',
+            nro_doc: '30111222',
+            description: 'Viajo seguido',
+            mobile_phone: '+5493415551234',
+            meta: { trips: 2 }
+        };
+
+        const draft = cloneProfileUser(source);
+        draft.nro_doc = '99999999';
+        draft.description = 'Cambio sin guardar';
+        draft.meta.trips = 99;
+
+        expect(source.nro_doc).toBe('30111222');
+        expect(source.description).toBe('Viajo seguido');
+        expect(source.meta.trips).toBe(2);
+        expect(draft).not.toBe(source);
+    });
+
+    it('returns null when user is missing', () => {
+        expect(cloneProfileUser(null)).toBe(null);
+        expect(cloneProfileUser(undefined)).toBe(null);
+    });
+});

--- a/src/utils/tripCreateErrors.js
+++ b/src/utils/tripCreateErrors.js
@@ -1,0 +1,22 @@
+export const INCOMPLETE_PROFILE_UPDATE_ROUTE = {
+    name: 'profile_update',
+    query: { incompleteProfile: 'true' }
+};
+
+export function isProfileRequiredTripError(error) {
+    if (!error || error.status !== 422) {
+        return false;
+    }
+
+    const profileRequired = error.data?.errors?.profile_required;
+    if (Array.isArray(profileRequired)) {
+        return profileRequired.length > 0;
+    }
+
+    return typeof profileRequired === 'string' && profileRequired.trim().length > 0;
+}
+
+export function redirectToIncompleteProfileForTripCreate(router) {
+    router.replace(INCOMPLETE_PROFILE_UPDATE_ROUTE);
+    return true;
+}

--- a/src/utils/tripCreateErrors.js
+++ b/src/utils/tripCreateErrors.js
@@ -8,7 +8,12 @@ export function isProfileRequiredTripError(error) {
         return false;
     }
 
-    const profileRequired = error.data?.errors?.profile_required;
+    const errors = error.data?.errors;
+    if (!errors) {
+        return false;
+    }
+    // API field name from Laravel validation bag
+    const profileRequired = errors.profile_required;
     if (Array.isArray(profileRequired)) {
         return profileRequired.length > 0;
     }

--- a/src/utils/tripCreateErrors.test.js
+++ b/src/utils/tripCreateErrors.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    INCOMPLETE_PROFILE_UPDATE_ROUTE,
+    isProfileRequiredTripError,
+    redirectToIncompleteProfileForTripCreate
+} from './tripCreateErrors.js';
+
+describe('tripCreateErrors', () => {
+    it('detects profile_required validation from trip create API', () => {
+        expect(
+            isProfileRequiredTripError({
+                status: 422,
+                data: {
+                    errors: {
+                        profile_required: ['The user profile must be complete.']
+                    }
+                }
+            })
+        ).toBe(true);
+    });
+
+    it('ignores unrelated trip create errors', () => {
+        expect(
+            isProfileRequiredTripError({
+                status: 422,
+                data: {
+                    errors: {
+                        car_id: ['The driver must have a car with a plate.']
+                    }
+                }
+            })
+        ).toBe(false);
+        expect(isProfileRequiredTripError(null)).toBe(false);
+    });
+
+    it('redirects to profile update with incompleteProfile query', () => {
+        const router = { replace: vi.fn() };
+        expect(redirectToIncompleteProfileForTripCreate(router)).toBe(true);
+        expect(router.replace).toHaveBeenCalledWith(INCOMPLETE_PROFILE_UPDATE_ROUTE);
+        expect(INCOMPLETE_PROFILE_UPDATE_ROUTE).toEqual({
+            name: 'profile_update',
+            query: { incompleteProfile: 'true' }
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Fixes two gaps that left users stuck when their profile was incomplete on the server but looked complete in the app.

### Cause

1. **Trip creation** — When the API rejected create with `profile_required`, `NewTrip` showed a generic *"Ocurrió un problema al cargar el viaje"* toast. Users retried the trip form without knowing they needed to **save** a complete profile first.

2. **Profile form** — `UpdateProfile` assigned `this.user = this.userData` by reference, so typing DNI/phone/description mutated the Pinia auth store **before save**. Route guards (`hasRequiredProfileFields`) could see a “complete” in-memory profile and allow `/trips/create`, while the server still had an incomplete profile (or blocked save due to duplicate DNI).

### Fix (frontend)

- **`tripCreateErrors.js`** — Detect `errors.profile_required` on trip create; redirect to `/setting/profile?incompleteProfile=true` with i18n message `completaPerfilParaCrearViaje` (arg/chl/en).
- **`NewTrip.vue`** — Handle that error before the generic catch-all.
- **`middleware.js`** — Reuse shared `INCOMPLETE_PROFILE_UPDATE_ROUTE` for consistent redirect target.
- **`profileUserClone.js`** — Deep-clone auth user for the profile form draft.
- **`UpdateProfile.vue`** — `syncProfileDraftFromStore()` on mount and when store user changes; unsaved edits no longer affect route guards.

## Test plan

- [ ] Log in with incomplete profile (missing DNI/phone on server); open trip create; submit → redirected to profile with toast *"Tenés que completar y guardar tu perfil..."*
- [ ] On profile settings, type DNI/phone without saving → footer/header “Crear viaje” → blocked by route guard (redirect to profile)
- [ ] Complete and save profile → create trip succeeds
- [ ] Duplicate DNI on save still shows “Datos en uso” modal (unchanged)
- [ ] `npm run test:unit -- --run src/utils/tripCreateErrors.test.js src/utils/profileUserClone.test.js`