### PR TITLE
Banner account verification logged out

### DIFF
--- a/src/utils/appBanner.js
+++ b/src/utils/appBanner.js
@@ -11,7 +11,7 @@ export function shouldShowAppBanner(banner, user) {
         return true;
     }
     if (!user) {
-        return true;
+        return false;
     }
     return !user.identity_validated;
 }

--- a/src/utils/appBanner.js
+++ b/src/utils/appBanner.js
@@ -10,8 +10,5 @@ export function shouldShowAppBanner(banner, user) {
     if (!isAccountVerificationBanner(banner)) {
         return true;
     }
-    if (!user) {
-        return false;
-    }
-    return !user.identity_validated;
+    return Boolean(user) && !user.identity_validated;
 }

--- a/src/utils/appBanner.test.js
+++ b/src/utils/appBanner.test.js
@@ -55,7 +55,7 @@ describe('shouldShowAppBanner', () => {
         ).toBe(false);
     });
 
-    it('shows verification banner when user is not logged in', () => {
-        expect(shouldShowAppBanner(verificationBanner, null)).toBe(true);
+    it('hides verification banner when user is not logged in', () => {
+        expect(shouldShowAppBanner(verificationBanner, null)).toBe(false);
     });
 });


### PR DESCRIPTION
## Summary

Hides the account verification app banner for logged-out users. The banner already did not show for verified members; it now only appears for logged-in users who still need to verify.

## Cause

`shouldShowAppBanner` treated a missing `user` as “show the verification banner” (`return true` when `!user`). On the trips page, guests could see a banner prompting account verification even though they cannot act on it until they log in.

## Fix (frontend)

- Updated `shouldShowAppBanner` in `src/utils/appBanner.js` so verification banners require `Boolean(user) && !user.identity_validated`.
- Added/updated unit test in `src/utils/appBanner.test.js` asserting the banner is hidden when `user` is `null`.
- No changes in `Trips.vue` — it already uses `shouldShowAppBanner(banner, this.user)`.

## Test plan

- [ ] Log out and open the trips/home view: account verification banner should not appear.
- [ ] Log in as an unverified user: banner should appear.
- [ ] Log in as a verified user: banner should not appear.
- [ ] Other app banners (non-verification) should still show for all users.