### PR TITLE
Restore PWA push notifications via Firebase FCM

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -19,5 +19,5 @@ VITE_FACEBOOK_API="147151221990591"
 VITE_RECAPTCHA_SITE_KEY="6LcJyuoqAAAAAFycfjGz2xTiOjhNmWP_wYudIiJT"
 
 # Firebase (single-quoted JSON — escaped double quotes break dotenv parsing)
-VITE_FIREBASE_PARAMS='{"apiKey":"AIzaSyCwecybmdmiWUehjT30RZXWKgiNnP7XI","authDomain":"carpoolear-production.firebaseapp.com","projectId":"carpoolear-production","storageBucket":"carpoolear-production.firebasestorage.app","messagingSenderId":"726271358034","appId":"1:726271358034:web:f09d2d38fae5f185f01b8b","measurementId":"G-V8ZHPQJ6HV"}'
+VITE_FIREBASE_PARAMS='{"apiKey":"AIzaSyCwecybmdmiWUehjZBT30RZXWKgiNnP7XI","authDomain":"carpoolear-production.firebaseapp.com","projectId":"carpoolear-production","storageBucket":"carpoolear-production.firebasestorage.app","messagingSenderId":"726271358034","appId":"1:726271358034:web:f09d2d38fae5f185f01b8b","measurementId":"G-V8ZHPQJ6HV"}'
 VITE_FIRABASE_VAPID_KEY="BGtEjSYLZ36eiHMUpeHzondfyJFGvCvpOXyvBpa21cqxBpfXlV3s1FOrfiRyxbgSpx3m3fDjBb-Eb7FR7dlqZ-k"

--- a/.env.production
+++ b/.env.production
@@ -18,6 +18,6 @@ VITE_MAPS_API=""
 VITE_FACEBOOK_API="147151221990591"
 VITE_RECAPTCHA_SITE_KEY="6LcJyuoqAAAAAFycfjGz2xTiOjhNmWP_wYudIiJT"
 
-# Firebase
-VITE_FIREBASE_PARAMS="{\"apiKey\":\"AIzaSyCwecybmdmiWUehjT30RZXWKgiNnP7XI\",\"authDomain\":\"carpoolear-production.firebaseapp.com\",\"projectId\":\"carpoolear-production\",\"storageBucket\":\"carpoolear-production.firebasestorage.app\",\"messagingSenderId\":\"726271358034\",\"appId\":\"1:726271358034:web:f09d2d38fae5f185f01b8b\",\"measurementId\":\"G-V8ZHPQJ6HV\"}"
+# Firebase (single-quoted JSON — escaped double quotes break dotenv parsing)
+VITE_FIREBASE_PARAMS='{"apiKey":"AIzaSyCwecybmdmiWUehjT30RZXWKgiNnP7XI","authDomain":"carpoolear-production.firebaseapp.com","projectId":"carpoolear-production","storageBucket":"carpoolear-production.firebasestorage.app","messagingSenderId":"726271358034","appId":"1:726271358034:web:f09d2d38fae5f185f01b8b","measurementId":"G-V8ZHPQJ6HV"}'
 VITE_FIRABASE_VAPID_KEY="BGtEjSYLZ36eiHMUpeHzondfyJFGvCvpOXyvBpa21cqxBpfXlV3s1FOrfiRyxbgSpx3m3fDjBb-Eb7FR7dlqZ-k"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.sts.carpoolear"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 3030030
-        versionName "3.3.3"
+        versionCode 3030040
+        versionName "3.3.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/config/conf.json
+++ b/config/conf.json
@@ -39,7 +39,7 @@
     "autocomplete_select_first": false,
     "profile_id_format": "##.###.###",
     "weekly_schedule": false,
-    "web_push_notification": false,
+    "web_push_notification": true,
     "price_show_cents": false,
     "identity_validation_enabled": false,
     "identity_validation_optional": false

--- a/src/components/views/Notifications.view.test.js
+++ b/src/components/views/Notifications.view.test.js
@@ -6,6 +6,15 @@ const viewPath = path.resolve(__dirname, 'Notifications.vue');
 const viewSource = fs.readFileSync(viewPath, 'utf8');
 
 describe('Notifications view', () => {
+    it('only renders the web push prompt for logged-in users', () => {
+        expect(viewSource).toContain(
+            "user: 'user'"
+        );
+        expect(viewSource).toContain(
+            'v-if="user && isPWA() && !hasNotificationPermission && showNotificationWarning"'
+        );
+    });
+
     it('routes identity_validation notifications to account verification page', () => {
         expect(viewSource).toContain("case 'identity_validation':");
         expect(viewSource).toContain("name: 'identity_validation'");

--- a/src/components/views/Notifications.vue
+++ b/src/components/views/Notifications.vue
@@ -128,9 +128,7 @@ export default {
                     this.showNotificationWarning = false;
                     // Initialize push-capacitor.js after permission is granted
                     try {
-                        setTimeout(() => {
-                            push.init();
-                        }, 3000);
+                        push.init();
                     } catch (error) {
                         console.log(
                             'Error initializing push notifications:',

--- a/src/components/views/Notifications.vue
+++ b/src/components/views/Notifications.vue
@@ -2,7 +2,7 @@
     <div>
         <Loading class="container" :data="notifications">
             <div
-                v-if="isPWA() && !hasNotificationPermission && showNotificationWarning"
+                v-if="user && isPWA() && !hasNotificationPermission && showNotificationWarning"
                 class="alert alert-warning ios-notification-warning"
                 style="text-align: center"
                 role="alert"
@@ -218,6 +218,7 @@ export default {
             notifications: 'index'
         }),
         ...mapState(useAuthStore, {
+            user: 'user',
             appConfig: 'appConfig'
         })
     },
@@ -225,7 +226,7 @@ export default {
     mounted() {
         this.search(this.query);
 
-        if (this.appConfig.web_push_notification && this.isPWA()) {
+        if (this.user && this.appConfig.web_push_notification && this.isPWA()) {
             this.checkNotificationPermission();
         }
     },

--- a/src/components/views/Trips.view.test.js
+++ b/src/components/views/Trips.view.test.js
@@ -36,6 +36,16 @@ describe('Trips.vue pending friend invitations card', () => {
     });
 });
 
+describe('Trips.vue web push prompt', () => {
+    it('renders the notification permission warning and actions on trips', () => {
+        expect(viewSource).toContain("$t('notificacionesNoHabilitadas')");
+        expect(viewSource).toContain('requestNotificationPermission');
+        expect(viewSource).toContain('dismissNotificationWarning');
+        expect(viewSource).toContain('checkNotificationPermission');
+        expect(viewSource).toContain('pwa_notification_dismiss');
+    });
+});
+
 describe('Trips.vue friend-first trip sections', () => {
     it('splits logged-in trip list into friend and other sections', () => {
         expect(viewSource).toContain('splitFriendTrips');

--- a/src/components/views/Trips.view.test.js
+++ b/src/components/views/Trips.view.test.js
@@ -37,7 +37,10 @@ describe('Trips.vue pending friend invitations card', () => {
 });
 
 describe('Trips.vue web push prompt', () => {
-    it('renders the notification permission warning and actions on trips', () => {
+    it('only renders the notification permission warning for logged-in users', () => {
+        expect(viewSource).toContain(
+            'v-if="user && appConfig.web_push_notification && isPWA() && !hasNotificationPermission && showNotificationWarning"'
+        );
         expect(viewSource).toContain("$t('notificacionesNoHabilitadas')");
         expect(viewSource).toContain('requestNotificationPermission');
         expect(viewSource).toContain('dismissNotificationWarning');

--- a/src/components/views/Trips.vue
+++ b/src/components/views/Trips.vue
@@ -20,7 +20,7 @@
         <OngoingTripCard v-if="ongoingTrip" :trip="ongoingTrip" />
         <PendingFriendRequestsCard v-if="user" />
         <div
-            v-if="appConfig.web_push_notification && isPWA() && !hasNotificationPermission && showNotificationWarning"
+            v-if="user && appConfig.web_push_notification && isPWA() && !hasNotificationPermission && showNotificationWarning"
             class="alert alert-warning ios-notification-warning"
             style="text-align: center"
             role="alert"
@@ -993,7 +993,7 @@ export default {
             this.pendingScrollRestore = null;
         }
 
-        if (this.appConfig.web_push_notification && this.isPWA()) {
+        if (this.user && this.appConfig.web_push_notification && this.isPWA()) {
             this.checkNotificationPermission();
         }
 

--- a/src/components/views/Trips.vue
+++ b/src/components/views/Trips.vue
@@ -19,6 +19,32 @@
         </div>
         <OngoingTripCard v-if="ongoingTrip" :trip="ongoingTrip" />
         <PendingFriendRequestsCard v-if="user" />
+        <div
+            v-if="appConfig.web_push_notification && isPWA() && !hasNotificationPermission && showNotificationWarning"
+            class="alert alert-warning ios-notification-warning"
+            style="text-align: center"
+            role="alert"
+        >
+            <h4>⚠️ {{ $t('notificacionesNoHabilitadas') }}</h4>
+            <p>
+                {{ $t('notificacionesNoAceptastePermisos') }}
+            </p>
+            <div class="notification-warning-buttons">
+                <button
+                    class="btn btn-success"
+                    @click="requestNotificationPermission"
+                >
+                    {{ $t('otorgarPermisos') }}
+                </button>
+                <button
+                    class="btn btn-default"
+                    @click="dismissNotificationWarning"
+                    style="margin-left: 10px;"
+                >
+                    {{ $t('noMostrarDeNuevo') }}
+                </button>
+            </div>
+        </div>
         <SearchBox
             :params="searchParams"
             v-on:trip-search="research"
@@ -421,6 +447,7 @@ import { useFriendsStore } from '../../stores/friends';
 import dayjs from '../../dayjs';
 import router from '../../router';
 import dialogs from '../../services/dialogs.js';
+import push from '../../cordova/push-capacitor.js';
 import modal from '../Modal';
 import { App } from '@capacitor/app';
 import { Capacitor } from '@capacitor/core';
@@ -507,10 +534,48 @@ export default {
             return /iphone|ipad|ipod/.test(userAgent) && /safari/.test(userAgent) && !/chrome/.test(userAgent);
         },
         isPWA() {
-            // Check if running as PWA (standalone mode)
-            return window.navigator.standalone === true || 
-                   window.matchMedia('(display-mode: standalone)').matches ||
-                   window.matchMedia('(display-mode: window-controls-overlay)').matches;
+            return !window.Capacitor || window.Capacitor.getPlatform() === 'web';
+        },
+        checkNotificationPermission() {
+            if (window.Notification && window.Notification.permission) {
+                if (window.Notification.permission === 'granted') {
+                    this.hasNotificationPermission = true;
+                    this.showNotificationWarning = false;
+                } else {
+                    this.hasNotificationPermission = false;
+                    const dismissedAt = parseInt(localStorage.getItem('pwa_notification_dismiss'));
+                    this.showNotificationWarning = !dismissedAt || Date.now() - dismissedAt > 14 * 24 * 3600 * 1000;
+                }
+            }
+        },
+        requestNotificationPermission() {
+            Notification.requestPermission().then((permission) => {
+                if (permission === 'granted') {
+                    this.hasNotificationPermission = true;
+                    this.showNotificationWarning = false;
+                    try {
+                        push.init();
+                    } catch (error) {
+                        console.log(
+                            'Error initializing push notifications:',
+                            error
+                        );
+                    }
+                    dialogs.message(this.$t('notificacionesPermitidas'), {
+                        duration: 10,
+                        estado: 'success'
+                    });
+                } else {
+                    dialogs.message(this.$t('notificacionesDenegadas'), {
+                        duration: 10,
+                        estado: 'error'
+                    });
+                }
+            });
+        },
+        dismissNotificationWarning() {
+            this.showNotificationWarning = false;
+            localStorage.setItem('pwa_notification_dismiss', Date.now());
         },
         shouldShowInstallModal() {
             // Show modal if we have install event (Android) or if we're on iOS
@@ -926,6 +991,10 @@ export default {
         this.pendingScrollRestore = Number.parseInt(this.getRouteQuery().scroll, 10);
         if (Number.isNaN(this.pendingScrollRestore)) {
             this.pendingScrollRestore = null;
+        }
+
+        if (this.appConfig.web_push_notification && this.isPWA()) {
+            this.checkNotificationPermission();
         }
 
         window.addEventListener('beforeinstallprompt', (e) => {

--- a/src/cordova/index.js
+++ b/src/cordova/index.js
@@ -204,10 +204,7 @@ if (Capacitor.isNativePlatform()) {
     }, 1000);
 } else {
     initNetworkMonitoring();
-    if (
-        config.web_push_notification &&
-        window.Notification.permission === 'granted'
-    ) {
+    if (config.web_push_notification) {
         onDeviceReady();
     }
 }

--- a/src/cordova/index.js
+++ b/src/cordova/index.js
@@ -11,7 +11,7 @@ import { useCordovaStore } from '../stores/cordova';
 import { useRootStore } from '../stores/root';
 
 window.facebook = facebook;
-window.appVersion = '3.3.3';
+window.appVersion = '3.3.4';
 
 const NETWORK_POLL_INTERVAL_MS = 5000;
 let networkMonitoringStarted = false;

--- a/src/cordova/push-capacitor.js
+++ b/src/cordova/push-capacitor.js
@@ -5,6 +5,24 @@ import { Capacitor } from '@capacitor/core';
 import { useCordovaStore } from '../stores/cordova';
 import { useDeviceStore } from '../stores/device';
 
+function getFirebaseConfig() {
+    let raw = import.meta.env.VITE_FIREBASE_PARAMS;
+    if (!raw) {
+        return null;
+    }
+    if (typeof raw === 'string') {
+        try {
+            raw = JSON.parse(raw);
+        } catch {
+            return null;
+        }
+    }
+    if (typeof raw !== 'object' || !raw.apiKey) {
+        return null;
+    }
+    return raw;
+}
+
 class Notification {
     constructor(e) {
         this.foreground = false;
@@ -71,102 +89,123 @@ export default {
     },
 
     async initWebPush() {
+        const firebaseConfig = getFirebaseConfig();
         if (
-            import.meta.env.VITE_FIREBASE_PARAMS !== undefined &&
-            window.Notification &&
-            window.Notification.requestPermission
+            !firebaseConfig ||
+            !window.Notification ||
+            !window.Notification.requestPermission
         ) {
-            try {
-                const firebaseParamsString = new URLSearchParams(
-                    import.meta.env.VITE_FIREBASE_PARAMS
-                ).toString();
+            return;
+        }
 
-                // Get service worker path based on environment
-                const swBase = import.meta.env.VITE_ROUTE_BASE || '/';
-                let serviceWorkerPath = swBase + 'firebase-messaging-sw.js';
+        try {
+            if (window.Notification.permission === 'default') {
+                const permission = await Notification.requestPermission();
+                if (permission !== 'granted') {
+                    return;
+                }
+            } else if (window.Notification.permission !== 'granted') {
+                return;
+            }
 
-                // Append firebase params as query since service workers can't access import.meta.env
-                serviceWorkerPath += '?' + firebaseParamsString;
+            const firebaseParamsString = new URLSearchParams(
+                firebaseConfig
+            ).toString();
 
-                const serviceWorker = navigator.serviceWorker
-                    .register(serviceWorkerPath)
-                    .catch((error) => {
-                        console.error(
-                            'Service worker registration failed:',
-                            error
-                        );
-                    });
+            // Get service worker path based on environment
+            const swBase = import.meta.env.VITE_ROUTE_BASE || '/';
+            let serviceWorkerPath = swBase + 'firebase-messaging-sw.js';
 
-                const reg = await serviceWorker;
+            // Append firebase params as query since service workers can't access import.meta.env
+            serviceWorkerPath += '?' + firebaseParamsString;
 
-                const firebaseApp = initializeApp(import.meta.env.VITE_FIREBASE_PARAMS);
-                const messaging = getMessaging(firebaseApp);
-
-                // Get FCM token
-                const currentToken = await getToken(messaging, {
-                    vapidKey: import.meta.env.VITE_FIRABASE_VAPID_KEY,
-                    serviceWorkerRegistration: reg
+            const serviceWorker = navigator.serviceWorker
+                .register(serviceWorkerPath)
+                .catch((error) => {
+                    console.error(
+                        'Service worker registration failed:',
+                        error
+                    );
                 });
 
-                if (currentToken) {
-                    useCordovaStore().setDeviceId(currentToken);
-                    useDeviceStore().register().catch((error) => {
-                        console.error('❌ Device registration failed:', error);
-                    });
+            const reg = await serviceWorker;
 
-                    // Monitor notification permission changes and reload if revoked to initialize polling
-                    const permissionStatus = await navigator.permissions.query({ name: 'notifications' });
-                    permissionStatus.onchange = function() {
-                        if (this.state !== 'granted') {
-                            window.location.reload();
-                        }
-                    };
-                } else {
-                    console.warn('Failed to get FCM token');
-                }
+            const firebaseApp = initializeApp(firebaseConfig);
+            const messaging = getMessaging(firebaseApp);
 
-                const handleNotification = (payload, isBackgroundMessage) => {
-                    const notification = new Notification({
-                        notification: payload.notification,
-                        data: payload.data
-                    });
+            const vapidKey = import.meta.env.VITE_FIRABASE_VAPID_KEY;
+            if (!vapidKey) {
+                console.warn('Web push: missing VITE_FIRABASE_VAPID_KEY');
+                return;
+            }
 
-                    useCordovaStore().notificationArrive(notification);
-                    // conversations/getUnreaded
-                    // notifications/count
+            // Get FCM token
+            const currentToken = await getToken(messaging, {
+                vapidKey,
+                serviceWorkerRegistration: reg
+            });
 
-                    // Background messages already open a notification
-                    if (isBackgroundMessage) {
-                        return;
-                    }
+            if (currentToken) {
+                useCordovaStore().setDeviceId(currentToken);
+                useDeviceStore().register().catch((error) => {
+                    console.error('❌ Device registration failed:', error);
+                });
 
-                    // Show native notification for web
-                    const notificationTitle = payload.notification.title;
-                    const notificationOptions = {
-                        body: payload.notification.body,
-                        data: payload.data,
-                        icon: payload.notification.icon // import.meta.env.VITE_ROUTE_BASE + 'img/icon-192.png'
-                    };
-
-                    if (payload.data.url !== window.location.pathname) {
-                        reg.showNotification(
-                            notificationTitle,
-                            notificationOptions
-                        );
+                // Monitor notification permission changes and reload if revoked to initialize polling
+                const permissionStatus = await navigator.permissions.query({
+                    name: 'notifications'
+                });
+                permissionStatus.onchange = function () {
+                    if (this.state !== 'granted') {
+                        window.location.reload();
                     }
                 };
+            } else {
+                console.warn('Failed to get FCM token');
+            }
 
-                navigator.serviceWorker.addEventListener('message', (event) => {
-                    if (event.data.type === 'firebase-background-message') {
-                        handleNotification(event.data.payload, true);
-                    }
+            const handleNotification = (payload, isBackgroundMessage) => {
+                const notification = new Notification({
+                    notification: payload.notification,
+                    data: payload.data
                 });
 
-                // Listen for foreground messages
-                onMessage(messaging, handleNotification);
-            } catch (error) {
-                console.error('Web push initialization error:', error);
-            }
+                useCordovaStore().notificationArrive(notification);
+
+                // Background messages already open a notification
+                if (isBackgroundMessage) {
+                    return;
+                }
+
+                // Show native notification for web
+                const notificationTitle = payload.notification.title;
+                const notificationOptions = {
+                    body: payload.notification.body,
+                    data: payload.data,
+                    icon: payload.notification.icon
+                };
+
+                if (
+                    payload.data &&
+                    payload.data.url !== window.location.pathname
+                ) {
+                    reg.showNotification(
+                        notificationTitle,
+                        notificationOptions
+                    );
+                }
+            };
+
+            navigator.serviceWorker.addEventListener('message', (event) => {
+                if (event.data.type === 'firebase-background-message') {
+                    handleNotification(event.data.payload, true);
+                }
+            });
+
+            // Listen for foreground messages
+            onMessage(messaging, handleNotification);
+        } catch (error) {
+            console.error('Web push initialization error:', error);
         }
     },
 

--- a/src/utils/customSplash.js
+++ b/src/utils/customSplash.js
@@ -1,5 +1,5 @@
 export const CUSTOM_SPLASH_DISMISS_MS = 3000;
-export const SPLASH_WEB_BUILD_NUMBER = 128;
+export const SPLASH_WEB_BUILD_NUMBER = 130;
 
 export function formatSplashVersionText({
     version,

--- a/static/firebase-messaging-sw.js
+++ b/static/firebase-messaging-sw.js
@@ -11,19 +11,27 @@ firebase.initializeApp(firebaseConfig);
 // Retrieve firebase messaging
 const messaging = firebase.messaging();
 
+const DEFAULT_ICON =
+    'https://carpoolear.com.ar/app/static/img/carpoolear_logo.png';
+
 messaging.onBackgroundMessage(function (payload) {
     console.log('Received background message ', payload);
 
-    /*
-    const notificationTitle = payload.notification.title;
+    const notificationTitle =
+        (payload.notification && payload.notification.title) || 'Carpoolear';
     const notificationOptions = {
-        body: payload.notification.body
+        body: (payload.notification && payload.notification.body) || '',
+        icon:
+            (payload.notification && payload.notification.icon) || DEFAULT_ICON,
+        data: payload.data || {}
     };
 
-    self.registration.showNotification(notificationTitle, notificationOptions);
-    */
+    self.registration.showNotification(
+        notificationTitle,
+        notificationOptions
+    );
 
-    // Send message to all open clients to update the store
+    // Notify open clients so in-app state (badge count, etc.) stays in sync
     self.clients
         .matchAll({
             type: 'window',

--- a/vite.config.js
+++ b/vite.config.js
@@ -80,9 +80,27 @@ function resolveRouteBase(rawWeb, rawMobile, isWebBuild) {
     return isWebBuild ? '/app/' : '';
 }
 
+function parseFirebaseParams(env) {
+    const raw = env.VITE_FIREBASE_PARAMS || env.FIREBASE_PARAMS || '';
+    if (!raw) {
+        return null;
+    }
+    if (typeof raw === 'object') {
+        return raw;
+    }
+    try {
+        return JSON.parse(raw);
+    } catch {
+        return null;
+    }
+}
+
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, process.cwd(), '');
     const nodeEnv = env.NODE_ENV || 'development';
+    const firebaseParams = parseFirebaseParams(env);
+    const firebaseVapidKey =
+        env.VITE_FIRABASE_VAPID_KEY || env.FIRABASE_VAPID_KEY || '';
 
     const PLATFORM = process.env.PLATFORM || 'browser';
     const isWebBuild = PLATFORM === 'browser';
@@ -182,8 +200,16 @@ export default defineConfig(({ mode }) => {
             VITE_FACEBOOK_API: JSON.stringify(env.FACEBOOK_API || ''),
             VITE_MAPS_API: JSON.stringify(env.MAPS_API || ''),
             VITE_RECAPTCHA_SITE_KEY: JSON.stringify(env.RECAPTCHA_SITE_KEY || ''),
-            VITE_FIREBASE_PARAMS: JSON.stringify(env.FIREBASE_PARAMS || ''),
-            VITE_FIRABASE_VAPID_KEY: JSON.stringify(env.FIRABASE_VAPID_KEY || '')
+            'import.meta.env.VITE_FIREBASE_PARAMS': firebaseParams
+                ? JSON.stringify(firebaseParams)
+                : 'undefined',
+            'import.meta.env.VITE_FIRABASE_VAPID_KEY': JSON.stringify(
+                firebaseVapidKey
+            ),
+            VITE_FIREBASE_PARAMS: firebaseParams
+                ? JSON.stringify(firebaseParams)
+                : 'undefined',
+            VITE_FIRABASE_VAPID_KEY: JSON.stringify(firebaseVapidKey)
         },
         optimizeDeps: {
             include: ['vue', 'vue-router', 'vue-i18n']


### PR DESCRIPTION
## Summary
- Re-enables `web_push_notification` and restores the Firebase FCM web push flow for installed PWAs
- Fixes Vite env injection and `.env.production` Firebase JSON parsing so production builds include the real Firebase config
- Restores background notification display in `firebase-messaging-sw.js` and improves permission/init flow on web

## Context
PWA push was effectively disabled after `web_push_notification` was set back to `false`, and even when enabled had gaps: Firebase config was not reaching production bundles, background messages only forwarded to open tabs (no OS notification when closed), and push init only ran when permission was already granted.

## Test plan
- [x] Deploy web build and open as installed PWA
- [x] Grant notification permission (browser prompt or Notifications page banner)
- [x] Confirm device registers with `device_type: browser` and FCM token via `/api/devices`
- [x] Send a test push with app in foreground, background, and fully closed
- [x] Confirm notification count polling stops when push is active
- [x] Verify native iOS/Android push still works (unchanged path via Capacitor)