### PR TITLE
Show mobile banner variant on mobile

### DIFF
--- a/src/components/views/Trips.view.test.js
+++ b/src/components/views/Trips.view.test.js
@@ -25,11 +25,26 @@ describe('Trips.vue app banner', () => {
     });
 
     it('passes isMobile into the banner asset resolution', () => {
+        const assetBlock = viewSource.match(
+            /appBannerAsset\(\)\s*\{[\s\S]*?\n\s*\},/
+        );
+        expect(assetBlock).not.toBeNull();
+        expect(assetBlock[0]).toContain('isMobile');
+        expect(assetBlock[0]).toContain('resolveAppBannerAsset');
+    });
+
+    it('derives banner image and href from the shared banner asset', () => {
         const imageBlock = viewSource.match(
             /bannerImageSrc\(\)\s*\{[\s\S]*?\n\s*\},/
         );
         expect(imageBlock).not.toBeNull();
-        expect(imageBlock[0]).toContain('isMobile');
+        expect(imageBlock[0]).toContain('this.appBannerAsset');
+
+        const hrefBlock = viewSource.match(
+            /bannerHref\(\)\s*\{[\s\S]*?\n\s*\},/
+        );
+        expect(hrefBlock).not.toBeNull();
+        expect(hrefBlock[0]).toContain('this.appBannerAsset');
     });
 
     it('uses the resolved url for the banner href and click handler', () => {

--- a/src/components/views/Trips.view.test.js
+++ b/src/components/views/Trips.view.test.js
@@ -17,6 +17,29 @@ describe('Trips.vue app banner', () => {
         expect(viewSource).toContain('resolveCapacitorBundledHostUrl');
         expect(viewSource).toContain(':src="bannerImageSrc"');
     });
+
+    it('uses resolveAppBannerAsset to pick mobile banner image and url', () => {
+        expect(viewSource).toContain('resolveAppBannerAsset');
+        expect(viewSource).toContain("from '../../utils/appBanner.js'");
+        expect(viewSource).toMatch(/resolveAppBannerAsset\([^)]*isMobile[^)]*\)/);
+    });
+
+    it('passes isMobile into the banner asset resolution', () => {
+        const imageBlock = viewSource.match(
+            /bannerImageSrc\(\)\s*\{[\s\S]*?\n\s*\},/
+        );
+        expect(imageBlock).not.toBeNull();
+        expect(imageBlock[0]).toContain('isMobile');
+    });
+
+    it('uses the resolved url for the banner href and click handler', () => {
+        expect(viewSource).toContain('bannerHref');
+        const clickBlock = viewSource.match(
+            /onBannerClick\(\)\s*\{[\s\S]*?\n\s*\},/
+        );
+        expect(clickBlock).not.toBeNull();
+        expect(clickBlock[0]).toContain('this.bannerHref');
+    });
 });
 
 describe('Trips.vue ongoing trip card', () => {

--- a/src/components/views/Trips.vue
+++ b/src/components/views/Trips.vue
@@ -1119,15 +1119,16 @@ export default {
             const banner = this.appConfig && this.appConfig.banner;
             return shouldShowAppBanner(banner, this.user);
         },
-        bannerImageSrc() {
+        appBannerAsset() {
             const banner = this.appConfig && this.appConfig.banner;
-            const asset = resolveAppBannerAsset(banner, this.isMobile);
-            return resolveCapacitorBundledHostUrl(asset && asset.image);
+            return resolveAppBannerAsset(banner, this.isMobile);
+        },
+        bannerImageSrc() {
+            const image = this.appBannerAsset && this.appBannerAsset.image;
+            return resolveCapacitorBundledHostUrl(image);
         },
         bannerHref() {
-            const banner = this.appConfig && this.appConfig.banner;
-            const asset = resolveAppBannerAsset(banner, this.isMobile);
-            const url = asset && asset.url;
+            const url = this.appBannerAsset && this.appBannerAsset.url;
             return typeof url === 'string' ? url : '#';
         },
         bannerTarget() {

--- a/src/components/views/Trips.vue
+++ b/src/components/views/Trips.vue
@@ -455,7 +455,10 @@ import {
     isIOSCapacitor,
     shouldHideDonationOnIOSCapacitor
 } from '../../services/capacitor.js';
-import { shouldShowAppBanner } from '../../utils/appBanner.js';
+import {
+    shouldShowAppBanner,
+    resolveAppBannerAsset
+} from '../../utils/appBanner.js';
 import { resolveCapacitorBundledHostUrl } from '../../utils/capacitorRemoteUrl.js';
 import {
     isNativePlatform,
@@ -519,11 +522,8 @@ export default {
             return typeof url === 'string' && url.trim().startsWith('/');
         },
         onBannerClick() {
-            const url =
-                this.appConfig &&
-                this.appConfig.banner &&
-                this.appConfig.banner.url;
-            if (!url || typeof url !== 'string') return;
+            const url = this.bannerHref;
+            if (!url || typeof url !== 'string' || url === '#') return;
             const normalized = url.trim();
             if (!normalized) return;
             if (this.isInternalBannerUrl(normalized)) {
@@ -1120,17 +1120,14 @@ export default {
             return shouldShowAppBanner(banner, this.user);
         },
         bannerImageSrc() {
-            const image =
-                this.appConfig &&
-                this.appConfig.banner &&
-                this.appConfig.banner.image;
-            return resolveCapacitorBundledHostUrl(image);
+            const banner = this.appConfig && this.appConfig.banner;
+            const asset = resolveAppBannerAsset(banner, this.isMobile);
+            return resolveCapacitorBundledHostUrl(asset && asset.image);
         },
         bannerHref() {
-            const url =
-                this.appConfig &&
-                this.appConfig.banner &&
-                this.appConfig.banner.url;
+            const banner = this.appConfig && this.appConfig.banner;
+            const asset = resolveAppBannerAsset(banner, this.isMobile);
+            const url = asset && asset.url;
             return typeof url === 'string' ? url : '#';
         },
         bannerTarget() {

--- a/src/utils/appBanner.js
+++ b/src/utils/appBanner.js
@@ -12,3 +12,10 @@ export function shouldShowAppBanner(banner, user) {
     }
     return Boolean(user) && !user.identity_validated;
 }
+
+export function resolveAppBannerAsset(banner, isMobile) {
+    if (!banner) return null;
+    const image = (isMobile && banner.image_mobile) || banner.image;
+    const url = (isMobile && banner.url_mobile) || banner.url;
+    return { image, url };
+}

--- a/src/utils/appBanner.test.js
+++ b/src/utils/appBanner.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
     isAccountVerificationBanner,
+    resolveAppBannerAsset,
     shouldShowAppBanner
 } from './appBanner.js';
 
@@ -57,5 +58,76 @@ describe('shouldShowAppBanner', () => {
 
     it('hides verification banner when user is not logged in', () => {
         expect(shouldShowAppBanner(verificationBanner, null)).toBe(false);
+    });
+});
+
+describe('resolveAppBannerAsset', () => {
+    const banner = {
+        image: 'https://cdn.example.com/banner.png',
+        url: 'https://example.com/desktop',
+        image_mobile: 'https://cdn.example.com/banner_mobile.png',
+        url_mobile: 'https://example.com/mobile'
+    };
+
+    it('returns null when there is no banner', () => {
+        expect(resolveAppBannerAsset(null, false)).toBeNull();
+        expect(resolveAppBannerAsset(undefined, true)).toBeNull();
+    });
+
+    it('returns desktop image and url when not mobile', () => {
+        expect(resolveAppBannerAsset(banner, false)).toEqual({
+            image: 'https://cdn.example.com/banner.png',
+            url: 'https://example.com/desktop'
+        });
+    });
+
+    it('returns mobile image and url when mobile', () => {
+        expect(resolveAppBannerAsset(banner, true)).toEqual({
+            image: 'https://cdn.example.com/banner_mobile.png',
+            url: 'https://example.com/mobile'
+        });
+    });
+
+    it('falls back to desktop image when mobile image is missing', () => {
+        expect(
+            resolveAppBannerAsset(
+                { image: 'desktop.png', url: 'https://example.com/desktop' },
+                true
+            )
+        ).toEqual({ image: 'desktop.png', url: 'https://example.com/desktop' });
+    });
+
+    it('falls back to desktop image when mobile image is empty', () => {
+        expect(
+            resolveAppBannerAsset(
+                {
+                    image: 'desktop.png',
+                    url: 'https://example.com/desktop',
+                    image_mobile: '',
+                    url_mobile: 'https://example.com/mobile'
+                },
+                true
+            )
+        ).toEqual({
+            image: 'desktop.png',
+            url: 'https://example.com/mobile'
+        });
+    });
+
+    it('falls back to desktop url when mobile url is empty', () => {
+        expect(
+            resolveAppBannerAsset(
+                {
+                    image: 'desktop.png',
+                    url: 'https://example.com/desktop',
+                    image_mobile: 'mobile.png',
+                    url_mobile: ''
+                },
+                true
+            )
+        ).toEqual({
+            image: 'mobile.png',
+            url: 'https://example.com/desktop'
+        });
     });
 });


### PR DESCRIPTION
## Summary
- The backend already serves `banner.image_mobile` / `banner.url_mobile` (Cordova and non-Cordova variants), but the legacy frontend in `Trips.vue` only ever read `banner.image` / `banner.url`, so mobile users saw the desktop banner.
- Adds a pure `resolveAppBannerAsset(banner, isMobile)` util that picks the mobile image/url when `isMobile` is true, falling back to the desktop variants when the mobile ones are missing or empty.
- Wires it into `Trips.vue` via a shared `appBannerAsset` computed so the banner image, href, and click handler all share one mobile-aware resolution. The existing logged-in/unverified gating (`shouldShowAppBanner`) is unchanged.

## Test plan
- [x] `resolveAppBannerAsset` unit tests cover mobile/desktop selection and empty/missing fallbacks (`src/utils/appBanner.test.js`)
- [x] `Trips.vue` view tests assert the resolver is used with `isMobile` and that href/click derive from the shared asset (`src/components/views/Trips.view.test.js`)
- [x] `npm run lint` clean
- [x] `npm run test:unit` — all banner tests pass (4 pre-existing `customSplash` build-number failures exist on master and are unrelated)
- [x] `npm run build:web` succeeds
- [x] Backend `AuthControllerApiTest` banner cases pass (contract for `image_mobile`/`url_mobile` intact)