### PR TITLE
Do not prompt car completion when creating a passenger trip

### DIFF
--- a/src/components/views/NewTrip.view.test.js
+++ b/src/components/views/NewTrip.view.test.js
@@ -260,4 +260,10 @@ describe('NewTrip.vue incomplete car completion', () => {
             /<CompleteCarModal[\s\S]*?:visible="showCompleteCarModal"/s
         );
     });
+
+    it('only asks to complete car info when creating a driver trip, not a passenger trip', () => {
+        expect(viewSource).toMatch(
+            /if \(requiresDriverPlate\(this\.trip\)\) \{[\s\S]*?const tripCar = this\.resolveDriverCarForTrip\(\);[\s\S]*?!isCarComplete\(tripCar\)[\s\S]*?this\.showCompleteCarModal = true;/s
+        );
+    });
 });

--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -3308,33 +3308,26 @@ export default {
         },
 
         async save() {
-            if (
-                requiresDriverPlate(this.trip) &&
-                !Array.isArray(this.cars)
-            ) {
-                await this.carIndex();
-            }
-            if (
-                requiresDriverPlate(this.trip) &&
-                !hasDriverPlate(this.cars)
-            ) {
-                dialogs.message(this.$t('olvidastePatente'), {
-                    estado: 'error'
-                });
-                this.showTripCarsModal = true;
-                return;
-            }
-            if (
-                requiresDriverPlate(this.trip) &&
-                needsCarSelection(this.cars) &&
-                !resolveTripCarId(this.cars, this.selectedCarId)
-            ) {
-                this.carSelectionError.state = true;
-                this.carSelectionError.message = this.$t('seleccionaAuto');
-                return;
-            }
-            this.carSelectionError.state = false;
             if (requiresDriverPlate(this.trip)) {
+                if (!Array.isArray(this.cars)) {
+                    await this.carIndex();
+                }
+                if (!hasDriverPlate(this.cars)) {
+                    dialogs.message(this.$t('olvidastePatente'), {
+                        estado: 'error'
+                    });
+                    this.showTripCarsModal = true;
+                    return;
+                }
+                if (
+                    needsCarSelection(this.cars) &&
+                    !resolveTripCarId(this.cars, this.selectedCarId)
+                ) {
+                    this.carSelectionError.state = true;
+                    this.carSelectionError.message = this.$t('seleccionaAuto');
+                    return;
+                }
+                this.carSelectionError.state = false;
                 const tripCar = this.resolveDriverCarForTrip();
                 if (tripCar && !isCarComplete(tripCar)) {
                     this.carToComplete = tripCar;
@@ -3342,6 +3335,7 @@ export default {
                     return;
                 }
             }
+            this.carSelectionError.state = false;
             const validationResult = this.validate();
             if (validationResult) {
                 this.formValidationAttempted = true;

--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -3334,11 +3334,13 @@ export default {
                 return;
             }
             this.carSelectionError.state = false;
-            const tripCar = this.resolveDriverCarForTrip();
-            if (tripCar && !isCarComplete(tripCar)) {
-                this.carToComplete = tripCar;
-                this.showCompleteCarModal = true;
-                return;
+            if (requiresDriverPlate(this.trip)) {
+                const tripCar = this.resolveDriverCarForTrip();
+                if (tripCar && !isCarComplete(tripCar)) {
+                    this.carToComplete = tripCar;
+                    this.showCompleteCarModal = true;
+                    return;
+                }
             }
             const validationResult = this.validate();
             if (validationResult) {


### PR DESCRIPTION
## Summary
- Passenger trip creation no longer prompts the user to complete car info
  (marca/modelo) when they have a saved patente but an incomplete car.
- Car-completion (`CompleteCarModal`) is now only requested for driver trips,
  matching the existing gating already applied to the plate and car-selection
  checks.

## Cause & Fix
- **Cause (frontend):** In `NewTrip.vue` `save()`, the
  `resolveDriverCarForTrip()` + `!isCarComplete(tripCar)` block that opens
  `CompleteCarModal` was not guarded by `requiresDriverPlate(this.trip)`. As a
  result, any user with a plate-but-incomplete car was asked to complete the car
  even for passenger trips.
- **Fix (frontend):** Gate the car-completion check behind
  `requiresDriverPlate(this.trip)`, and group the repeated driver-car
  validations (car load, plate, selection, completion) under a single guard for
  clarity. Behavior for driver trips is unchanged.
- **Backend:** No change required. `TripsManager` already scopes all
  patente/car-incomplete validation to driver trips via `isDriverTrip($data)`.

## Test plan
- [x] New unit test asserts the `CompleteCarModal` trigger is wrapped in
      `requiresDriverPlate(this.trip)` (RED → GREEN).
- [x] Existing `NewTrip` view tests still pass (27/27).
- [x] Frontend ESLint clean; production build succeeds.
- [x] Backend test suite green (3316 passed, 0 failed).

## Notes
- Pre-existing, unrelated failures in `customSplash.test.js` (web build-number
  assertion) are not addressed here and exist on `master`.