### PR TITLE
Distinguish web vs PWA in support/device info

### DIFF
--- a/src/services/debug/debugLogger.js
+++ b/src/services/debug/debugLogger.js
@@ -4,6 +4,7 @@ import {
     buildSupportInfoSnapshot,
     formatSupportInfoBlock
 } from '../../utils/supportInfo.js';
+import { isNativePlatform, isPWA } from '../../utils/notificationPermission.js';
 
 const STORAGE_KEY = 'DEBUG_MODE_ENABLED';
 const LOG_LEVELS = ['log', 'info', 'warn', 'error', 'debug'];
@@ -31,6 +32,8 @@ function createDebugLogger(options = {}) {
         return buildSupportInfoSnapshot({
             windowAppVersion: (typeof window !== 'undefined' && window.appVersion) || null,
             device: (typeof window !== 'undefined' && window.device) || null,
+            isNativePlatform: isNativePlatform(),
+            isPWA: isPWA(),
             notificationPermission: typeof window !== 'undefined' && window.Notification
                 ? window.Notification.permission
                 : null,

--- a/src/services/debug/debugLogger.test.js
+++ b/src/services/debug/debugLogger.test.js
@@ -111,6 +111,31 @@ describe('debugLogger', () => {
             expect(info).not.toContain('"platform"');
         });
 
+        it('includes an App Mode line from the snapshot', async () => {
+            const logger = createDebugLogger({ storage: mockStorage, getSupportInfoSnapshot: mockGetSupportInfoSnapshot });
+            await logger.init();
+            const info = logger.getDebugInfo();
+            expect(info).toContain('App Mode:');
+        });
+
+        it('default fallback reports pwa mode when running as installed PWA', async () => {
+            const originalWindow = globalThis.window;
+            globalThis.window = {
+                matchMedia: (query) => ({
+                    matches: query === '(display-mode: standalone)',
+                    media: query
+                })
+            };
+            try {
+                const logger = createDebugLogger({ storage: mockStorage });
+                await logger.init();
+                const info = logger.getDebugInfo();
+                expect(info).toContain('App Mode: pwa');
+            } finally {
+                globalThis.window = originalWindow;
+            }
+        });
+
         it('includes notification permission in output', async () => {
             const logger = createDebugLogger({ storage: mockStorage, getSupportInfoSnapshot: mockGetSupportInfoSnapshot });
             await logger.init();

--- a/src/services/debug/index.js
+++ b/src/services/debug/index.js
@@ -6,6 +6,7 @@ import {
     buildSupportInfoSnapshot,
     fetchSupportInfoSnapshot
 } from '../../utils/supportInfo.js';
+import { isNativePlatform, isPWA } from '../../utils/notificationPermission.js';
 
 let defaultInstance = null;
 
@@ -15,6 +16,8 @@ function getSupportInfoSnapshot() {
             ? window.appVersion
             : null,
         device: typeof window !== 'undefined' && window.device ? window.device : null,
+        isNativePlatform: isNativePlatform(),
+        isPWA: isPWA(),
         notificationPermission: typeof window !== 'undefined' && window.Notification
             ? window.Notification.permission
             : null,

--- a/src/utils/supportInfo.js
+++ b/src/utils/supportInfo.js
@@ -74,12 +74,20 @@ export function normalizeDeviceRecord(device) {
     };
 }
 
+export function resolveAppMode({ isNativePlatform = false, isPWA = false } = {}) {
+    if (isNativePlatform) {
+        return 'native';
+    }
+    return isPWA ? 'pwa' : 'web';
+}
+
 export function buildSupportInfoSnapshot(deps = {}) {
     const {
         appVersionInfo = null,
         windowAppVersion = null,
         capacitorPlatform = 'unknown',
         isNativePlatform = false,
+        isPWA = false,
         webBuildNumber = SPLASH_WEB_BUILD_NUMBER,
         device = null,
         deviceId = null,
@@ -99,6 +107,7 @@ export function buildSupportInfoSnapshot(deps = {}) {
     return {
         ...versionFields,
         platform: displayValue(capacitorPlatform, 'unknown'),
+        appMode: resolveAppMode({ isNativePlatform, isPWA }),
         ...deviceFields,
         deviceId: displayValue(deviceId, 'unknown'),
         networkOnline: networkOnline === null
@@ -115,6 +124,7 @@ const SUPPORT_INFO_FIELD_LABELS = [
     ['appVersionSource', 'App Version Source'],
     ['webBuildNumber', 'Web Build'],
     ['platform', 'Platform'],
+    ['appMode', 'App Mode'],
     ['operatingSystem', 'Operating System'],
     ['deviceModel', 'Device Model'],
     ['osVersion', 'OS Version'],

--- a/src/utils/supportInfo.js
+++ b/src/utils/supportInfo.js
@@ -192,6 +192,7 @@ export async function fetchSupportInfoSnapshot(deps = {}) {
         importCordovaStore = () => import('../stores/cordova.js'),
         importRootStore = () => import('../stores/root.js'),
         importCapacitorCore = () => import('@capacitor/core'),
+        importNotificationPermission = () => import('./notificationPermission.js'),
         windowRef = typeof window !== 'undefined' ? window : null,
         navigatorRef = typeof navigator !== 'undefined' ? navigator : null
     } = deps;
@@ -204,6 +205,7 @@ export async function fetchSupportInfoSnapshot(deps = {}) {
         : null;
     let capacitorPlatform = 'unknown';
     let isNativePlatform = false;
+    let isPWA = false;
 
     try {
         const { Capacitor } = await importCapacitorCore();
@@ -211,6 +213,13 @@ export async function fetchSupportInfoSnapshot(deps = {}) {
         isNativePlatform = Capacitor.isNativePlatform();
     } catch (e) {
         // Capacitor unavailable in test or web-only contexts
+    }
+
+    try {
+        const { isPWA: detectPWA } = await importNotificationPermission();
+        isPWA = detectPWA();
+    } catch (e) {
+        // notificationPermission module unavailable
     }
 
     try {
@@ -246,6 +255,7 @@ export async function fetchSupportInfoSnapshot(deps = {}) {
         windowAppVersion: windowRef && windowRef.appVersion ? windowRef.appVersion : null,
         capacitorPlatform,
         isNativePlatform,
+        isPWA,
         device,
         deviceId,
         networkOnline,

--- a/src/utils/supportInfo.test.js
+++ b/src/utils/supportInfo.test.js
@@ -68,6 +68,44 @@ describe('buildSupportInfoSnapshot', () => {
         expect(snapshot.webViewVersion).toBe('120.0.0');
         expect(Object.values(snapshot).every((value) => value !== undefined)).toBe(true);
     });
+
+    describe('appMode', () => {
+        it('is "web" for plain web (no pwa, not native)', () => {
+            const snapshot = buildSupportInfoSnapshot({
+                capacitorPlatform: 'web',
+                isNativePlatform: false,
+                isPWA: false
+            });
+
+            expect(snapshot.appMode).toBe('web');
+        });
+
+        it('is "pwa" when isPWA is true and not native', () => {
+            const snapshot = buildSupportInfoSnapshot({
+                capacitorPlatform: 'web',
+                isNativePlatform: false,
+                isPWA: true
+            });
+
+            expect(snapshot.appMode).toBe('pwa');
+        });
+
+        it('is "native" when isNativePlatform is true, even if isPWA is true', () => {
+            const snapshot = buildSupportInfoSnapshot({
+                capacitorPlatform: 'android',
+                isNativePlatform: true,
+                isPWA: true
+            });
+
+            expect(snapshot.appMode).toBe('native');
+        });
+
+        it('is "web" by default when no platform flags are provided', () => {
+            const snapshot = buildSupportInfoSnapshot({});
+
+            expect(snapshot.appMode).toBe('web');
+        });
+    });
 });
 
 describe('formatSupportInfoBlock', () => {
@@ -96,6 +134,18 @@ describe('formatSupportInfoBlock', () => {
         expect(block).toContain('Platform: android');
         expect(block).toContain('Device Model: Pixel 7');
         expect(block).toContain('OS Version: 14');
+    });
+
+    it('renders App Mode line for pwa', () => {
+        const snapshot = buildSupportInfoSnapshot({
+            capacitorPlatform: 'web',
+            isNativePlatform: false,
+            isPWA: true
+        });
+
+        const block = formatSupportInfoBlock(snapshot);
+
+        expect(block).toContain('App Mode: pwa');
     });
 });
 

--- a/src/utils/supportInfo.test.js
+++ b/src/utils/supportInfo.test.js
@@ -272,4 +272,58 @@ describe('fetchSupportInfoSnapshot', () => {
         expect(snapshot.networkOnline).toBe('offline');
         expect(snapshot.notificationPermission).toBe('granted');
     });
+
+    it('sets appMode "native" when running on a native platform', async () => {
+        const snapshot = await fetchSupportInfoSnapshot({
+            importCordovaStore: async () => ({ useCordovaStore: () => ({}) }),
+            importRootStore: async () => ({ useRootStore: () => ({}) }),
+            importCapacitorCore: async () => ({
+                Capacitor: {
+                    getPlatform: () => 'android',
+                    isNativePlatform: () => true
+                }
+            }),
+            importNotificationPermission: async () => ({ isPWA: () => true }),
+            windowRef: { Notification: { permission: 'granted' } },
+            navigatorRef: { userAgent: 'TestAgent/1.0', onLine: true }
+        });
+
+        expect(snapshot.appMode).toBe('native');
+    });
+
+    it('sets appMode "pwa" when isPWA returns true on web platform', async () => {
+        const snapshot = await fetchSupportInfoSnapshot({
+            importCordovaStore: async () => ({ useCordovaStore: () => ({}) }),
+            importRootStore: async () => ({ useRootStore: () => ({}) }),
+            importCapacitorCore: async () => ({
+                Capacitor: {
+                    getPlatform: () => 'web',
+                    isNativePlatform: () => false
+                }
+            }),
+            importNotificationPermission: async () => ({ isPWA: () => true }),
+            windowRef: { Notification: { permission: 'default' } },
+            navigatorRef: { userAgent: 'TestAgent/1.0', onLine: true }
+        });
+
+        expect(snapshot.appMode).toBe('pwa');
+    });
+
+    it('sets appMode "web" when isPWA returns false on web platform', async () => {
+        const snapshot = await fetchSupportInfoSnapshot({
+            importCordovaStore: async () => ({ useCordovaStore: () => ({}) }),
+            importRootStore: async () => ({ useRootStore: () => ({}) }),
+            importCapacitorCore: async () => ({
+                Capacitor: {
+                    getPlatform: () => 'web',
+                    isNativePlatform: () => false
+                }
+            }),
+            importNotificationPermission: async () => ({ isPWA: () => false }),
+            windowRef: { Notification: { permission: 'default' } },
+            navigatorRef: { userAgent: 'TestAgent/1.0', onLine: true }
+        });
+
+        expect(snapshot.appMode).toBe('web');
+    });
 });


### PR DESCRIPTION
## Summary
- Add an `appMode` field (`web` | `pwa` | `native`) to the support/device info snapshot, surfaced as an `App Mode:` line in both support tickets and the debug info dump.
- PWA is detected with the existing `isPWA()` helper (`display-mode: standalone`/`fullscreen` and iOS `navigator.standalone`); native platform takes priority over PWA.

## Cause & fix
- Cause: The support/device info only stored `platform` from `Capacitor.getPlatform()`, which returns `web` for both plain browser sessions and installed PWAs. There was no way to tell from a support ticket or debug log whether the user was on the PWA or plain web, even though `isPWA()` already existed and was used by the notification flow.
- Fix: Introduce `appMode` in `buildSupportInfoSnapshot`, resolve it from `isNativePlatform` + `isPWA`, wire `isPWA` detection into `fetchSupportInfoSnapshot` (support tickets) and the debug logger's sync snapshot fallback (`services/debug/index.js`, `services/debug/debugLogger.js`). Native wins over PWA; plain web is the default.

## Frontend changes
- `src/utils/supportInfo.js`: new `resolveAppMode()` + `appMode` field; `App Mode` label; `fetchSupportInfoSnapshot` now imports and calls `isPWA()`.
- `src/services/debug/index.js` and `src/services/debug/debugLogger.js`: the debug snapshot now derives `appMode` from `isNativePlatform()`/`isPWA()`.
- `TicketNew.vue` requires no changes — it already uses `fetchSupportInfoSnapshot()`.

## Backend changes
- None. Backend test suite verified green (3316 passed) as a sanity check; no backend code was touched.

## Test plan
- [x] `src/utils/supportInfo.test.js` — `appMode` for web/pwa/native/default + `App Mode:` label; `fetchSupportInfoSnapshot` resolves pwa/native/web via injected `isPWA`.
- [x] `src/services/debug/debugLogger.test.js` — default fallback reports `App Mode: pwa` when `display-mode: standalone`.
- [x] `npm run lint` clean.
- [x] `npm run build:web` succeeds.
- [x] `php artisan test` — 3316 passed, 0 failed.
- Note: 4 pre-existing failures in `src/utils/customSplash.test.js` exist on `master` (test expects `SPLASH_WEB_BUILD_NUMBER` = 124 but constant is 130); unrelated to this branch.