### PR TITLE
fix: remove unused iOS communication notifications entitlement

### DIFF
--- a/ios/App/App/App.entitlements
+++ b/ios/App/App/App.entitlements
@@ -4,7 +4,5 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
-	<key>com.apple.developer.usernotifications.communication</key>
-	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Removes `com.apple.developer.usernotifications.communication` from `ios/App/App/App.entitlements`, keeping only `aps-environment`.
- This entitlement was added in 3575fea3 ("fix: Entitlement for push") but is not required for regular push notifications. It is only needed for communication-style notifications (showing sender name/avatar), which the app does not use.
- Clears App Store Connect warning **ITMS-90894**, which requires apps with this entitlement to declare `INSendMessageIntent` or `INStartCallIntent` in `NSUserActivityTypes` in `Info.plist`.

## Context
Push notifications only need:
- `aps-environment` in entitlements (kept)
- the Push Notifications capability
- `remote-notification` in `UIBackgroundModes` (already present in `Info.plist`)

No behavioral change to push delivery.

## Test plan
- [ ] Open `App.xcworkspace`, confirm Push Notifications is the only relevant capability in Signing & Capabilities (Communication Notifications should be gone).
- [ ] Build the app, install on a device, and verify a push notification is received.
- [ ] Archive and upload to App Store Connect; confirm ITMS-90894 no longer appears.