### PR TITLE
Denuncielo ticket

### DIFF
--- a/src/components/elements/CoordinateTrip.view.test.js
+++ b/src/components/elements/CoordinateTrip.view.test.js
@@ -30,11 +30,14 @@ describe('CoordinateTrip.vue', () => {
         );
     });
 
-    it('links passenger report action to soporte', () => {
+    it('links passenger report action to a prefilled denuncia ticket', () => {
         expect(viewSource).toContain("$t('coordinateTripContributionWarningPassengerPrefix'");
         expect(viewSource).toContain("$t('coordinateTripContributionWarningPassengerSuffix')");
+        expect(viewSource).toContain("from '../../utils/supportTicketTripReport.js'");
+        expect(viewSource).toContain('buildTripReportSupportTicketRoute');
+        expect(viewSource).toContain('reportSupportTicketRoute');
         expect(viewSource).toMatch(
-            /<router-link\s+:to="\{\s*path:\s*'\/soporte'\s*\}">\s*\{\{\s*\$t\('coordinateTripContributionWarningPassengerReportLink'\)\s*\}\}\s*<\/router-link>/
+            /<router-link\s+:to="reportSupportTicketRoute">\s*\{\{\s*\$t\('coordinateTripContributionWarningPassengerReportLink'\)\s*\}\}\s*<\/router-link>/
         );
     });
 });

--- a/src/components/elements/CoordinateTrip.vue
+++ b/src/components/elements/CoordinateTrip.vue
@@ -58,7 +58,7 @@
                         amountPart: contributionWarningAmountPart
                     })
                 }}
-                <router-link :to="{ path: '/soporte' }">
+                <router-link :to="reportSupportTicketRoute">
                     {{ $t('coordinateTripContributionWarningPassengerReportLink') }}
                 </router-link>
                 {{ $t('coordinateTripContributionWarningPassengerSuffix') }}
@@ -194,6 +194,10 @@ import dayjs from '../../dayjs';
 import { getConversationContributionWarningData } from '../../utils/conversationContributionWarning.js';
 import { getContributionWarningAmountPart } from '../../utils/contributionWarningAmountPart.js';
 import { isVoluntaryContributionSeatPrice } from '../../utils/tripSeatPrice.js';
+import {
+    buildTripReportSupportTicketRoute,
+    resolveWebAppBaseUrl
+} from '../../utils/supportTicketTripReport.js';
 
 export default {
     name: 'conversation-chat',
@@ -268,6 +272,15 @@ export default {
                 this.$n.bind(this),
                 data.maxContributionCents
             );
+        },
+        reportSupportTicketRoute() {
+            if (!this.conversation || !this.conversation.trip) {
+                return { name: 'ticket-new', query: { category: 'report' } };
+            }
+            return buildTripReportSupportTicketRoute({
+                trip: this.conversation.trip,
+                webAppBaseUrl: resolveWebAppBaseUrl()
+            });
         }
     },
     methods: {

--- a/src/components/views/TicketNew.view.test.js
+++ b/src/components/views/TicketNew.view.test.js
@@ -30,16 +30,12 @@ describe('TicketNew view', () => {
         expect(source).toContain("this.$t('mensajeTicketPlaceholder')");
     });
 
-    it('prefills ticket message from route query via editor initial value', () => {
+    it('applies trip block prefill when the editor loads', () => {
         expect(source).toContain('prefillMessage');
         expect(source).toContain('this.$route.query.message');
-        expect(source).toMatch(/:initial-value="prefillMessage"/);
-    });
-
-    it('moves cursor to the start after a prefilled message loads', () => {
-        expect(source).toContain('@load="onCreateEditorLoad"');
-        expect(source).toContain('focusPrefilledEditorAtStart');
-        expect(source).toContain("invoke('moveCursorToStart', true)");
-        expect(source).not.toContain("'setMarkdown'");
+        expect(source).toContain("from '../../utils/ticketMessagePrefill.js'");
+        expect(source).toContain('applyPrefilledTripBlock');
+        expect(source).toContain('applyTripBlockPrefillToEditor');
+        expect(source).toContain('load: () => this.applyPrefilledTripBlock()');
     });
 });

--- a/src/components/views/TicketNew.view.test.js
+++ b/src/components/views/TicketNew.view.test.js
@@ -29,4 +29,10 @@ describe('TicketNew view', () => {
         expect(source).toContain('editorOptionsWithPlaceholder');
         expect(source).toContain("this.$t('mensajeTicketPlaceholder')");
     });
+
+    it('prefills ticket message from route query on mount', () => {
+        expect(source).toContain('applyPrefillFromQuery');
+        expect(source).toContain('this.$route.query.message');
+        expect(source).toContain("invoke('setMarkdown'");
+    });
 });

--- a/src/components/views/TicketNew.view.test.js
+++ b/src/components/views/TicketNew.view.test.js
@@ -33,6 +33,7 @@ describe('TicketNew view', () => {
     it('prefills ticket message from route query on mount', () => {
         expect(source).toContain('applyPrefillFromQuery');
         expect(source).toContain('this.$route.query.message');
+        expect(source).toContain('this.$nextTick');
         expect(source).toContain("invoke('setMarkdown'");
     });
 });

--- a/src/components/views/TicketNew.view.test.js
+++ b/src/components/views/TicketNew.view.test.js
@@ -30,12 +30,12 @@ describe('TicketNew view', () => {
         expect(source).toContain("this.$t('mensajeTicketPlaceholder')");
     });
 
-    it('applies trip block prefill when the editor loads', () => {
+    it('renders trip block via initial value and prepares cursor on load', () => {
         expect(source).toContain('prefillMessage');
         expect(source).toContain('this.$route.query.message');
-        expect(source).toContain("from '../../utils/ticketMessagePrefill.js'");
-        expect(source).toContain('applyPrefilledTripBlock');
-        expect(source).toContain('applyTripBlockPrefillToEditor');
-        expect(source).toContain('load: () => this.applyPrefilledTripBlock()');
+        expect(source).toMatch(/:initial-value="prefillMessage"/);
+        expect(source).toContain('@load="onCreateEditorLoad"');
+        expect(source).toContain('preparePrefilledTicketEditorCursor');
+        expect(source).toContain('preparePrefilledEditorCursor');
     });
 });

--- a/src/components/views/TicketNew.view.test.js
+++ b/src/components/views/TicketNew.view.test.js
@@ -32,10 +32,12 @@ describe('TicketNew view', () => {
 
     it('renders trip block via initial value and prepares cursor on load', () => {
         expect(source).toContain('prefillMessage');
-        expect(source).toContain('this.$route.query.message');
-        expect(source).toMatch(/:initial-value="prefillMessage"/);
+        expect(source).toContain('editorInitialValue');
+        expect(source).toContain('buildPrefilledTicketEditorMarkdown');
+        expect(source).toMatch(/:initial-value="editorInitialValue"/);
+        expect(source).toContain(':key="createEditorKey"');
+        expect(source).toContain('mountCreateEditor');
         expect(source).toContain('@load="onCreateEditorLoad"');
-        expect(source).toContain('prependBlankLinesToPrefilledTicketEditor');
-        expect(source).toContain('prependPrefilledEditorBlankLines');
+        expect(source).toContain('focusPrefilledTicketEditorAtStart');
     });
 });

--- a/src/components/views/TicketNew.view.test.js
+++ b/src/components/views/TicketNew.view.test.js
@@ -30,17 +30,16 @@ describe('TicketNew view', () => {
         expect(source).toContain("this.$t('mensajeTicketPlaceholder')");
     });
 
-    it('prefills ticket message from route query when the editor loads', () => {
+    it('prefills ticket message from route query via editor initial value', () => {
         expect(source).toContain('prefillMessage');
         expect(source).toContain('this.$route.query.message');
-        expect(source).toContain("'setMarkdown'");
-        expect(source).toContain('false');
+        expect(source).toMatch(/:initial-value="prefillMessage"/);
     });
 
     it('moves cursor to the start after a prefilled message loads', () => {
         expect(source).toContain('@load="onCreateEditorLoad"');
-        expect(source).toContain('onCreateEditorLoad');
+        expect(source).toContain('focusPrefilledEditorAtStart');
         expect(source).toContain("invoke('moveCursorToStart', true)");
-        expect(source).toContain('setTimeout');
+        expect(source).not.toContain("'setMarkdown'");
     });
 });

--- a/src/components/views/TicketNew.view.test.js
+++ b/src/components/views/TicketNew.view.test.js
@@ -30,10 +30,9 @@ describe('TicketNew view', () => {
         expect(source).toContain("this.$t('mensajeTicketPlaceholder')");
     });
 
-    it('prefills ticket message from route query on mount', () => {
-        expect(source).toContain('applyPrefillFromQuery');
+    it('prefills ticket message from route query via editor initial value', () => {
+        expect(source).toContain('prefillMessage');
         expect(source).toContain('this.$route.query.message');
-        expect(source).toContain('this.$nextTick');
-        expect(source).toContain("invoke('setMarkdown'");
+        expect(source).toMatch(/:initial-value="prefillMessage"/);
     });
 });

--- a/src/components/views/TicketNew.view.test.js
+++ b/src/components/views/TicketNew.view.test.js
@@ -35,4 +35,11 @@ describe('TicketNew view', () => {
         expect(source).toContain('this.$route.query.message');
         expect(source).toMatch(/:initial-value="prefillMessage"/);
     });
+
+    it('moves cursor to the start after a prefilled message loads', () => {
+        expect(source).toContain('@load="onCreateEditorLoad"');
+        expect(source).toContain('onCreateEditorLoad');
+        expect(source).toContain("invoke('moveCursorToStart', true)");
+        expect(source).toContain('setTimeout');
+    });
 });

--- a/src/components/views/TicketNew.view.test.js
+++ b/src/components/views/TicketNew.view.test.js
@@ -30,10 +30,11 @@ describe('TicketNew view', () => {
         expect(source).toContain("this.$t('mensajeTicketPlaceholder')");
     });
 
-    it('prefills ticket message from route query via editor initial value', () => {
+    it('prefills ticket message from route query when the editor loads', () => {
         expect(source).toContain('prefillMessage');
         expect(source).toContain('this.$route.query.message');
-        expect(source).toMatch(/:initial-value="prefillMessage"/);
+        expect(source).toContain("'setMarkdown'");
+        expect(source).toContain('false');
     });
 
     it('moves cursor to the start after a prefilled message loads', () => {

--- a/src/components/views/TicketNew.view.test.js
+++ b/src/components/views/TicketNew.view.test.js
@@ -35,7 +35,7 @@ describe('TicketNew view', () => {
         expect(source).toContain('this.$route.query.message');
         expect(source).toMatch(/:initial-value="prefillMessage"/);
         expect(source).toContain('@load="onCreateEditorLoad"');
-        expect(source).toContain('preparePrefilledTicketEditorCursor');
-        expect(source).toContain('preparePrefilledEditorCursor');
+        expect(source).toContain('prependBlankLinesToPrefilledTicketEditor');
+        expect(source).toContain('prependPrefilledEditorBlankLines');
     });
 });

--- a/src/components/views/TicketNew.vue
+++ b/src/components/views/TicketNew.vue
@@ -21,8 +21,10 @@
                 <input v-model="form.subject" class="form-control" :placeholder="$t('asuntoTicketPlaceholder')" />
                 <label class="control-label mtop-10">{{ $t('mensajeTicket') }}</label>
                 <editor
+                    v-if="showCreateEditor"
+                    :key="createEditorKey"
                     ref="createEditor"
-                    :initial-value="prefillMessage"
+                    :initial-value="editorInitialValue"
                     :options="editorOptionsWithPlaceholder"
                     initial-edit-type="wysiwyg"
                     height="180px"
@@ -59,7 +61,10 @@ import {
     fetchSupportInfoSnapshot,
     isEmptyUserTicketMessage
 } from '../../utils/supportInfo';
-import { prependBlankLinesToPrefilledTicketEditor } from '../../utils/ticketMessagePrefill.js';
+import {
+    buildPrefilledTicketEditorMarkdown,
+    focusPrefilledTicketEditorAtStart
+} from '../../utils/ticketMessagePrefill.js';
 
 export default {
     name: 'ticket-new',
@@ -72,6 +77,8 @@ export default {
             attachments: [],
             imageUploadAccept: IMAGE_UPLOAD_ACCEPT,
             ticketTypeOptions: USER_TICKET_TYPE_OPTIONS,
+            showCreateEditor: false,
+            createEditorKey: 0,
             editorOptions: {
                 usageStatistics: false,
                 hideModeSwitch: true,
@@ -83,6 +90,9 @@ export default {
         prefillMessage() {
             const message = this.$route.query.message;
             return message ? String(message) : '';
+        },
+        editorInitialValue() {
+            return buildPrefilledTicketEditorMarkdown(this.prefillMessage);
         },
         editorOptionsWithPlaceholder() {
             return {
@@ -144,28 +154,23 @@ export default {
             }
         },
         onCreateEditorLoad() {
-            this.prependPrefilledEditorBlankLines();
-        },
-        prependPrefilledEditorBlankLines() {
             if (!this.prefillMessage) {
                 return;
             }
-            const run = (attempt = 0) => {
-                const applied = prependBlankLinesToPrefilledTicketEditor(
-                    this.$refs.createEditor
-                );
-                if (!applied && attempt < 5) {
-                    setTimeout(() => run(attempt + 1), 100);
-                }
-            };
             this.$nextTick(() => {
-                setTimeout(() => run(), 100);
+                setTimeout(() => {
+                    focusPrefilledTicketEditorAtStart(this.$refs.createEditor);
+                }, 50);
             });
+        },
+        mountCreateEditor() {
+            this.showCreateEditor = true;
+            this.createEditorKey += 1;
         }
     },
     mounted() {
         this.setTypeFromUrl();
-        this.prependPrefilledEditorBlankLines();
+        this.mountCreateEditor();
     },
     watch: {
         '$route.query.category': function () {

--- a/src/components/views/TicketNew.vue
+++ b/src/components/views/TicketNew.vue
@@ -22,7 +22,7 @@
                 <label class="control-label mtop-10">{{ $t('mensajeTicket') }}</label>
                 <editor
                     ref="createEditor"
-                    :initial-value="prefillMessage"
+                    :initial-value="''"
                     :options="editorOptionsWithPlaceholder"
                     initial-edit-type="wysiwyg"
                     height="180px"
@@ -150,6 +150,11 @@ export default {
                 if (!this.$refs.createEditor) {
                     return;
                 }
+                this.$refs.createEditor.invoke(
+                    'setMarkdown',
+                    this.prefillMessage,
+                    false
+                );
                 this.$refs.createEditor.invoke('moveCursorToStart', true);
             }, 50);
         }

--- a/src/components/views/TicketNew.vue
+++ b/src/components/views/TicketNew.vue
@@ -22,11 +22,12 @@
                 <label class="control-label mtop-10">{{ $t('mensajeTicket') }}</label>
                 <editor
                     ref="createEditor"
-                    :initial-value="''"
+                    :initial-value="prefillMessage"
                     :options="editorOptionsWithPlaceholder"
                     initial-edit-type="wysiwyg"
                     height="180px"
                     class="mtop-10"
+                    @load="onCreateEditorLoad"
                 />
                 <label class="control-label mtop-10">{{ $t('adjuntosTicket') }}</label>
                 <input class="mtop-10" type="file" :accept="imageUploadAccept" multiple @change="onCreateAttachments" />
@@ -58,7 +59,7 @@ import {
     fetchSupportInfoSnapshot,
     isEmptyUserTicketMessage
 } from '../../utils/supportInfo';
-import { applyTripBlockPrefillToEditor } from '../../utils/ticketMessagePrefill.js';
+import { preparePrefilledTicketEditorCursor } from '../../utils/ticketMessagePrefill.js';
 
 export default {
     name: 'ticket-new',
@@ -84,16 +85,10 @@ export default {
             return message ? String(message) : '';
         },
         editorOptionsWithPlaceholder() {
-            const options = {
+            return {
                 ...this.editorOptions,
                 placeholder: this.$t('mensajeTicketPlaceholder')
             };
-            if (this.prefillMessage) {
-                options.events = {
-                    load: () => this.applyPrefilledTripBlock()
-                };
-            }
-            return options;
         }
     },
     methods: {
@@ -148,22 +143,23 @@ export default {
                 this.form.type = category;
             }
         },
-        applyPrefilledTripBlock() {
+        onCreateEditorLoad() {
+            this.preparePrefilledEditorCursor();
+        },
+        preparePrefilledEditorCursor() {
             if (!this.prefillMessage) {
                 return;
             }
             this.$nextTick(() => {
                 setTimeout(() => {
-                    applyTripBlockPrefillToEditor(
-                        this.$refs.createEditor,
-                        this.prefillMessage
-                    );
+                    preparePrefilledTicketEditorCursor(this.$refs.createEditor);
                 }, 100);
             });
         }
     },
     mounted() {
         this.setTypeFromUrl();
+        this.preparePrefilledEditorCursor();
     },
     watch: {
         '$route.query.category': function () {

--- a/src/components/views/TicketNew.vue
+++ b/src/components/views/TicketNew.vue
@@ -140,10 +140,15 @@ export default {
         applyPrefillFromQuery() {
             this.setTypeFromUrl();
             const message = this.$route.query.message;
-            if (!message || !this.$refs.createEditor) {
+            if (!message) {
                 return;
             }
-            this.$refs.createEditor.invoke('setMarkdown', String(message));
+            this.$nextTick(() => {
+                if (!this.$refs.createEditor) {
+                    return;
+                }
+                this.$refs.createEditor.invoke('setMarkdown', String(message));
+            });
         }
     },
     mounted() {

--- a/src/components/views/TicketNew.vue
+++ b/src/components/views/TicketNew.vue
@@ -22,7 +22,7 @@
                 <label class="control-label mtop-10">{{ $t('mensajeTicket') }}</label>
                 <editor
                     ref="createEditor"
-                    :initial-value="''"
+                    :initial-value="prefillMessage"
                     :options="editorOptionsWithPlaceholder"
                     initial-edit-type="wysiwyg"
                     height="180px"
@@ -78,6 +78,10 @@ export default {
         };
     },
     computed: {
+        prefillMessage() {
+            const message = this.$route.query.message;
+            return message ? String(message) : '';
+        },
         editorOptionsWithPlaceholder() {
             return {
                 ...this.editorOptions,
@@ -136,30 +140,14 @@ export default {
             if (allowed.includes(category)) {
                 this.form.type = category;
             }
-        },
-        applyPrefillFromQuery() {
-            this.setTypeFromUrl();
-            const message = this.$route.query.message;
-            if (!message) {
-                return;
-            }
-            this.$nextTick(() => {
-                if (!this.$refs.createEditor) {
-                    return;
-                }
-                this.$refs.createEditor.invoke('setMarkdown', String(message));
-            });
         }
     },
     mounted() {
-        this.applyPrefillFromQuery();
+        this.setTypeFromUrl();
     },
     watch: {
         '$route.query.category': function () {
             this.setTypeFromUrl();
-        },
-        '$route.query.message': function () {
-            this.applyPrefillFromQuery();
         }
     },
     components: {

--- a/src/components/views/TicketNew.vue
+++ b/src/components/views/TicketNew.vue
@@ -22,7 +22,7 @@
                 <label class="control-label mtop-10">{{ $t('mensajeTicket') }}</label>
                 <editor
                     ref="createEditor"
-                    :initial-value="''"
+                    :initial-value="prefillMessage"
                     :options="editorOptionsWithPlaceholder"
                     initial-edit-type="wysiwyg"
                     height="180px"
@@ -143,24 +143,25 @@ export default {
             }
         },
         onCreateEditorLoad() {
+            this.focusPrefilledEditorAtStart();
+        },
+        focusPrefilledEditorAtStart() {
             if (!this.prefillMessage) {
                 return;
             }
-            setTimeout(() => {
-                if (!this.$refs.createEditor) {
-                    return;
-                }
-                this.$refs.createEditor.invoke(
-                    'setMarkdown',
-                    this.prefillMessage,
-                    false
-                );
-                this.$refs.createEditor.invoke('moveCursorToStart', true);
-            }, 50);
+            this.$nextTick(() => {
+                setTimeout(() => {
+                    if (!this.$refs.createEditor) {
+                        return;
+                    }
+                    this.$refs.createEditor.invoke('moveCursorToStart', true);
+                }, 50);
+            });
         }
     },
     mounted() {
         this.setTypeFromUrl();
+        this.focusPrefilledEditorAtStart();
     },
     watch: {
         '$route.query.category': function () {

--- a/src/components/views/TicketNew.vue
+++ b/src/components/views/TicketNew.vue
@@ -22,12 +22,11 @@
                 <label class="control-label mtop-10">{{ $t('mensajeTicket') }}</label>
                 <editor
                     ref="createEditor"
-                    :initial-value="prefillMessage"
+                    :initial-value="''"
                     :options="editorOptionsWithPlaceholder"
                     initial-edit-type="wysiwyg"
                     height="180px"
                     class="mtop-10"
-                    @load="onCreateEditorLoad"
                 />
                 <label class="control-label mtop-10">{{ $t('adjuntosTicket') }}</label>
                 <input class="mtop-10" type="file" :accept="imageUploadAccept" multiple @change="onCreateAttachments" />
@@ -59,6 +58,7 @@ import {
     fetchSupportInfoSnapshot,
     isEmptyUserTicketMessage
 } from '../../utils/supportInfo';
+import { applyTripBlockPrefillToEditor } from '../../utils/ticketMessagePrefill.js';
 
 export default {
     name: 'ticket-new',
@@ -84,10 +84,16 @@ export default {
             return message ? String(message) : '';
         },
         editorOptionsWithPlaceholder() {
-            return {
+            const options = {
                 ...this.editorOptions,
                 placeholder: this.$t('mensajeTicketPlaceholder')
             };
+            if (this.prefillMessage) {
+                options.events = {
+                    load: () => this.applyPrefilledTripBlock()
+                };
+            }
+            return options;
         }
     },
     methods: {
@@ -142,26 +148,22 @@ export default {
                 this.form.type = category;
             }
         },
-        onCreateEditorLoad() {
-            this.focusPrefilledEditorAtStart();
-        },
-        focusPrefilledEditorAtStart() {
+        applyPrefilledTripBlock() {
             if (!this.prefillMessage) {
                 return;
             }
             this.$nextTick(() => {
                 setTimeout(() => {
-                    if (!this.$refs.createEditor) {
-                        return;
-                    }
-                    this.$refs.createEditor.invoke('moveCursorToStart', true);
+                    applyTripBlockPrefillToEditor(
+                        this.$refs.createEditor,
+                        this.prefillMessage
+                    );
                 }, 100);
             });
         }
     },
     mounted() {
         this.setTypeFromUrl();
-        this.focusPrefilledEditorAtStart();
     },
     watch: {
         '$route.query.category': function () {

--- a/src/components/views/TicketNew.vue
+++ b/src/components/views/TicketNew.vue
@@ -27,6 +27,7 @@
                     initial-edit-type="wysiwyg"
                     height="180px"
                     class="mtop-10"
+                    @load="onCreateEditorLoad"
                 />
                 <label class="control-label mtop-10">{{ $t('adjuntosTicket') }}</label>
                 <input class="mtop-10" type="file" :accept="imageUploadAccept" multiple @change="onCreateAttachments" />
@@ -140,6 +141,17 @@ export default {
             if (allowed.includes(category)) {
                 this.form.type = category;
             }
+        },
+        onCreateEditorLoad() {
+            if (!this.prefillMessage) {
+                return;
+            }
+            setTimeout(() => {
+                if (!this.$refs.createEditor) {
+                    return;
+                }
+                this.$refs.createEditor.invoke('moveCursorToStart', true);
+            }, 50);
         }
     },
     mounted() {

--- a/src/components/views/TicketNew.vue
+++ b/src/components/views/TicketNew.vue
@@ -136,14 +136,25 @@ export default {
             if (allowed.includes(category)) {
                 this.form.type = category;
             }
+        },
+        applyPrefillFromQuery() {
+            this.setTypeFromUrl();
+            const message = this.$route.query.message;
+            if (!message || !this.$refs.createEditor) {
+                return;
+            }
+            this.$refs.createEditor.invoke('setMarkdown', String(message));
         }
     },
     mounted() {
-        this.setTypeFromUrl();
+        this.applyPrefillFromQuery();
     },
     watch: {
         '$route.query.category': function () {
             this.setTypeFromUrl();
+        },
+        '$route.query.message': function () {
+            this.applyPrefillFromQuery();
         }
     },
     components: {

--- a/src/components/views/TicketNew.vue
+++ b/src/components/views/TicketNew.vue
@@ -59,7 +59,7 @@ import {
     fetchSupportInfoSnapshot,
     isEmptyUserTicketMessage
 } from '../../utils/supportInfo';
-import { preparePrefilledTicketEditorCursor } from '../../utils/ticketMessagePrefill.js';
+import { prependBlankLinesToPrefilledTicketEditor } from '../../utils/ticketMessagePrefill.js';
 
 export default {
     name: 'ticket-new',
@@ -144,22 +144,28 @@ export default {
             }
         },
         onCreateEditorLoad() {
-            this.preparePrefilledEditorCursor();
+            this.prependPrefilledEditorBlankLines();
         },
-        preparePrefilledEditorCursor() {
+        prependPrefilledEditorBlankLines() {
             if (!this.prefillMessage) {
                 return;
             }
+            const run = (attempt = 0) => {
+                const applied = prependBlankLinesToPrefilledTicketEditor(
+                    this.$refs.createEditor
+                );
+                if (!applied && attempt < 5) {
+                    setTimeout(() => run(attempt + 1), 100);
+                }
+            };
             this.$nextTick(() => {
-                setTimeout(() => {
-                    preparePrefilledTicketEditorCursor(this.$refs.createEditor);
-                }, 100);
+                setTimeout(() => run(), 100);
             });
         }
     },
     mounted() {
         this.setTypeFromUrl();
-        this.preparePrefilledEditorCursor();
+        this.prependPrefilledEditorBlankLines();
     },
     watch: {
         '$route.query.category': function () {

--- a/src/components/views/TicketNew.vue
+++ b/src/components/views/TicketNew.vue
@@ -155,7 +155,7 @@ export default {
                         return;
                     }
                     this.$refs.createEditor.invoke('moveCursorToStart', true);
-                }, 50);
+                }, 100);
             });
         }
     },

--- a/src/utils/supportTicketTripReport.js
+++ b/src/utils/supportTicketTripReport.js
@@ -2,7 +2,7 @@ function normalizeWebAppBaseUrl(webAppBaseUrl) {
     return String(webAppBaseUrl || '').replace(/\/$/, '');
 }
 
-const TRIP_REPORT_MESSAGE_SEPARATOR = '********';
+const TRIP_REPORT_MESSAGE_SEPARATOR = '====';
 
 function buildTripReportSupportTicketContext({
     tripId,
@@ -42,7 +42,7 @@ export function buildTripReportSupportTicketMessage({
         driverProfileUrl
     });
 
-    return `\n\n${TRIP_REPORT_MESSAGE_SEPARATOR}\n\n${context}`;
+    return `\n${TRIP_REPORT_MESSAGE_SEPARATOR}\n\n${context}`;
 }
 
 export function buildTripReportSupportTicketRoute({ trip, webAppBaseUrl }) {

--- a/src/utils/supportTicketTripReport.js
+++ b/src/utils/supportTicketTripReport.js
@@ -42,7 +42,7 @@ export function buildTripReportSupportTicketMessage({
         driverProfileUrl
     });
 
-    return `\n${TRIP_REPORT_MESSAGE_SEPARATOR}\n\n${context}`;
+    return `${TRIP_REPORT_MESSAGE_SEPARATOR}\n\n${context}`;
 }
 
 export function buildTripReportSupportTicketRoute({ trip, webAppBaseUrl }) {

--- a/src/utils/supportTicketTripReport.js
+++ b/src/utils/supportTicketTripReport.js
@@ -2,7 +2,7 @@ function normalizeWebAppBaseUrl(webAppBaseUrl) {
     return String(webAppBaseUrl || '').replace(/\/$/, '');
 }
 
-const TRIP_REPORT_MESSAGE_SEPARATOR = '--------';
+const TRIP_REPORT_MESSAGE_SEPARATOR = '********';
 
 function buildTripReportSupportTicketContext({
     tripId,

--- a/src/utils/supportTicketTripReport.js
+++ b/src/utils/supportTicketTripReport.js
@@ -2,7 +2,9 @@ function normalizeWebAppBaseUrl(webAppBaseUrl) {
     return String(webAppBaseUrl || '').replace(/\/$/, '');
 }
 
-const TRIP_REPORT_MESSAGE_SEPARATOR = '====';
+// Toast UI Editor (toastmark) treats whole lines of ***, ---, or ___ as <hr>, and
+// whole lines of only = or - as setext heading underlines. Use a labeled line instead.
+export const TRIP_REPORT_MESSAGE_SEPARATOR = '--- datos del viaje ---';
 
 function buildTripReportSupportTicketContext({
     tripId,

--- a/src/utils/supportTicketTripReport.js
+++ b/src/utils/supportTicketTripReport.js
@@ -44,7 +44,7 @@ export function buildTripReportSupportTicketMessage({
         driverProfileUrl
     });
 
-    return `${TRIP_REPORT_MESSAGE_SEPARATOR}\n\n${context}`;
+    return `\n\n${TRIP_REPORT_MESSAGE_SEPARATOR}\n\n${context}`;
 }
 
 export function buildTripReportSupportTicketRoute({ trip, webAppBaseUrl }) {

--- a/src/utils/supportTicketTripReport.js
+++ b/src/utils/supportTicketTripReport.js
@@ -44,7 +44,7 @@ export function buildTripReportSupportTicketMessage({
         driverProfileUrl
     });
 
-    return `\n\n${TRIP_REPORT_MESSAGE_SEPARATOR}\n\n${context}`;
+    return `${TRIP_REPORT_MESSAGE_SEPARATOR}\n\n${context}`;
 }
 
 export function buildTripReportSupportTicketRoute({ trip, webAppBaseUrl }) {

--- a/src/utils/supportTicketTripReport.js
+++ b/src/utils/supportTicketTripReport.js
@@ -2,7 +2,9 @@ function normalizeWebAppBaseUrl(webAppBaseUrl) {
     return String(webAppBaseUrl || '').replace(/\/$/, '');
 }
 
-export function buildTripReportSupportTicketMessage({
+const TRIP_REPORT_MESSAGE_SEPARATOR = '--------';
+
+function buildTripReportSupportTicketContext({
     tripId,
     tripUrl,
     driverName,
@@ -25,6 +27,22 @@ export function buildTripReportSupportTicketMessage({
     }
 
     return lines.join('\n');
+}
+
+export function buildTripReportSupportTicketMessage({
+    tripId,
+    tripUrl,
+    driverName,
+    driverProfileUrl
+}) {
+    const context = buildTripReportSupportTicketContext({
+        tripId,
+        tripUrl,
+        driverName,
+        driverProfileUrl
+    });
+
+    return `\n\n${TRIP_REPORT_MESSAGE_SEPARATOR}\n\n${context}`;
 }
 
 export function buildTripReportSupportTicketRoute({ trip, webAppBaseUrl }) {

--- a/src/utils/supportTicketTripReport.js
+++ b/src/utils/supportTicketTripReport.js
@@ -1,0 +1,68 @@
+function normalizeWebAppBaseUrl(webAppBaseUrl) {
+    return String(webAppBaseUrl || '').replace(/\/$/, '');
+}
+
+export function buildTripReportSupportTicketMessage({
+    tripId,
+    tripUrl,
+    driverName,
+    driverProfileUrl
+}) {
+    const lines = [`Viaje ID: ${tripId}`];
+
+    if (tripUrl) {
+        lines.push(`Viaje: ${tripUrl}`);
+    }
+
+    const normalizedDriverName =
+        driverName == null ? '' : String(driverName).trim();
+    if (normalizedDriverName) {
+        lines.push(`Conductor: ${normalizedDriverName}`);
+    }
+
+    if (driverProfileUrl) {
+        lines.push(`Perfil conductor: ${driverProfileUrl}`);
+    }
+
+    return lines.join('\n');
+}
+
+export function buildTripReportSupportTicketRoute({ trip, webAppBaseUrl }) {
+    const tripId = trip && trip.id;
+    const driver = trip && trip.user;
+    const baseUrl = normalizeWebAppBaseUrl(webAppBaseUrl);
+    const tripUrl = baseUrl ? `${baseUrl}/trips/${tripId}` : '';
+    const driverProfileUrl =
+        baseUrl && driver && driver.id ? `${baseUrl}/profile/${driver.id}` : '';
+
+    return {
+        name: 'ticket-new',
+        query: {
+            category: 'report',
+            message: buildTripReportSupportTicketMessage({
+                tripId,
+                tripUrl,
+                driverName: driver && driver.name,
+                driverProfileUrl
+            })
+        }
+    };
+}
+
+export function resolveWebAppBaseUrl(env = import.meta.env) {
+    if (env && env.VITE_WEB_URL) {
+        return normalizeWebAppBaseUrl(env.VITE_WEB_URL);
+    }
+
+    if (typeof window !== 'undefined' && window.location) {
+        const routeBase = env && env.VITE_ROUTE_BASE ? String(env.VITE_ROUTE_BASE) : '/';
+        const normalizedRouteBase = routeBase.startsWith('/')
+            ? routeBase
+            : `/${routeBase}`;
+        return normalizeWebAppBaseUrl(
+            `${window.location.origin}${normalizedRouteBase}`
+        );
+    }
+
+    return '';
+}

--- a/src/utils/supportTicketTripReport.test.js
+++ b/src/utils/supportTicketTripReport.test.js
@@ -14,7 +14,7 @@ describe('buildTripReportSupportTicketMessage', () => {
             driverProfileUrl: 'https://carpoolear.com.ar/app/profile/8'
         });
 
-        expect(message.startsWith('\n\n********\n\n')).toBe(true);
+        expect(message.startsWith('\n====\n\n')).toBe(true);
         expect(message).toContain('Viaje ID: 42');
     });
 

--- a/src/utils/supportTicketTripReport.test.js
+++ b/src/utils/supportTicketTripReport.test.js
@@ -30,7 +30,7 @@ describe('buildTripReportSupportTicketMessage', () => {
             driverProfileUrl: 'https://carpoolear.com.ar/app/profile/8'
         });
 
-        expect(message.startsWith(`\n\n${TRIP_REPORT_MESSAGE_SEPARATOR}\n\n`)).toBe(true);
+        expect(message.startsWith(`${TRIP_REPORT_MESSAGE_SEPARATOR}\n\n`)).toBe(true);
         expect(message).toContain('Viaje ID: 42');
     });
 

--- a/src/utils/supportTicketTripReport.test.js
+++ b/src/utils/supportTicketTripReport.test.js
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
     buildTripReportSupportTicketMessage,
-    buildTripReportSupportTicketRoute
+    buildTripReportSupportTicketRoute,
+    resolveWebAppBaseUrl
 } from './supportTicketTripReport.js';
 
 describe('buildTripReportSupportTicketMessage', () => {
@@ -54,5 +55,15 @@ describe('buildTripReportSupportTicketRoute', () => {
                 })
             }
         });
+    });
+});
+
+describe('resolveWebAppBaseUrl', () => {
+    it('prefers VITE_WEB_URL when available', () => {
+        expect(
+            resolveWebAppBaseUrl({
+                VITE_WEB_URL: 'https://carpoolear.com.ar/app/'
+            })
+        ).toBe('https://carpoolear.com.ar/app');
     });
 });

--- a/src/utils/supportTicketTripReport.test.js
+++ b/src/utils/supportTicketTripReport.test.js
@@ -1,9 +1,25 @@
 import { describe, expect, it } from 'vitest';
 import {
+    TRIP_REPORT_MESSAGE_SEPARATOR,
     buildTripReportSupportTicketMessage,
     buildTripReportSupportTicketRoute,
     resolveWebAppBaseUrl
 } from './supportTicketTripReport.js';
+
+// Patterns from @toast-ui/editor dist/esm/index.js (toastmark block parser).
+const TOAST_THEMATIC_BREAK_LINE =
+    /^(?:(?:\*[ \t]*){3,}|(?:_[ \t]*){3,}|(?:-[ \t]*){3,})[ \t]*$/;
+const TOAST_SETEXT_UNDERLINE_LINE = /^(?:=+|-+)[ \t]*$/;
+
+describe('TRIP_REPORT_MESSAGE_SEPARATOR', () => {
+    it('is not parsed as a thematic break (horizontal rule)', () => {
+        expect(TRIP_REPORT_MESSAGE_SEPARATOR).not.toMatch(TOAST_THEMATIC_BREAK_LINE);
+    });
+
+    it('is not parsed as a setext heading underline', () => {
+        expect(TRIP_REPORT_MESSAGE_SEPARATOR).not.toMatch(TOAST_SETEXT_UNDERLINE_LINE);
+    });
+});
 
 describe('buildTripReportSupportTicketMessage', () => {
     it('leaves room to type above a separator before trip context', () => {
@@ -14,7 +30,7 @@ describe('buildTripReportSupportTicketMessage', () => {
             driverProfileUrl: 'https://carpoolear.com.ar/app/profile/8'
         });
 
-        expect(message.startsWith('====\n\n')).toBe(true);
+        expect(message.startsWith(`${TRIP_REPORT_MESSAGE_SEPARATOR}\n\n`)).toBe(true);
         expect(message).toContain('Viaje ID: 42');
     });
 

--- a/src/utils/supportTicketTripReport.test.js
+++ b/src/utils/supportTicketTripReport.test.js
@@ -6,6 +6,18 @@ import {
 } from './supportTicketTripReport.js';
 
 describe('buildTripReportSupportTicketMessage', () => {
+    it('leaves room to type above a separator before trip context', () => {
+        const message = buildTripReportSupportTicketMessage({
+            tripId: 42,
+            tripUrl: 'https://carpoolear.com.ar/app/trips/42',
+            driverName: 'Juan Pérez',
+            driverProfileUrl: 'https://carpoolear.com.ar/app/profile/8'
+        });
+
+        expect(message.startsWith('\n\n--------\n\n')).toBe(true);
+        expect(message).toContain('Viaje ID: 42');
+    });
+
     it('includes trip id, trip link, driver name and driver profile link', () => {
         const message = buildTripReportSupportTicketMessage({
             tripId: 42,

--- a/src/utils/supportTicketTripReport.test.js
+++ b/src/utils/supportTicketTripReport.test.js
@@ -14,7 +14,7 @@ describe('buildTripReportSupportTicketMessage', () => {
             driverProfileUrl: 'https://carpoolear.com.ar/app/profile/8'
         });
 
-        expect(message.startsWith('\n\n--------\n\n')).toBe(true);
+        expect(message.startsWith('\n\n********\n\n')).toBe(true);
         expect(message).toContain('Viaje ID: 42');
     });
 

--- a/src/utils/supportTicketTripReport.test.js
+++ b/src/utils/supportTicketTripReport.test.js
@@ -14,7 +14,7 @@ describe('buildTripReportSupportTicketMessage', () => {
             driverProfileUrl: 'https://carpoolear.com.ar/app/profile/8'
         });
 
-        expect(message.startsWith('\n====\n\n')).toBe(true);
+        expect(message.startsWith('====\n\n')).toBe(true);
         expect(message).toContain('Viaje ID: 42');
     });
 

--- a/src/utils/supportTicketTripReport.test.js
+++ b/src/utils/supportTicketTripReport.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import {
+    buildTripReportSupportTicketMessage,
+    buildTripReportSupportTicketRoute
+} from './supportTicketTripReport.js';
+
+describe('buildTripReportSupportTicketMessage', () => {
+    it('includes trip id, trip link, driver name and driver profile link', () => {
+        const message = buildTripReportSupportTicketMessage({
+            tripId: 42,
+            tripUrl: 'https://carpoolear.com.ar/app/trips/42',
+            driverName: 'Juan Pérez',
+            driverProfileUrl: 'https://carpoolear.com.ar/app/profile/8'
+        });
+
+        expect(message).toContain('Viaje ID: 42');
+        expect(message).toContain('https://carpoolear.com.ar/app/trips/42');
+        expect(message).toContain('Juan Pérez');
+        expect(message).toContain('https://carpoolear.com.ar/app/profile/8');
+    });
+
+    it('omits driver lines when driver data is missing', () => {
+        const message = buildTripReportSupportTicketMessage({
+            tripId: 7,
+            tripUrl: 'https://carpoolear.com.ar/app/trips/7'
+        });
+
+        expect(message).toContain('Viaje ID: 7');
+        expect(message).toContain('https://carpoolear.com.ar/app/trips/7');
+        expect(message).not.toContain('Conductor:');
+        expect(message).not.toContain('Perfil conductor:');
+    });
+});
+
+describe('buildTripReportSupportTicketRoute', () => {
+    it('routes to a report ticket prefilled with trip context', () => {
+        const route = buildTripReportSupportTicketRoute({
+            trip: {
+                id: 99,
+                user: { id: 8, name: 'Ana García' }
+            },
+            webAppBaseUrl: 'https://carpoolear.com.ar/app'
+        });
+
+        expect(route).toEqual({
+            name: 'ticket-new',
+            query: {
+                category: 'report',
+                message: buildTripReportSupportTicketMessage({
+                    tripId: 99,
+                    tripUrl: 'https://carpoolear.com.ar/app/trips/99',
+                    driverName: 'Ana García',
+                    driverProfileUrl: 'https://carpoolear.com.ar/app/profile/8'
+                })
+            }
+        });
+    });
+});

--- a/src/utils/supportTicketTripReport.test.js
+++ b/src/utils/supportTicketTripReport.test.js
@@ -30,7 +30,7 @@ describe('buildTripReportSupportTicketMessage', () => {
             driverProfileUrl: 'https://carpoolear.com.ar/app/profile/8'
         });
 
-        expect(message.startsWith(`${TRIP_REPORT_MESSAGE_SEPARATOR}\n\n`)).toBe(true);
+        expect(message.startsWith(`\n\n${TRIP_REPORT_MESSAGE_SEPARATOR}\n\n`)).toBe(true);
         expect(message).toContain('Viaje ID: 42');
     });
 

--- a/src/utils/ticketMessagePrefill.js
+++ b/src/utils/ticketMessagePrefill.js
@@ -1,25 +1,28 @@
-export const PREFILLED_TICKET_BLANK_LINES_HTML = '<p><br></p><p><br></p>';
+/** Invisible paragraph content so Toast UI keeps empty lines in WYSIWYG mode. */
+export const PREFILLED_TICKET_BLANK_LINE_MARKDOWN = '\u200B';
+
+export function buildPrefilledTicketEditorMarkdown(tripBlockMarkdown) {
+    const tripBlock = tripBlockMarkdown == null ? '' : String(tripBlockMarkdown).trim();
+    if (!tripBlock) {
+        return '';
+    }
+
+    return [
+        PREFILLED_TICKET_BLANK_LINE_MARKDOWN,
+        PREFILLED_TICKET_BLANK_LINE_MARKDOWN,
+        tripBlock
+    ].join('\n\n');
+}
 
 /**
- * Prepend empty paragraphs above trip context already rendered in WYSIWYG mode.
  * @param {{ invoke: (method: string, ...args: unknown[]) => unknown } | null | undefined} editorRef
  * @returns {boolean}
  */
-export function prependBlankLinesToPrefilledTicketEditor(editorRef) {
+export function focusPrefilledTicketEditorAtStart(editorRef) {
     if (!editorRef || typeof editorRef.invoke !== 'function') {
         return false;
     }
 
-    const currentHtml = editorRef.invoke('getHTML');
-    if (currentHtml == null || !String(currentHtml).trim()) {
-        return false;
-    }
-
-    editorRef.invoke(
-        'setHTML',
-        `${PREFILLED_TICKET_BLANK_LINES_HTML}${currentHtml}`,
-        false
-    );
     editorRef.invoke('moveCursorToStart', true);
     return true;
 }

--- a/src/utils/ticketMessagePrefill.js
+++ b/src/utils/ticketMessagePrefill.js
@@ -1,15 +1,13 @@
 /**
+ * After initial-value renders the trip block, prepend blank lines for user input.
  * @param {{ invoke: (method: string, ...args: unknown[]) => unknown } | null | undefined} editorRef
- * @param {string} tripBlockMarkdown
  * @returns {boolean}
  */
-export function applyTripBlockPrefillToEditor(editorRef, tripBlockMarkdown) {
-    const tripBlock = tripBlockMarkdown == null ? '' : String(tripBlockMarkdown);
-    if (!tripBlock || !editorRef || typeof editorRef.invoke !== 'function') {
+export function preparePrefilledTicketEditorCursor(editorRef) {
+    if (!editorRef || typeof editorRef.invoke !== 'function') {
         return false;
     }
 
-    editorRef.invoke('setMarkdown', tripBlock, true);
     editorRef.invoke('moveCursorToStart', true);
     editorRef.invoke('insertText', '\n\n');
     editorRef.invoke('moveCursorToStart', true);

--- a/src/utils/ticketMessagePrefill.js
+++ b/src/utils/ticketMessagePrefill.js
@@ -1,4 +1,5 @@
-export const PREFILLED_TICKET_TOP_SPACES = '  ';
+/** Invisible paragraph content so Toast UI keeps empty lines in WYSIWYG mode. */
+export const PREFILLED_TICKET_BLANK_LINE_MARKDOWN = '\u200B';
 
 export function buildPrefilledTicketEditorMarkdown(tripBlockMarkdown) {
     const tripBlock = tripBlockMarkdown == null ? '' : String(tripBlockMarkdown).trim();
@@ -6,7 +7,11 @@ export function buildPrefilledTicketEditorMarkdown(tripBlockMarkdown) {
         return '';
     }
 
-    return `${PREFILLED_TICKET_TOP_SPACES}\n\n${tripBlock}`;
+    return [
+        PREFILLED_TICKET_BLANK_LINE_MARKDOWN,
+        PREFILLED_TICKET_BLANK_LINE_MARKDOWN,
+        tripBlock
+    ].join('\n\n');
 }
 
 /**

--- a/src/utils/ticketMessagePrefill.js
+++ b/src/utils/ticketMessagePrefill.js
@@ -1,15 +1,25 @@
+export const PREFILLED_TICKET_BLANK_LINES_HTML = '<p><br></p><p><br></p>';
+
 /**
- * After initial-value renders the trip block, prepend blank lines for user input.
+ * Prepend empty paragraphs above trip context already rendered in WYSIWYG mode.
  * @param {{ invoke: (method: string, ...args: unknown[]) => unknown } | null | undefined} editorRef
  * @returns {boolean}
  */
-export function preparePrefilledTicketEditorCursor(editorRef) {
+export function prependBlankLinesToPrefilledTicketEditor(editorRef) {
     if (!editorRef || typeof editorRef.invoke !== 'function') {
         return false;
     }
 
-    editorRef.invoke('moveCursorToStart', true);
-    editorRef.invoke('insertText', '\n\n');
+    const currentHtml = editorRef.invoke('getHTML');
+    if (currentHtml == null || !String(currentHtml).trim()) {
+        return false;
+    }
+
+    editorRef.invoke(
+        'setHTML',
+        `${PREFILLED_TICKET_BLANK_LINES_HTML}${currentHtml}`,
+        false
+    );
     editorRef.invoke('moveCursorToStart', true);
     return true;
 }

--- a/src/utils/ticketMessagePrefill.js
+++ b/src/utils/ticketMessagePrefill.js
@@ -2,16 +2,13 @@
 export const PREFILLED_TICKET_BLANK_LINE_MARKDOWN = '\u200B';
 
 export function buildPrefilledTicketEditorMarkdown(tripBlockMarkdown) {
-    const tripBlock = tripBlockMarkdown == null ? '' : String(tripBlockMarkdown).trim();
+    const tripBlock =
+        tripBlockMarkdown == null ? '' : String(tripBlockMarkdown).trim();
     if (!tripBlock) {
         return '';
     }
 
-    return [
-        PREFILLED_TICKET_BLANK_LINE_MARKDOWN,
-        PREFILLED_TICKET_BLANK_LINE_MARKDOWN,
-        tripBlock
-    ].join('\n\n');
+    return [PREFILLED_TICKET_BLANK_LINE_MARKDOWN, tripBlock].join('\n\n');
 }
 
 /**

--- a/src/utils/ticketMessagePrefill.js
+++ b/src/utils/ticketMessagePrefill.js
@@ -1,5 +1,4 @@
-/** Invisible paragraph content so Toast UI keeps empty lines in WYSIWYG mode. */
-export const PREFILLED_TICKET_BLANK_LINE_MARKDOWN = '\u200B';
+export const PREFILLED_TICKET_TOP_SPACES = '  ';
 
 export function buildPrefilledTicketEditorMarkdown(tripBlockMarkdown) {
     const tripBlock = tripBlockMarkdown == null ? '' : String(tripBlockMarkdown).trim();
@@ -7,11 +6,7 @@ export function buildPrefilledTicketEditorMarkdown(tripBlockMarkdown) {
         return '';
     }
 
-    return [
-        PREFILLED_TICKET_BLANK_LINE_MARKDOWN,
-        PREFILLED_TICKET_BLANK_LINE_MARKDOWN,
-        tripBlock
-    ].join('\n\n');
+    return `${PREFILLED_TICKET_TOP_SPACES}\n\n${tripBlock}`;
 }
 
 /**

--- a/src/utils/ticketMessagePrefill.js
+++ b/src/utils/ticketMessagePrefill.js
@@ -1,0 +1,17 @@
+/**
+ * @param {{ invoke: (method: string, ...args: unknown[]) => unknown } | null | undefined} editorRef
+ * @param {string} tripBlockMarkdown
+ * @returns {boolean}
+ */
+export function applyTripBlockPrefillToEditor(editorRef, tripBlockMarkdown) {
+    const tripBlock = tripBlockMarkdown == null ? '' : String(tripBlockMarkdown);
+    if (!tripBlock || !editorRef || typeof editorRef.invoke !== 'function') {
+        return false;
+    }
+
+    editorRef.invoke('setMarkdown', tripBlock, true);
+    editorRef.invoke('moveCursorToStart', true);
+    editorRef.invoke('insertText', '\n\n');
+    editorRef.invoke('moveCursorToStart', true);
+    return true;
+}

--- a/src/utils/ticketMessagePrefill.test.js
+++ b/src/utils/ticketMessagePrefill.test.js
@@ -1,18 +1,18 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
-    PREFILLED_TICKET_TOP_SPACES,
+    PREFILLED_TICKET_BLANK_LINE_MARKDOWN,
     buildPrefilledTicketEditorMarkdown,
     focusPrefilledTicketEditorAtStart
 } from './ticketMessagePrefill.js';
 
 describe('buildPrefilledTicketEditorMarkdown', () => {
-    it('adds two spaces before the trip block', () => {
+    it('adds two blank paragraphs before the trip block', () => {
         const markdown = buildPrefilledTicketEditorMarkdown(
             '--- datos del viaje ---\n\nViaje ID: 1'
         );
 
         expect(markdown).toBe(
-            `${PREFILLED_TICKET_TOP_SPACES}\n\n--- datos del viaje ---\n\nViaje ID: 1`
+            `${PREFILLED_TICKET_BLANK_LINE_MARKDOWN}\n\n${PREFILLED_TICKET_BLANK_LINE_MARKDOWN}\n\n--- datos del viaje ---\n\nViaje ID: 1`
         );
     });
 

--- a/src/utils/ticketMessagePrefill.test.js
+++ b/src/utils/ticketMessagePrefill.test.js
@@ -1,42 +1,30 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
-    PREFILLED_TICKET_BLANK_LINES_HTML,
-    prependBlankLinesToPrefilledTicketEditor
+    PREFILLED_TICKET_BLANK_LINE_MARKDOWN,
+    buildPrefilledTicketEditorMarkdown,
+    focusPrefilledTicketEditorAtStart
 } from './ticketMessagePrefill.js';
 
-describe('prependBlankLinesToPrefilledTicketEditor', () => {
-    it('prepends empty paragraphs and leaves the cursor at the top', () => {
-        const invoke = vi.fn((method) => {
-            if (method === 'getHTML') {
-                return '<p>--- datos del viaje ---</p><p>Viaje ID: 1</p>';
-            }
-            return null;
-        });
-        const editorRef = { invoke };
-
-        prependBlankLinesToPrefilledTicketEditor(editorRef);
-
-        expect(invoke).toHaveBeenCalledWith(
-            'setHTML',
-            `${PREFILLED_TICKET_BLANK_LINES_HTML}<p>--- datos del viaje ---</p><p>Viaje ID: 1</p>`,
-            false
+describe('buildPrefilledTicketEditorMarkdown', () => {
+    it('adds two blank paragraphs before the trip block', () => {
+        const markdown = buildPrefilledTicketEditorMarkdown(
+            '--- datos del viaje ---\n\nViaje ID: 1'
         );
+
+        expect(markdown).toBe(
+            `${PREFILLED_TICKET_BLANK_LINE_MARKDOWN}\n\n${PREFILLED_TICKET_BLANK_LINE_MARKDOWN}\n\n--- datos del viaje ---\n\nViaje ID: 1`
+        );
+    });
+
+    it('returns an empty string when the trip block is missing', () => {
+        expect(buildPrefilledTicketEditorMarkdown('')).toBe('');
+    });
+});
+
+describe('focusPrefilledTicketEditorAtStart', () => {
+    it('moves the cursor to the document start', () => {
+        const invoke = vi.fn();
+        focusPrefilledTicketEditorAtStart({ invoke });
         expect(invoke).toHaveBeenCalledWith('moveCursorToStart', true);
-    });
-
-    it('does nothing when the editor has no html yet', () => {
-        const invoke = vi.fn((method) => {
-            if (method === 'getHTML') {
-                return '';
-            }
-            return null;
-        });
-
-        expect(prependBlankLinesToPrefilledTicketEditor({ invoke })).toBe(false);
-        expect(invoke).not.toHaveBeenCalledWith('setHTML', expect.anything(), expect.anything());
-    });
-
-    it('does nothing when the editor ref is missing', () => {
-        expect(prependBlankLinesToPrefilledTicketEditor(null)).toBe(false);
     });
 });

--- a/src/utils/ticketMessagePrefill.test.js
+++ b/src/utils/ticketMessagePrefill.test.js
@@ -6,13 +6,13 @@ import {
 } from './ticketMessagePrefill.js';
 
 describe('buildPrefilledTicketEditorMarkdown', () => {
-    it('adds two blank paragraphs before the trip block', () => {
+    it('adds a blank paragraph before the trip block', () => {
         const markdown = buildPrefilledTicketEditorMarkdown(
             '--- datos del viaje ---\n\nViaje ID: 1'
         );
 
         expect(markdown).toBe(
-            `${PREFILLED_TICKET_BLANK_LINE_MARKDOWN}\n\n${PREFILLED_TICKET_BLANK_LINE_MARKDOWN}\n\n--- datos del viaje ---\n\nViaje ID: 1`
+            `${PREFILLED_TICKET_BLANK_LINE_MARKDOWN}\n\n--- datos del viaje ---\n\nViaje ID: 1`
         );
     });
 

--- a/src/utils/ticketMessagePrefill.test.js
+++ b/src/utils/ticketMessagePrefill.test.js
@@ -1,20 +1,42 @@
 import { describe, expect, it, vi } from 'vitest';
-import { preparePrefilledTicketEditorCursor } from './ticketMessagePrefill.js';
+import {
+    PREFILLED_TICKET_BLANK_LINES_HTML,
+    prependBlankLinesToPrefilledTicketEditor
+} from './ticketMessagePrefill.js';
 
-describe('preparePrefilledTicketEditorCursor', () => {
-    it('prepends blank lines and leaves the cursor at the top', () => {
-        const invoke = vi.fn();
+describe('prependBlankLinesToPrefilledTicketEditor', () => {
+    it('prepends empty paragraphs and leaves the cursor at the top', () => {
+        const invoke = vi.fn((method) => {
+            if (method === 'getHTML') {
+                return '<p>--- datos del viaje ---</p><p>Viaje ID: 1</p>';
+            }
+            return null;
+        });
         const editorRef = { invoke };
 
-        preparePrefilledTicketEditorCursor(editorRef);
+        prependBlankLinesToPrefilledTicketEditor(editorRef);
 
-        expect(invoke).toHaveBeenNthCalledWith(1, 'moveCursorToStart', true);
-        expect(invoke).toHaveBeenNthCalledWith(2, 'insertText', '\n\n');
-        expect(invoke).toHaveBeenNthCalledWith(3, 'moveCursorToStart', true);
-        expect(invoke).not.toHaveBeenCalledWith('setMarkdown', expect.anything());
+        expect(invoke).toHaveBeenCalledWith(
+            'setHTML',
+            `${PREFILLED_TICKET_BLANK_LINES_HTML}<p>--- datos del viaje ---</p><p>Viaje ID: 1</p>`,
+            false
+        );
+        expect(invoke).toHaveBeenCalledWith('moveCursorToStart', true);
+    });
+
+    it('does nothing when the editor has no html yet', () => {
+        const invoke = vi.fn((method) => {
+            if (method === 'getHTML') {
+                return '';
+            }
+            return null;
+        });
+
+        expect(prependBlankLinesToPrefilledTicketEditor({ invoke })).toBe(false);
+        expect(invoke).not.toHaveBeenCalledWith('setHTML', expect.anything(), expect.anything());
     });
 
     it('does nothing when the editor ref is missing', () => {
-        expect(preparePrefilledTicketEditorCursor(null)).toBe(false);
+        expect(prependBlankLinesToPrefilledTicketEditor(null)).toBe(false);
     });
 });

--- a/src/utils/ticketMessagePrefill.test.js
+++ b/src/utils/ticketMessagePrefill.test.js
@@ -1,18 +1,18 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
-    PREFILLED_TICKET_BLANK_LINE_MARKDOWN,
+    PREFILLED_TICKET_TOP_SPACES,
     buildPrefilledTicketEditorMarkdown,
     focusPrefilledTicketEditorAtStart
 } from './ticketMessagePrefill.js';
 
 describe('buildPrefilledTicketEditorMarkdown', () => {
-    it('adds two blank paragraphs before the trip block', () => {
+    it('adds two spaces before the trip block', () => {
         const markdown = buildPrefilledTicketEditorMarkdown(
             '--- datos del viaje ---\n\nViaje ID: 1'
         );
 
         expect(markdown).toBe(
-            `${PREFILLED_TICKET_BLANK_LINE_MARKDOWN}\n\n${PREFILLED_TICKET_BLANK_LINE_MARKDOWN}\n\n--- datos del viaje ---\n\nViaje ID: 1`
+            `${PREFILLED_TICKET_TOP_SPACES}\n\n--- datos del viaje ---\n\nViaje ID: 1`
         );
     });
 

--- a/src/utils/ticketMessagePrefill.test.js
+++ b/src/utils/ticketMessagePrefill.test.js
@@ -1,27 +1,20 @@
 import { describe, expect, it, vi } from 'vitest';
-import { applyTripBlockPrefillToEditor } from './ticketMessagePrefill.js';
+import { preparePrefilledTicketEditorCursor } from './ticketMessagePrefill.js';
 
-describe('applyTripBlockPrefillToEditor', () => {
-    it('loads the trip block then leaves the cursor on blank lines at the top', () => {
+describe('preparePrefilledTicketEditorCursor', () => {
+    it('prepends blank lines and leaves the cursor at the top', () => {
         const invoke = vi.fn();
         const editorRef = { invoke };
 
-        applyTripBlockPrefillToEditor(editorRef, '--- datos del viaje ---\n\nViaje ID: 1');
+        preparePrefilledTicketEditorCursor(editorRef);
 
-        expect(invoke).toHaveBeenNthCalledWith(
-            1,
-            'setMarkdown',
-            '--- datos del viaje ---\n\nViaje ID: 1',
-            true
-        );
-        expect(invoke).toHaveBeenNthCalledWith(2, 'moveCursorToStart', true);
-        expect(invoke).toHaveBeenNthCalledWith(3, 'insertText', '\n\n');
-        expect(invoke).toHaveBeenNthCalledWith(4, 'moveCursorToStart', true);
+        expect(invoke).toHaveBeenNthCalledWith(1, 'moveCursorToStart', true);
+        expect(invoke).toHaveBeenNthCalledWith(2, 'insertText', '\n\n');
+        expect(invoke).toHaveBeenNthCalledWith(3, 'moveCursorToStart', true);
+        expect(invoke).not.toHaveBeenCalledWith('setMarkdown', expect.anything());
     });
 
-    it('does nothing when the trip block is empty', () => {
-        const invoke = vi.fn();
-        applyTripBlockPrefillToEditor({ invoke }, '');
-        expect(invoke).not.toHaveBeenCalled();
+    it('does nothing when the editor ref is missing', () => {
+        expect(preparePrefilledTicketEditorCursor(null)).toBe(false);
     });
 });

--- a/src/utils/ticketMessagePrefill.test.js
+++ b/src/utils/ticketMessagePrefill.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest';
+import { applyTripBlockPrefillToEditor } from './ticketMessagePrefill.js';
+
+describe('applyTripBlockPrefillToEditor', () => {
+    it('loads the trip block then leaves the cursor on blank lines at the top', () => {
+        const invoke = vi.fn();
+        const editorRef = { invoke };
+
+        applyTripBlockPrefillToEditor(editorRef, '--- datos del viaje ---\n\nViaje ID: 1');
+
+        expect(invoke).toHaveBeenNthCalledWith(
+            1,
+            'setMarkdown',
+            '--- datos del viaje ---\n\nViaje ID: 1',
+            true
+        );
+        expect(invoke).toHaveBeenNthCalledWith(2, 'moveCursorToStart', true);
+        expect(invoke).toHaveBeenNthCalledWith(3, 'insertText', '\n\n');
+        expect(invoke).toHaveBeenNthCalledWith(4, 'moveCursorToStart', true);
+    });
+
+    it('does nothing when the trip block is empty', () => {
+        const invoke = vi.fn();
+        applyTripBlockPrefillToEditor({ invoke }, '');
+        expect(invoke).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary

When a passenger clicks **denúncielo** in the trip coordination contribution warning, they are sent to create a new Mesa de ayuda **Denuncia** ticket with trip context pre-filled. A blank line is left at the top so they can type their report above the auto-filled trip details.

## Cause

The report link pointed to the generic `/soporte` list with no trip context. Users had to manually pick **Denuncia** and enter the trip ID, links, and driver info themselves.

Toast UI Editor (WYSIWYG) also made this harder: leading newlines and `setMarkdown` after load were stripped or unreliable, and separators like `====`, `********`, or `---` alone were parsed as headings or horizontal rules.

## Fix (frontend)

- **`supportTicketTripReport.js`**: builds the `ticket-new` route (`category=report`) and message with trip ID, trip URL, driver name, and driver profile URL. Uses a Toast UI-safe separator: `--- datos del viaje ---`.
- **`CoordinateTrip.vue`**: **denúncielo** links to the prefilled Denuncia ticket route instead of `/soporte`.
- **`TicketNew.vue`**: reads `category` and `message` from the URL; mounts the editor with composed initial markdown; focuses the cursor at the top on load.
- **`ticketMessagePrefill.js`**: prepends one invisible blank paragraph (zero-width space) before the trip block so WYSIWYG keeps top spacing for user input.

## Test plan

- [ ] As a passenger, open a conversation with an over-max contribution warning and click **denúncielo**
- [ ] Confirm navigation to `/soporte/nuevo` with category **Denuncia**
- [ ] Confirm a blank line at the top, then `--- datos del viaje ---`, then trip ID, trip link, driver name, and driver profile link
- [ ] Confirm the cursor starts at the top blank line
- [ ] Type a report, submit the ticket, and verify it is created with your text and trip context
- [ ] Create a normal ticket (no query params) and confirm the editor still works as before