### PR TITLE
Datos invalidos

### DIFF
--- a/src/components/elements/TripFormValidationSummary.view.test.js
+++ b/src/components/elements/TripFormValidationSummary.view.test.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const componentPath = path.resolve(__dirname, '../elements/TripFormValidationSummary.vue');
+const componentSource = fs.readFileSync(componentPath, 'utf8');
+
+describe('TripFormValidationSummary', () => {
+    it('renders a visible list of validation messages at the end of the form', () => {
+        expect(componentSource).toContain('trip-form-validation-summary');
+        expect(componentSource).toContain('v-for="(message, index) in messages"');
+        expect(componentSource).toContain('v-if="shouldShow"');
+        expect(componentSource).toContain('shouldShowTripFormValidationSummary');
+    });
+});

--- a/src/components/elements/TripFormValidationSummary.view.test.js
+++ b/src/components/elements/TripFormValidationSummary.view.test.js
@@ -11,5 +11,9 @@ describe('TripFormValidationSummary', () => {
         expect(componentSource).toContain('v-for="(message, index) in messages"');
         expect(componentSource).toContain('v-if="shouldShow"');
         expect(componentSource).toContain('shouldShowTripFormValidationSummary');
+        expect(componentSource).toContain('list-style-type: disc');
+        expect(componentSource).toContain('border: 2px solid var(--main-error, #d72521)');
+        expect(componentSource).toContain('background-color: #fff');
+        expect(componentSource).toContain('margin-right: 5px');
     });
 });

--- a/src/components/elements/TripFormValidationSummary.vue
+++ b/src/components/elements/TripFormValidationSummary.vue
@@ -1,7 +1,7 @@
 <template>
     <div
         v-if="shouldShow"
-        class="trip-form-validation-summary alert alert-danger"
+        class="trip-form-validation-summary"
         role="alert"
     >
         <p class="trip-form-validation-summary__title">{{ title }}</p>
@@ -47,15 +47,32 @@ export default {
 .trip-form-validation-summary {
     margin-top: 1rem;
     margin-bottom: 1rem;
+    margin-right: 5px;
+    padding: 1rem;
+    background-color: #fff;
+    border: 2px solid var(--main-error, #d72521);
+    border-radius: 4px;
+    color: #1f1f1f;
 }
 
 .trip-form-validation-summary__title {
     margin: 0 0 0.5rem;
-    font-weight: 600;
+    font-weight: 700;
+    color: var(--main-error, #d72521);
 }
 
 .trip-form-validation-summary__list {
     margin: 0;
-    padding-left: 1.25rem;
+    padding-left: 1.5rem;
+    list-style-type: disc;
+    color: #1f1f1f;
+}
+
+.trip-form-validation-summary__list li {
+    margin-bottom: 0.25rem;
+}
+
+.trip-form-validation-summary__list li::marker {
+    color: #1f1f1f;
 }
 </style>

--- a/src/components/elements/TripFormValidationSummary.vue
+++ b/src/components/elements/TripFormValidationSummary.vue
@@ -1,0 +1,61 @@
+<template>
+    <div
+        v-if="shouldShow"
+        class="trip-form-validation-summary alert alert-danger"
+        role="alert"
+    >
+        <p class="trip-form-validation-summary__title">{{ title }}</p>
+        <ul class="trip-form-validation-summary__list">
+            <li
+                v-for="(message, index) in messages"
+                :key="`${message}-${index}`"
+            >
+                {{ message }}
+            </li>
+        </ul>
+    </div>
+</template>
+
+<script>
+import { shouldShowTripFormValidationSummary } from '../../utils/tripFormValidationFeedback.js';
+
+export default {
+    name: 'trip-form-validation-summary',
+    props: {
+        attempted: {
+            type: Boolean,
+            default: false
+        },
+        messages: {
+            type: Array,
+            default: () => []
+        },
+        title: {
+            type: String,
+            required: true
+        }
+    },
+    computed: {
+        shouldShow() {
+            return shouldShowTripFormValidationSummary(this.attempted, this.messages);
+        }
+    }
+};
+</script>
+
+<style scoped>
+.trip-form-validation-summary {
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+}
+
+.trip-form-validation-summary__title {
+    margin: 0 0 0.5rem;
+    font-weight: 600;
+}
+
+.trip-form-validation-summary__list {
+    margin: 0;
+    padding-left: 1.25rem;
+}
+</style>

--- a/src/components/views/NewTrip.validationFeedback.view.test.js
+++ b/src/components/views/NewTrip.validationFeedback.view.test.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const newTripViewPath = path.resolve(__dirname, 'NewTrip.vue');
+const newTripViewSource = fs.readFileSync(newTripViewPath, 'utf8');
+
+describe('NewTrip validation feedback', () => {
+    it('lists invalid trip fields and scrolls to the first visible error', () => {
+        expect(newTripViewSource).toContain('collectActiveValidationMessages');
+        expect(newTripViewSource).toContain('formatTripValidationDialogMessage');
+        expect(newTripViewSource).toContain('findFirstTripFormErrorElement');
+        expect(newTripViewSource).toContain('getTripValidationErrorFields');
+    });
+});

--- a/src/components/views/NewTrip.validationFeedback.view.test.js
+++ b/src/components/views/NewTrip.validationFeedback.view.test.js
@@ -19,4 +19,10 @@ describe('NewTrip validation feedback', () => {
             /else if \(globalError\) \{\s*dialogs\.message\(this\.\$t\('algunosDatosNoValidos'\)/
         );
     });
+
+    it('renders an in-form validation summary before submit actions', () => {
+        expect(newTripViewSource).toContain('TripFormValidationSummary');
+        expect(newTripViewSource).toContain('formValidationAttempted');
+        expect(newTripViewSource).toContain('activeFormValidationMessages');
+    });
 });

--- a/src/components/views/NewTrip.validationFeedback.view.test.js
+++ b/src/components/views/NewTrip.validationFeedback.view.test.js
@@ -24,5 +24,13 @@ describe('NewTrip validation feedback', () => {
         expect(newTripViewSource).toContain('TripFormValidationSummary');
         expect(newTripViewSource).toContain('formValidationAttempted');
         expect(newTripViewSource).toContain('activeFormValidationMessages');
+        expect(newTripViewSource).toContain('tripFormValidationSummaryBindings');
+    });
+
+    it('clears description and no-lucrar errors when those fields change', () => {
+        expect(newTripViewSource).toContain("'trip.description': function ()");
+        expect(newTripViewSource).toContain('this.commentError.state = false');
+        expect(newTripViewSource).toContain('no_lucrar()');
+        expect(newTripViewSource).toContain('this.lucrarError.state = false');
     });
 });

--- a/src/components/views/NewTrip.validationFeedback.view.test.js
+++ b/src/components/views/NewTrip.validationFeedback.view.test.js
@@ -12,4 +12,11 @@ describe('NewTrip validation feedback', () => {
         expect(newTripViewSource).toContain('findFirstTripFormErrorElement');
         expect(newTripViewSource).toContain('getTripValidationErrorFields');
     });
+
+    it('shows the validation summary after all field checks complete', () => {
+        expect(newTripViewSource).toContain('showTripValidationSummary');
+        expect(newTripViewSource).not.toMatch(
+            /else if \(globalError\) \{\s*dialogs\.message\(this\.\$t\('algunosDatosNoValidos'\)/
+        );
+    });
 });

--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -1023,6 +1023,11 @@
                                     </span>
                                 </div>
                             </div>
+                            <TripFormValidationSummary
+                                :attempted="formValidationAttempted"
+                                :messages="activeFormValidationMessages"
+                                :title="$t('algunosDatosNoValidos')"
+                            />
                             <button
                                 v-if="!showReturnTrip && !isMobile"
                                 class="trip-create btn btn-primary btn-lg"
@@ -1906,6 +1911,11 @@
                                     </div>
                                 </div>
                             </div>
+                            <TripFormValidationSummary
+                                :attempted="formValidationAttempted"
+                                :messages="activeFormValidationMessages"
+                                :title="$t('algunosDatosNoValidos')"
+                            />
                             <button
                                 v-if="showReturnTrip && !isMobile"
                                 class="trip-create btn btn-primary btn-lg"
@@ -2002,6 +2012,12 @@
                     {{ $t('cargarViajeRegreso') }}
                 </label>
             </div>
+            <TripFormValidationSummary
+                v-if="isMobile"
+                :attempted="formValidationAttempted"
+                :messages="activeFormValidationMessages"
+                :title="$t('algunosDatosNoValidos')"
+            />
             <button
                 class="trip-create btn btn-primary btn-lg trip-form-mobile-footer__submit"
                 :class="{ 'trip-create--update': updatingTrip && !showReturnTrip }"
@@ -2073,6 +2089,7 @@ import SvgItem from '../SvgItem';
 import WeeklySchedule from '../elements/WeeklySchedule';
 import CompleteCarModal from '../elements/CompleteCarModal.vue';
 import TripCarsModal from '../elements/TripCarsModal.vue';
+import TripFormValidationSummary from '../elements/TripFormValidationSummary.vue';
 import TripPointDetailFields from '../elements/TripPointDetailFields';
 import bus from '../../services/bus-event.js';
 import { tripDetailRouteAfterCreate } from '../../utils/tripCreateRedirect.js';
@@ -2141,7 +2158,8 @@ export default {
         spinner,
         modal,
         CompleteCarModal,
-        TripCarsModal
+        TripCarsModal,
+        TripFormValidationSummary
     },
     data() {
         return {
@@ -2226,6 +2244,7 @@ export default {
             puntoPartidaError: new Error(),
             puntoLlegadaError: new Error(),
             saving: false,
+            formValidationAttempted: false,
             allowForeignPoints: false,
             url: 'https://{s}.tile.osm.org/{z}/{x}/{y}.png',
             attribution:
@@ -2342,6 +2361,11 @@ export default {
         ...mapState(useDeviceStore, {
             isMobile: 'isMobile'
         }),
+        activeFormValidationMessages() {
+            return collectActiveValidationMessages(
+                this.getTripValidationErrorFields()
+            );
+        },
         columnClass() {
             return !this.isMobile && this.tripCardTheme === 'light'
                 ? ['col-sm-10', 'col-sm-14']
@@ -3311,12 +3335,13 @@ export default {
             }
             const validationResult = this.validate();
             if (validationResult) {
-                // Jump To Error
+                this.formValidationAttempted = true;
                 this.$nextTick(() => {
                     this.jumpToError();
                 });
                 return;
             }
+            this.formValidationAttempted = false;
             /* eslint-disable no-unreachable */
             this.saving = true;
             if (!this.updatingTrip) {

--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -1024,9 +1024,7 @@
                                 </div>
                             </div>
                             <TripFormValidationSummary
-                                :attempted="formValidationAttempted"
-                                :messages="activeFormValidationMessages"
-                                :title="$t('algunosDatosNoValidos')"
+                                v-bind="tripFormValidationSummaryBindings"
                             />
                             <button
                                 v-if="!showReturnTrip && !isMobile"
@@ -1912,9 +1910,7 @@
                                 </div>
                             </div>
                             <TripFormValidationSummary
-                                :attempted="formValidationAttempted"
-                                :messages="activeFormValidationMessages"
-                                :title="$t('algunosDatosNoValidos')"
+                                v-bind="tripFormValidationSummaryBindings"
                             />
                             <button
                                 v-if="showReturnTrip && !isMobile"
@@ -2014,9 +2010,7 @@
             </div>
             <TripFormValidationSummary
                 v-if="isMobile"
-                :attempted="formValidationAttempted"
-                :messages="activeFormValidationMessages"
-                :title="$t('algunosDatosNoValidos')"
+                v-bind="tripFormValidationSummaryBindings"
             />
             <button
                 class="trip-create btn btn-primary btn-lg trip-form-mobile-footer__submit"
@@ -2366,6 +2360,13 @@ export default {
                 this.getTripValidationErrorFields()
             );
         },
+        tripFormValidationSummaryBindings() {
+            return {
+                attempted: this.formValidationAttempted,
+                messages: this.activeFormValidationMessages,
+                title: this.$t('algunosDatosNoValidos')
+            };
+        },
         columnClass() {
             return !this.isMobile && this.tripCardTheme === 'light'
                 ? ['col-sm-10', 'col-sm-14']
@@ -2494,6 +2495,12 @@ export default {
         },
         'otherTrip.trip.description': function () {
             this.otherTrip.commentError.state = false;
+        },
+        'trip.description': function () {
+            this.commentError.state = false;
+        },
+        no_lucrar() {
+            this.lucrarError.state = false;
         },
         'trip.friendship_type_id': function () {
             this.otherTrip.trip.friendship_type_id =

--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -2080,6 +2080,11 @@ import {
     isProfileRequiredTripError,
     redirectToIncompleteProfileForTripCreate
 } from '../../utils/tripCreateErrors.js';
+import {
+    collectActiveValidationMessages,
+    findFirstTripFormErrorElement,
+    formatTripValidationDialogMessage
+} from '../../utils/tripFormValidationFeedback.js';
 import { getMaxContributionExceededMessage } from '../../utils/maxContributionExceededMessage.js';
 import { rememberMaxContributionWarning } from '../../utils/maxContributionWarningState.js';
 import {
@@ -2637,11 +2642,59 @@ export default {
             this.dateAnswer = date;
         },
         jumpToError() {
-            let hasError = document.getElementsByClassName('has-error');
-            if (hasError.length) {
-                let element = hasError[0];
+            const element = findFirstTripFormErrorElement(document);
+            if (element) {
                 this.$scrollToElement(element);
             }
+        },
+        getTripValidationErrorFields() {
+            const fields = [
+                ...this.points.map((point) => point.error),
+                this.puntoPartidaError,
+                this.puntoLlegadaError,
+                this.timeError,
+                this.dateError,
+                this.seatsError,
+                this.priceError,
+                this.lucrarError,
+                this.commentError,
+                this.carSelectionError
+            ];
+
+            if (this.showReturnTrip) {
+                fields.push(
+                    ...this.otherTrip.points.map((point) => point.error),
+                    this.otherTrip.puntoPartidaError,
+                    this.otherTrip.puntoLlegadaError,
+                    this.otherTrip.timeError,
+                    this.otherTrip.dateError,
+                    this.otherTrip.seatsError,
+                    this.otherTrip.commentError,
+                    this.returnPriceError
+                );
+            }
+
+            return fields;
+        },
+        showTripValidationSummary() {
+            const messages = collectActiveValidationMessages(
+                this.getTripValidationErrorFields()
+            );
+
+            if (!messages.length) {
+                return;
+            }
+
+            dialogs.message(
+                formatTripValidationDialogMessage(
+                    this.$t('algunosDatosNoValidos'),
+                    messages
+                ),
+                {
+                    estado: 'error',
+                    duration: 12
+                }
+            );
         },
     restoreData(trip) {
         this.no_lucrar = true;
@@ -2926,10 +2979,6 @@ export default {
                         estado: 'error'
                     }
                 );
-            } else if (globalError) {
-                dialogs.message(this.$t('algunosDatosNoValidos'), {
-                    estado: 'error'
-                });
             } else if (
                 !this.no_lucrar &&
                 this.trip.is_passenger.toString() !== '1'
@@ -3170,6 +3219,10 @@ export default {
 
             if (!this.showReturnTrip) {
                 this.returnPriceError.state = false;
+            }
+
+            if (globalError) {
+                this.showTripValidationSummary();
             }
 
             return globalError;

--- a/src/utils/tripFormValidationFeedback.js
+++ b/src/utils/tripFormValidationFeedback.js
@@ -29,6 +29,10 @@ export function collectActiveValidationMessages(errorFields) {
     return messages;
 }
 
+export function shouldShowTripFormValidationSummary(attempted, messages) {
+    return attempted === true && Array.isArray(messages) && messages.length > 0;
+}
+
 export function formatTripValidationDialogMessage(fallback, messages) {
     const unique = [...new Set(
         (messages || [])

--- a/src/utils/tripFormValidationFeedback.js
+++ b/src/utils/tripFormValidationFeedback.js
@@ -1,0 +1,57 @@
+export const TRIP_FORM_ERROR_SELECTORS = [
+    '.trip-error',
+    '.has-error',
+    'span.error'
+];
+
+export function collectActiveValidationMessages(errorFields) {
+    const messages = [];
+    const seen = new Set();
+
+    if (!Array.isArray(errorFields)) {
+        return messages;
+    }
+
+    errorFields.forEach((field) => {
+        if (!field || !field.state) {
+            return;
+        }
+
+        const message = String(field.message || '').trim();
+        if (!message || seen.has(message)) {
+            return;
+        }
+
+        seen.add(message);
+        messages.push(message);
+    });
+
+    return messages;
+}
+
+export function formatTripValidationDialogMessage(fallback, messages) {
+    const unique = [...new Set(
+        (messages || [])
+            .map((message) => String(message).trim())
+            .filter(Boolean)
+    )];
+
+    if (!unique.length) {
+        return fallback;
+    }
+
+    return `${fallback}\n${unique.map((message) => `• ${message}`).join('\n')}`;
+}
+
+export function findFirstTripFormErrorElement(root = document) {
+    for (let i = 0; i < TRIP_FORM_ERROR_SELECTORS.length; i += 1) {
+        const selector = TRIP_FORM_ERROR_SELECTORS[i];
+        const nodes = root.querySelectorAll(selector);
+
+        if (nodes && nodes.length > 0) {
+            return nodes[0];
+        }
+    }
+
+    return null;
+}

--- a/src/utils/tripFormValidationFeedback.test.js
+++ b/src/utils/tripFormValidationFeedback.test.js
@@ -35,6 +35,14 @@ describe('tripFormValidationFeedback', () => {
         ).toBe('Algunos datos ingresados no son válidos.');
     });
 
+    it('lists a single active validation message explicitly', () => {
+        expect(
+            formatTripValidationDialogMessage('Algunos datos ingresados no son válidos.', [
+                'Falta fecha'
+            ])
+        ).toBe('Algunos datos ingresados no son válidos.\n• Falta fecha');
+    });
+
     it('prioritizes trip-error markers when scrolling to the first invalid field', () => {
         const root = {
             querySelectorAll(selector) {

--- a/src/utils/tripFormValidationFeedback.test.js
+++ b/src/utils/tripFormValidationFeedback.test.js
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+    TRIP_FORM_ERROR_SELECTORS,
+    collectActiveValidationMessages,
+    findFirstTripFormErrorElement,
+    formatTripValidationDialogMessage
+} from './tripFormValidationFeedback.js';
+
+describe('tripFormValidationFeedback', () => {
+    it('collects unique active validation messages from field errors', () => {
+        const messages = collectActiveValidationMessages([
+            { state: true, message: 'Falta fecha' },
+            { state: false, message: 'Ignorado' },
+            { state: true, message: 'Falta fecha' },
+            { state: true, message: 'Horario no válido' }
+        ]);
+
+        expect(messages).toEqual(['Falta fecha', 'Horario no válido']);
+    });
+
+    it('lists active validation messages in the generic trip dialog copy', () => {
+        expect(
+            formatTripValidationDialogMessage('Algunos datos ingresados no son válidos.', [
+                'Falta fecha',
+                'Horario no válido'
+            ])
+        ).toBe(
+            'Algunos datos ingresados no son válidos.\n• Falta fecha\n• Horario no válido'
+        );
+    });
+
+    it('falls back to the generic message when no field errors are active', () => {
+        expect(
+            formatTripValidationDialogMessage('Algunos datos ingresados no son válidos.', [])
+        ).toBe('Algunos datos ingresados no son válidos.');
+    });
+
+    it('prioritizes trip-error markers when scrolling to the first invalid field', () => {
+        const root = {
+            querySelectorAll(selector) {
+                if (selector === '.trip-error') {
+                    return [{ textContent: 'Origen inválido' }];
+                }
+                if (selector === '.has-error') {
+                    return [{ textContent: 'Fecha' }];
+                }
+                return [];
+            }
+        };
+
+        expect(findFirstTripFormErrorElement(root)).toEqual({
+            textContent: 'Origen inválido'
+        });
+        expect(TRIP_FORM_ERROR_SELECTORS[0]).toBe('.trip-error');
+    });
+});

--- a/src/utils/tripFormValidationFeedback.test.js
+++ b/src/utils/tripFormValidationFeedback.test.js
@@ -3,7 +3,8 @@ import {
     TRIP_FORM_ERROR_SELECTORS,
     collectActiveValidationMessages,
     findFirstTripFormErrorElement,
-    formatTripValidationDialogMessage
+    formatTripValidationDialogMessage,
+    shouldShowTripFormValidationSummary
 } from './tripFormValidationFeedback.js';
 
 describe('tripFormValidationFeedback', () => {
@@ -41,6 +42,12 @@ describe('tripFormValidationFeedback', () => {
                 'Falta fecha'
             ])
         ).toBe('Algunos datos ingresados no son válidos.\n• Falta fecha');
+    });
+
+    it('shows the in-form summary only after a failed submit with active errors', () => {
+        expect(shouldShowTripFormValidationSummary(true, ['Falta fecha'])).toBe(true);
+        expect(shouldShowTripFormValidationSummary(false, ['Falta fecha'])).toBe(false);
+        expect(shouldShowTripFormValidationSummary(true, [])).toBe(false);
     });
 
     it('prioritizes trip-error markers when scrolling to the first invalid field', () => {


### PR DESCRIPTION
## Summary

Improves trip creation validation feedback so users can see **which fields are wrong** and where to fix them.

### Cause

When `NewTrip` validation failed, the app only showed a generic toast (*"Algunos datos ingresados no son válidos"*) without naming the fields. Problems stacked on top of each other:

- The toast could fire **mid-validation**, before later checks (price, return trip, etc.) ran.
- `jumpToError()` only looked for `.has-error`, so location errors marked with `.trip-error` were often skipped.
- There was **no persistent summary in the form**, so on mobile especially it was unclear what still needed fixing after the toast disappeared.

### Fix (frontend)

- **`tripFormValidationFeedback.js`**
  - Collects active field error messages.
  - Formats the toast as a bulleted list under `algunosDatosNoValidos`.
  - Scrolls to the first invalid element (`.trip-error` → `.has-error` → `span.error`).
  - Defers the summary toast until **all** validation checks finish.

- **`TripFormValidationSummary.vue`**
  - In-form error panel at the end of the form (before submit).
  - White background, 2px red border, bright red title, dark bulleted list.
  - Shown after a failed submit while errors remain; each item disappears when that field’s error is cleared.
  - Right margin so the panel does not sit flush with the form edge.

- **`NewTrip.vue`**
  - Wires toast + scroll + in-form summary.
  - `formValidationAttempted` / `activeFormValidationMessages` drive the panel.
  - Clears description and no-lucrar errors when those fields are edited.

Example feedback:

**Toast / title:** Algunos datos ingresados no son válidos.  
**List:**
- Seleccione una localidad válida.
- Aún no ha ingresado ninguna fecha.
- Tenés que completar la contribución por persona.

## Test plan

- [ ] Submit trip with multiple invalid fields → toast lists each error; in-form summary shows the same items
- [ ] Page scrolls to the first invalid field (including origin/destination)
- [ ] Fix one field → that item disappears from the in-form summary
- [ ] Fix all fields → summary hides; valid submit works
- [ ] Return trip with errors → return-leg messages appear in summary
- [ ] Mobile: summary appears above footer “Crear” button with correct spacing
- [ ] `npm run test:unit -- --run src/utils/tripFormValidationFeedback.test.js src/components/elements/TripFormValidationSummary.view.test.js src/components/views/NewTrip.validationFeedback.view.test.js`