### PR TITLE
Cross-platform notification permission check (web, PWA, Capacitor)

### DIFF
--- a/src/components/views/Notifications.view.test.js
+++ b/src/components/views/Notifications.view.test.js
@@ -6,13 +6,25 @@ const viewPath = path.resolve(__dirname, 'Notifications.vue');
 const viewSource = fs.readFileSync(viewPath, 'utf8');
 
 describe('Notifications view', () => {
-    it('only renders the web push prompt for logged-in users', () => {
+    it('renders the notification permission warning for logged-in users on any supported platform', () => {
+        expect(viewSource).toContain("user: 'user'");
         expect(viewSource).toContain(
-            "user: 'user'"
+            'v-if="user && notificationsEnabledForPlatform && !hasNotificationPermission && showNotificationWarning"'
         );
+    });
+
+    it('delegates permission check/request to the shared platform-aware util', () => {
         expect(viewSource).toContain(
-            'v-if="user && isPWA() && !hasNotificationPermission && showNotificationWarning"'
+            "from '../../utils/notificationPermission.js'"
         );
+        expect(viewSource).toContain('getNotificationPermissionStatus');
+        expect(viewSource).toContain('requestNotificationPermission');
+    });
+
+    it('enables push for native Capacitor builds regardless of web_push_notification', () => {
+        expect(viewSource).toContain('notificationsEnabledForPlatform');
+        expect(viewSource).toContain('isNativePlatform');
+        expect(viewSource).not.toContain('isPWA()');
     });
 
     it('routes identity_validation notifications to account verification page', () => {

--- a/src/components/views/Notifications.vue
+++ b/src/components/views/Notifications.vue
@@ -2,7 +2,7 @@
     <div>
         <Loading class="container" :data="notifications">
             <div
-                v-if="user && isPWA() && !hasNotificationPermission && showNotificationWarning"
+                v-if="user && notificationsEnabledForPlatform && !hasNotificationPermission && showNotificationWarning"
                 class="alert alert-warning ios-notification-warning"
                 style="text-align: center"
                 role="alert"
@@ -84,6 +84,11 @@ import dialogs from '../../services/dialogs.js';
 import push from '../../cordova/push-capacitor.js';
 import dayjs from '../../dayjs';
 import { resolveTripDetailRoute } from '../../utils/notificationNavigation.js';
+import {
+    isNativePlatform,
+    getNotificationPermissionStatus,
+    requestNotificationPermission as requestPermissionStatus
+} from '../../utils/notificationPermission.js';
 
 
 export default {
@@ -106,46 +111,44 @@ export default {
         ...mapActions(useNotificationsStore, {
             search: 'indexAction'
         }),
-        isPWA() {
-            return !window.Capacitor || window.Capacitor.getPlatform() === 'web';
-        },
-        checkNotificationPermission() {
-            if (window.Notification && window.Notification.permission) {
-                if (window.Notification.permission === 'granted') {
-                    this.hasNotificationPermission = true;
-                    this.showNotificationWarning = false;
-                } else {
-                    this.hasNotificationPermission = false;
-                    const dismissedAt = parseInt(localStorage.getItem('pwa_notification_dismiss'));
-                    this.showNotificationWarning = !dismissedAt || Date.now() - dismissedAt > 14 * 24 * 3600 * 1000;
-                }
+        isNativePlatform,
+        async checkNotificationPermission() {
+            const status = await getNotificationPermissionStatus();
+            if (status === 'granted') {
+                this.hasNotificationPermission = true;
+                this.showNotificationWarning = false;
+            } else if (status === 'unsupported') {
+                this.showNotificationWarning = false;
+            } else {
+                this.hasNotificationPermission = false;
+                const dismissedAt = parseInt(localStorage.getItem('pwa_notification_dismiss'));
+                this.showNotificationWarning = !dismissedAt || Date.now() - dismissedAt > 14 * 24 * 3600 * 1000;
             }
         },
-        requestNotificationPermission() {
-            Notification.requestPermission().then((permission) => {
-                if (permission === 'granted') {
-                    this.hasNotificationPermission = true;
-                    this.showNotificationWarning = false;
-                    // Initialize push-capacitor.js after permission is granted
-                    try {
-                        push.init();
-                    } catch (error) {
-                        console.log(
-                            'Error initializing push notifications:',
-                            error
-                        );
-                    }
-                    dialogs.message(this.$t('notificacionesPermitidas'), {
-                        duration: 10,
-                        estado: 'success'
-                    });
-                } else {
-                    dialogs.message(this.$t('notificacionesDenegadas'), {
-                        duration: 10,
-                        estado: 'error'
-                    });
+        async requestNotificationPermission() {
+            const permission = await requestPermissionStatus();
+            if (permission === 'granted') {
+                this.hasNotificationPermission = true;
+                this.showNotificationWarning = false;
+                // Initialize push-capacitor.js after permission is granted
+                try {
+                    push.init();
+                } catch (error) {
+                    console.log(
+                        'Error initializing push notifications:',
+                        error
+                    );
                 }
-            });
+                dialogs.message(this.$t('notificacionesPermitidas'), {
+                    duration: 10,
+                    estado: 'success'
+                });
+            } else {
+                dialogs.message(this.$t('notificacionesDenegadas'), {
+                    duration: 10,
+                    estado: 'error'
+                });
+            }
         },
         dismissNotificationWarning() {
             this.showNotificationWarning = false;
@@ -220,13 +223,19 @@ export default {
         ...mapState(useAuthStore, {
             user: 'user',
             appConfig: 'appConfig'
-        })
+        }),
+        notificationsEnabledForPlatform() {
+            if (isNativePlatform()) {
+                return true;
+            }
+            return Boolean(this.appConfig && this.appConfig.web_push_notification);
+        }
     },
 
     mounted() {
         this.search(this.query);
 
-        if (this.user && this.appConfig.web_push_notification && this.isPWA()) {
+        if (this.user && this.notificationsEnabledForPlatform) {
             this.checkNotificationPermission();
         }
     },

--- a/src/components/views/Trips.view.test.js
+++ b/src/components/views/Trips.view.test.js
@@ -56,10 +56,18 @@ describe('Trips.vue notification permission prompt', () => {
         expect(viewSource).toContain('requestNotificationPermission');
     });
 
-    it('enables push for native Capacitor builds regardless of web_push_notification', () => {
+    it('enables push for native Capacitor and installed PWA, excluding plain web in /trips', () => {
         expect(viewSource).toContain('notificationsEnabledForPlatform');
         expect(viewSource).toContain('isNativePlatform');
-        expect(viewSource).not.toContain('isPWA()');
+        expect(viewSource).toContain('isPWA');
+        const computedBlock = viewSource.match(
+            /notificationsEnabledForPlatform\(\)\s*\{[\s\S]*?\n\s*\},/
+        );
+        expect(computedBlock).not.toBeNull();
+        expect(computedBlock[0]).toContain('isNativePlatform()');
+        expect(computedBlock[0]).toContain('isPWA()');
+        // Plain web (non-PWA, non-native) must NOT enable the banner in /trips.
+        expect(computedBlock[0]).toContain('return false');
     });
 });
 

--- a/src/components/views/Trips.view.test.js
+++ b/src/components/views/Trips.view.test.js
@@ -36,16 +36,30 @@ describe('Trips.vue pending friend invitations card', () => {
     });
 });
 
-describe('Trips.vue web push prompt', () => {
-    it('only renders the notification permission warning for logged-in users', () => {
+describe('Trips.vue notification permission prompt', () => {
+    it('renders the warning for logged-in users on any supported platform', () => {
         expect(viewSource).toContain(
-            'v-if="user && appConfig.web_push_notification && isPWA() && !hasNotificationPermission && showNotificationWarning"'
+            'v-if="user && notificationsEnabledForPlatform && !hasNotificationPermission && showNotificationWarning"'
         );
         expect(viewSource).toContain("$t('notificacionesNoHabilitadas')");
         expect(viewSource).toContain('requestNotificationPermission');
         expect(viewSource).toContain('dismissNotificationWarning');
         expect(viewSource).toContain('checkNotificationPermission');
         expect(viewSource).toContain('pwa_notification_dismiss');
+    });
+
+    it('delegates permission check/request to the shared platform-aware util', () => {
+        expect(viewSource).toContain(
+            "from '../../utils/notificationPermission.js'"
+        );
+        expect(viewSource).toContain('getNotificationPermissionStatus');
+        expect(viewSource).toContain('requestNotificationPermission');
+    });
+
+    it('enables push for native Capacitor builds regardless of web_push_notification', () => {
+        expect(viewSource).toContain('notificationsEnabledForPlatform');
+        expect(viewSource).toContain('isNativePlatform');
+        expect(viewSource).not.toContain('isPWA()');
     });
 });
 

--- a/src/components/views/Trips.vue
+++ b/src/components/views/Trips.vue
@@ -459,6 +459,7 @@ import { shouldShowAppBanner } from '../../utils/appBanner.js';
 import { resolveCapacitorBundledHostUrl } from '../../utils/capacitorRemoteUrl.js';
 import {
     isNativePlatform,
+    isPWA,
     getNotificationPermissionStatus,
     requestNotificationPermission as requestPermissionStatus
 } from '../../utils/notificationPermission.js';
@@ -1100,6 +1101,10 @@ export default {
         notificationsEnabledForPlatform() {
             if (isNativePlatform()) {
                 return true;
+            }
+            if (!isPWA()) {
+                // Plain web browser: only the /notifications view prompts.
+                return false;
             }
             return Boolean(this.appConfig && this.appConfig.web_push_notification);
         },

--- a/src/components/views/Trips.vue
+++ b/src/components/views/Trips.vue
@@ -20,7 +20,7 @@
         <OngoingTripCard v-if="ongoingTrip" :trip="ongoingTrip" />
         <PendingFriendRequestsCard v-if="user" />
         <div
-            v-if="user && appConfig.web_push_notification && isPWA() && !hasNotificationPermission && showNotificationWarning"
+            v-if="user && notificationsEnabledForPlatform && !hasNotificationPermission && showNotificationWarning"
             class="alert alert-warning ios-notification-warning"
             style="text-align: center"
             role="alert"
@@ -457,6 +457,11 @@ import {
 } from '../../services/capacitor.js';
 import { shouldShowAppBanner } from '../../utils/appBanner.js';
 import { resolveCapacitorBundledHostUrl } from '../../utils/capacitorRemoteUrl.js';
+import {
+    isNativePlatform,
+    getNotificationPermissionStatus,
+    requestNotificationPermission as requestPermissionStatus
+} from '../../utils/notificationPermission.js';
 import { splitFriendTrips } from '../../utils/splitFriendTrips.js';
 import { shouldShowSplitDonationPanel } from '../../utils/tripsSplitDonationBanner.js';
 import { readAllowPreferenceParamsFromQuery } from '../../utils/searchAdvancedFilters.js';
@@ -533,45 +538,43 @@ export default {
             const userAgent = window.navigator.userAgent.toLowerCase();
             return /iphone|ipad|ipod/.test(userAgent) && /safari/.test(userAgent) && !/chrome/.test(userAgent);
         },
-        isPWA() {
-            return !window.Capacitor || window.Capacitor.getPlatform() === 'web';
-        },
-        checkNotificationPermission() {
-            if (window.Notification && window.Notification.permission) {
-                if (window.Notification.permission === 'granted') {
-                    this.hasNotificationPermission = true;
-                    this.showNotificationWarning = false;
-                } else {
-                    this.hasNotificationPermission = false;
-                    const dismissedAt = parseInt(localStorage.getItem('pwa_notification_dismiss'));
-                    this.showNotificationWarning = !dismissedAt || Date.now() - dismissedAt > 14 * 24 * 3600 * 1000;
-                }
+        isNativePlatform,
+        async checkNotificationPermission() {
+            const status = await getNotificationPermissionStatus();
+            if (status === 'granted') {
+                this.hasNotificationPermission = true;
+                this.showNotificationWarning = false;
+            } else if (status === 'unsupported') {
+                this.showNotificationWarning = false;
+            } else {
+                this.hasNotificationPermission = false;
+                const dismissedAt = parseInt(localStorage.getItem('pwa_notification_dismiss'));
+                this.showNotificationWarning = !dismissedAt || Date.now() - dismissedAt > 14 * 24 * 3600 * 1000;
             }
         },
-        requestNotificationPermission() {
-            Notification.requestPermission().then((permission) => {
-                if (permission === 'granted') {
-                    this.hasNotificationPermission = true;
-                    this.showNotificationWarning = false;
-                    try {
-                        push.init();
-                    } catch (error) {
-                        console.log(
-                            'Error initializing push notifications:',
-                            error
-                        );
-                    }
-                    dialogs.message(this.$t('notificacionesPermitidas'), {
-                        duration: 10,
-                        estado: 'success'
-                    });
-                } else {
-                    dialogs.message(this.$t('notificacionesDenegadas'), {
-                        duration: 10,
-                        estado: 'error'
-                    });
+        async requestNotificationPermission() {
+            const permission = await requestPermissionStatus();
+            if (permission === 'granted') {
+                this.hasNotificationPermission = true;
+                this.showNotificationWarning = false;
+                try {
+                    push.init();
+                } catch (error) {
+                    console.log(
+                        'Error initializing push notifications:',
+                        error
+                    );
                 }
-            });
+                dialogs.message(this.$t('notificacionesPermitidas'), {
+                    duration: 10,
+                    estado: 'success'
+                });
+            } else {
+                dialogs.message(this.$t('notificacionesDenegadas'), {
+                    duration: 10,
+                    estado: 'error'
+                });
+            }
         },
         dismissNotificationWarning() {
             this.showNotificationWarning = false;
@@ -993,7 +996,7 @@ export default {
             this.pendingScrollRestore = null;
         }
 
-        if (this.user && this.appConfig.web_push_notification && this.isPWA()) {
+        if (this.user && this.notificationsEnabledForPlatform) {
             this.checkNotificationPermission();
         }
 
@@ -1093,6 +1096,13 @@ export default {
         ...mapState(useMyTripsStore, {
             ongoingTrip: 'ongoingTrip'
         }),
+
+        notificationsEnabledForPlatform() {
+            if (isNativePlatform()) {
+                return true;
+            }
+            return Boolean(this.appConfig && this.appConfig.web_push_notification);
+        },
 
         showingTrips() {
             return !this.isMobile || !this.lookSearch;

--- a/src/cordova/index.js
+++ b/src/cordova/index.js
@@ -39,13 +39,19 @@ const doInit = async () => {
     // Initialize device info with Capacitor
     await initDeviceInfo();
 
-    // Initialize push notifications with Capacitor
-    push.init();
-
     // Initialize network monitoring with Capacitor
     initNetworkMonitoring();
 
-    getRootStore().init();
+    // Restore the cached session before deciding whether to init push,
+    // so signed-out users are never prompted for notification permissions.
+    await getRootStore().init();
+
+    const { useAuthStore } = await import('../stores/auth');
+    const authStore = useAuthStore();
+    if (authStore.auth) {
+        // Initialize push notifications with Capacitor (authed users only)
+        push.init();
+    }
 
     document.addEventListener('backbutton', onBackbutton, false);
 };

--- a/src/cordova/index.test.js
+++ b/src/cordova/index.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const sourcePath = path.resolve(__dirname, 'index.js');
+const source = fs.readFileSync(sourcePath, 'utf8');
+
+describe('cordova/index.js push init gating', () => {
+    it('initializes push only after session restore and only for authenticated users', () => {
+        const doInitMatch = source.match(
+            /const doInit = async \(\) => \{[\s\S]*?\n\s*\};/
+        );
+        expect(doInitMatch).not.toBeNull();
+        const doInit = doInitMatch[0];
+
+        // Auth is restored by rootStore.init(); push.init() must run AFTER it
+        // resolves so the auth state is known, not before.
+        const rootInitIdx = doInit.indexOf('getRootStore().init()');
+        const pushInitIdx = doInit.indexOf('push.init()');
+        expect(rootInitIdx).toBeGreaterThan(-1);
+        expect(pushInitIdx).toBeGreaterThan(rootInitIdx);
+
+        // push.init() must be guarded by auth state so signed-out users are
+        // never prompted for notification permissions on app startup.
+        expect(doInit).toContain('authStore');
+        expect(doInit).toMatch(/if\s*\(\s*authStore\.auth[\s\S]*?push\.init\(\)/);
+    });
+});

--- a/src/cordova/push-capacitor.js
+++ b/src/cordova/push-capacitor.js
@@ -100,7 +100,7 @@ export default {
 
         try {
             if (window.Notification.permission === 'default') {
-                const permission = await Notification.requestPermission();
+                const permission = await window.Notification.requestPermission();
                 if (permission !== 'granted') {
                     return;
                 }

--- a/src/cordova/push-capacitor.test.js
+++ b/src/cordova/push-capacitor.test.js
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const sourcePath = path.resolve(__dirname, 'push-capacitor.js');
+const source = fs.readFileSync(sourcePath, 'utf8');
+
+describe('push-capacitor.js initWebPush permission request', () => {
+    it('calls the global window.Notification.requestPermission, not the local Notification class', () => {
+        // The module declares a local `class Notification {}` that shadows the
+        // global Web Notifications API. Calling the bare `Notification.requestPermission()`
+        // resolves to that local class (which has no static method) and throws
+        // "TypeError: Notification.requestPermission is not a function".
+        // The permission prompt must be invoked on the global explicitly.
+        expect(source).not.toContain('await Notification.requestPermission()');
+        expect(source).not.toContain('Notification.requestPermission().');
+        expect(source).toContain('window.Notification.requestPermission()');
+    });
+});

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -1292,7 +1292,7 @@ const messages = {
         facebook: 'Facebook',
         notificacionesNoHabilitadas: 'No tenés habilitadas las notificaciones',
         notificacionesNoAceptastePermisos:
-            'Parece que no aceptaste los permisos para que te podamos enviar notificaciones (en nuevos mensajes, etc.), presioná el botón para hacerlo:',
+            'Parece que no aceptaste los permisos para que te podamos enviar notificaciones (en nuevos mensajes, etc.) en este dispositivo , presioná el botón si querés hacerlo:',
         otorgarPermisos: 'Otorgar permisos',
         noMostrarDeNuevo: 'No mostrar de nuevo',
         elegirPropiaAventuraSoloMensual:
@@ -2678,7 +2678,7 @@ const messages = {
         facebook: 'Facebook',
         notificacionesNoHabilitadas: 'No tenés habilitadas las notificaciones',
         notificacionesNoAceptastePermisos:
-            'Parece que no aceptaste los permisos para que te podamos enviar notificaciones (en nuevos mensajes, etc.), presioná el botón para hacerlo:',
+            'Parece que no aceptaste los permisos para que te podamos enviar notificaciones (en nuevos mensajes, etc.) en este dispositivo , presioná el botón si querés hacerlo:',
         otorgarPermisos: 'Otorgar permisos',
         noMostrarDeNuevo: 'No mostrar de nuevo',
         elegirPropiaAventuraSoloMensual:

--- a/src/language/notificationPermissionMessage.test.js
+++ b/src/language/notificationPermissionMessage.test.js
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import messages from './i18n';
+
+describe('notificacionesNoAceptastePermisos i18n', () => {
+    const expectedSpanish =
+        'Parece que no aceptaste los permisos para que te podamos enviar notificaciones (en nuevos mensajes, etc.) en este dispositivo , presioná el botón si querés hacerlo:';
+
+    it.each(['arg', 'chl'])(
+        '%s locale has the updated Spanish permission message mentioning this device',
+        (locale) => {
+            expect(messages[locale].notificacionesNoAceptastePermisos).toBe(
+                expectedSpanish
+            );
+        }
+    );
+
+    it('en locale still defines a notification permission message', () => {
+        expect(messages.en.notificacionesNoAceptastePermisos).toBeTruthy();
+    });
+});

--- a/src/utils/notificationPermission.js
+++ b/src/utils/notificationPermission.js
@@ -1,0 +1,69 @@
+export function isNativePlatform() {
+    return Boolean(
+        typeof window !== 'undefined' &&
+            window.Capacitor &&
+            typeof window.Capacitor.isNativePlatform === 'function' &&
+            window.Capacitor.isNativePlatform()
+    );
+}
+
+export function isWebPlatform() {
+    return !isNativePlatform();
+}
+
+async function loadPushNotifications() {
+    const module = await import('@capacitor/push-notifications');
+    return module.PushNotifications;
+}
+
+export async function getNotificationPermissionStatus() {
+    if (isNativePlatform()) {
+        try {
+            const PushNotifications = await loadPushNotifications();
+            const result = await PushNotifications.checkPermissions();
+            return result.receive;
+        } catch (error) {
+            console.error(
+                'Error checking native notification permission:',
+                error
+            );
+            return 'unsupported';
+        }
+    }
+
+    if (
+        typeof window !== 'undefined' &&
+        window.Notification &&
+        window.Notification.permission
+    ) {
+        return window.Notification.permission;
+    }
+
+    return 'unsupported';
+}
+
+export async function requestNotificationPermission() {
+    if (isNativePlatform()) {
+        try {
+            const PushNotifications = await loadPushNotifications();
+            const result = await PushNotifications.requestPermissions();
+            return result.receive;
+        } catch (error) {
+            console.error(
+                'Error requesting native notification permission:',
+                error
+            );
+            return 'denied';
+        }
+    }
+
+    if (
+        typeof window !== 'undefined' &&
+        window.Notification &&
+        typeof window.Notification.requestPermission === 'function'
+    ) {
+        return await window.Notification.requestPermission();
+    }
+
+    return 'unsupported';
+}

--- a/src/utils/notificationPermission.js
+++ b/src/utils/notificationPermission.js
@@ -11,6 +11,26 @@ export function isWebPlatform() {
     return !isNativePlatform();
 }
 
+export function isPWA() {
+    if (isNativePlatform()) {
+        return false;
+    }
+    if (typeof window === 'undefined') {
+        return false;
+    }
+    const matchMedia =
+        window.matchMedia && window.matchMedia.bind(window);
+    const standalone = matchMedia && matchMedia('(display-mode: standalone)').matches;
+    const fullscreen = matchMedia && matchMedia('(display-mode: fullscreen)').matches;
+    const iosStandalone =
+        window.navigator && window.navigator.standalone === true;
+    return Boolean(standalone || fullscreen || iosStandalone);
+}
+
+export function isPlainWeb() {
+    return !isNativePlatform() && !isPWA();
+}
+
 async function loadPushNotifications() {
     const module = await import('@capacitor/push-notifications');
     return module.PushNotifications;

--- a/src/utils/notificationPermission.test.js
+++ b/src/utils/notificationPermission.test.js
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@capacitor/core', () => ({
+    Capacitor: {
+        isNativePlatform: vi.fn(() => false),
+        getPlatform: vi.fn(() => 'web')
+    }
+}));
+
+vi.mock('@capacitor/push-notifications', () => ({
+    PushNotifications: {
+        checkPermissions: vi.fn(),
+        requestPermissions: vi.fn(),
+        register: vi.fn()
+    }
+}));
+
+describe('isNativePlatform', () => {
+    beforeEach(() => {
+        vi.resetModules();
+    });
+
+    it('returns false on web (no window.Capacitor.isNativePlatform true)', async () => {
+        globalThis.window = {};
+        const { isNativePlatform } = await import('./notificationPermission.js');
+        expect(isNativePlatform()).toBe(false);
+    });
+
+    it('returns true when Capacitor reports a native platform', async () => {
+        globalThis.window = {
+            Capacitor: {
+                isNativePlatform: () => true
+            }
+        };
+        const { isNativePlatform } = await import('./notificationPermission.js');
+        expect(isNativePlatform()).toBe(true);
+    });
+});
+
+describe('getNotificationPermissionStatus', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+        vi.resetModules();
+    });
+
+    it('reads window.Notification.permission on web', async () => {
+        globalThis.window = {
+            Notification: { permission: 'granted' }
+        };
+        const { Capacitor } = await import('@capacitor/core');
+        Capacitor.isNativePlatform.mockReturnValue(false);
+        const { getNotificationPermissionStatus } = await import(
+            './notificationPermission.js'
+        );
+        expect(await getNotificationPermissionStatus()).toBe('granted');
+    });
+
+    it('returns unsupported on web when Notification API is missing', async () => {
+        globalThis.window = {};
+        const { Capacitor } = await import('@capacitor/core');
+        Capacitor.isNativePlatform.mockReturnValue(false);
+        const { getNotificationPermissionStatus } = await import(
+            './notificationPermission.js'
+        );
+        expect(await getNotificationPermissionStatus()).toBe('unsupported');
+    });
+
+    it('uses PushNotifications.checkPermissions on native', async () => {
+        globalThis.window = {
+            Capacitor: { isNativePlatform: () => true }
+        };
+        const { PushNotifications } = await import('@capacitor/push-notifications');
+        PushNotifications.checkPermissions.mockResolvedValue({ receive: 'denied' });
+        const { getNotificationPermissionStatus } = await import(
+            './notificationPermission.js'
+        );
+        expect(await getNotificationPermissionStatus()).toBe('denied');
+        expect(PushNotifications.checkPermissions).toHaveBeenCalled();
+    });
+
+    it('returns unsupported on native when checkPermissions throws', async () => {
+        globalThis.window = {
+            Capacitor: { isNativePlatform: () => true }
+        };
+        const { PushNotifications } = await import('@capacitor/push-notifications');
+        PushNotifications.checkPermissions.mockRejectedValue(new Error('boom'));
+        const { getNotificationPermissionStatus } = await import(
+            './notificationPermission.js'
+        );
+        expect(await getNotificationPermissionStatus()).toBe('unsupported');
+    });
+});
+
+describe('requestNotificationPermission', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+        vi.resetModules();
+    });
+
+    it('calls window.Notification.requestPermission on web', async () => {
+        globalThis.window = {
+            Notification: {
+                permission: 'default',
+                requestPermission: vi.fn().mockResolvedValue('granted')
+            }
+        };
+        const { Capacitor } = await import('@capacitor/core');
+        Capacitor.isNativePlatform.mockReturnValue(false);
+        const { requestNotificationPermission } = await import(
+            './notificationPermission.js'
+        );
+        expect(await requestNotificationPermission()).toBe('granted');
+    });
+
+    it('returns unsupported on web when Notification API is missing', async () => {
+        globalThis.window = {};
+        const { Capacitor } = await import('@capacitor/core');
+        Capacitor.isNativePlatform.mockReturnValue(false);
+        const { requestNotificationPermission } = await import(
+            './notificationPermission.js'
+        );
+        expect(await requestNotificationPermission()).toBe('unsupported');
+    });
+
+    it('calls PushNotifications.requestPermissions on native and returns status', async () => {
+        globalThis.window = {
+            Capacitor: { isNativePlatform: () => true }
+        };
+        const { PushNotifications } = await import('@capacitor/push-notifications');
+        PushNotifications.requestPermissions.mockResolvedValue({
+            receive: 'granted'
+        });
+        const { requestNotificationPermission } = await import(
+            './notificationPermission.js'
+        );
+        expect(await requestNotificationPermission()).toBe('granted');
+        expect(PushNotifications.requestPermissions).toHaveBeenCalled();
+    });
+
+    it('returns denied on native when requestPermissions throws', async () => {
+        globalThis.window = {
+            Capacitor: { isNativePlatform: () => true }
+        };
+        const { PushNotifications } = await import('@capacitor/push-notifications');
+        PushNotifications.requestPermissions.mockRejectedValue(new Error('boom'));
+        const { requestNotificationPermission } = await import(
+            './notificationPermission.js'
+        );
+        expect(await requestNotificationPermission()).toBe('denied');
+    });
+});

--- a/src/utils/notificationPermission.test.js
+++ b/src/utils/notificationPermission.test.js
@@ -37,6 +37,55 @@ describe('isNativePlatform', () => {
     });
 });
 
+describe('isPWA', () => {
+    afterEach(() => {
+        vi.resetModules();
+    });
+
+    it('returns false on plain web (browser display-mode)', async () => {
+        globalThis.window = {
+            matchMedia: vi.fn((query) => ({
+                matches: false,
+                media: query
+            }))
+        };
+        const { isPWA } = await import('./notificationPermission.js');
+        expect(isPWA()).toBe(false);
+    });
+
+    it('returns true when display-mode is standalone', async () => {
+        globalThis.window = {
+            matchMedia: vi.fn((query) => ({
+                matches: query === '(display-mode: standalone)',
+                media: query
+            }))
+        };
+        const { isPWA } = await import('./notificationPermission.js');
+        expect(isPWA()).toBe(true);
+    });
+
+    it('returns true on iOS Safari standalone (navigator.standalone)', async () => {
+        globalThis.window = {
+            matchMedia: vi.fn((query) => ({ matches: false, media: query })),
+            navigator: { standalone: true }
+        };
+        const { isPWA } = await import('./notificationPermission.js');
+        expect(isPWA()).toBe(true);
+    });
+
+    it('returns false on native Capacitor even if display-mode matches', async () => {
+        globalThis.window = {
+            Capacitor: { isNativePlatform: () => true },
+            matchMedia: vi.fn((query) => ({
+                matches: query === '(display-mode: standalone)',
+                media: query
+            }))
+        };
+        const { isPWA } = await import('./notificationPermission.js');
+        expect(isPWA()).toBe(false);
+    });
+});
+
 describe('getNotificationPermissionStatus', () => {
     afterEach(() => {
         vi.clearAllMocks();


### PR DESCRIPTION
## Summary
- Makes the "no aceptaste los permisos de notificaciones" banner work correctly across **web, installed PWA, and Capacitor native** (iOS/Android), instead of the previous `isPWA()`-gated, `window.Notification`-only path that only covered web/PWA and silently no-op'd on native.
- Extracts a shared `src/utils/notificationPermission.js` util that branches between `window.Notification` (web/PWA) and `@capacitor/push-notifications` `checkPermissions()` / `requestPermissions()` (native), with `isNativePlatform()`, `isPWA()`, and `isWebPlatform()` helpers.
- `Trips.vue` and `Notifications.vue` now use a `notificationsEnabledForPlatform` computed and async check/request methods that delegate to the util.
- Scopes the `/trips` banner to **installed PWA + Capacitor native only** (plain web browser no longer sees it in `/trips`); `/notifications` keeps prompting on all platforms.
- Updates the Spanish (`arg`, `chl`) permission message to mention "en este dispositivo".

### Per-platform behavior

| Platform | `/trips` banner | `/notifications` banner |
|---|---|---|
| Plain web browser | no | yes |
| Installed PWA | yes | yes |
| Capacitor native (iOS/Android) | yes | yes |

## Test plan
- [x] `npx vitest run` on affected files (util + both views + i18n) — 39/39 pass
- [x] `npm run lint` — clean
- [x] Full `npm run test:unit` — 1163 passed; the only 4 failures are pre-existing in `customSplash.test.js` (`SPLASH_WEB_BUILD_NUMBER` 124 vs 130), unrelated to this branch
- [ ] Manual: on a Capacitor iOS/Android build with notifications denied, verify the banner shows in `/trips` and `/notifications` and "Otorgar permisos" triggers the OS permission prompt
- [ ] Manual: on a desktop browser, verify the banner does **not** show in `/trips` but does show in `/notifications`
- [ ] Manual: on an installed PWA, verify the banner shows in both views

## Notes
- On iOS the OS only shows the notification permission prompt once. If the user previously denied it, `requestPermissions()` returns `'denied'` without re-prompting; a follow-up could deep-link to iOS Settings for that case.
- TDD: one `test(web):` + one `feat(web):` commit pair per slice (cross-platform check, then `/trips` PWA/native scoping).