### PR TITLE
Stop awaiting Capacitor PushNotifications proxy (Otorgar permisos on Android)

### DIFF
--- a/src/utils/notificationPermission.capacitorProxy.test.js
+++ b/src/utils/notificationPermission.capacitorProxy.test.js
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+
+// Faithful replica of the Capacitor plugin Proxy produced by `registerPlugin`.
+// The real proxy (node_modules/@capacitor/core/dist/index.js) returns a method
+// wrapper for *every* property access, including `then`. There is no special
+// case for `then`, so awaiting the plugin object itself makes the JS engine
+// call `.then(resolve, reject)`, which hits Capacitor's `notImplemented` path
+// and throws `"PushNotifications.then()" is not implemented on <platform>`.
+//
+// On Android/iOS this surfaces as:
+//   Uncaught (in promise) s: "PushNotifications.then()" is not implemented on android
+// triggered by `await loadPushNotifications()` in notificationPermission.js.
+function createCapacitorProxy(pluginName, platform, methodImpls) {
+    return new Proxy(
+        {},
+        {
+            get(_target, prop) {
+                if (typeof prop !== 'string') {
+                    return undefined;
+                }
+                if (prop === '$$typeof') {
+                    return undefined;
+                }
+                if (prop === 'toJSON') {
+                    return () => ({});
+                }
+                if (prop === 'then') {
+                    // Mimic Capacitor: no special-case for `then`, so the
+                    // wrapper throws the unimplemented error when invoked.
+                    return () => {
+                        throw new Error(
+                            `"${pluginName}.${prop}()" is not implemented on ${platform}`
+                        );
+                    };
+                }
+                const impl = methodImpls[prop];
+                if (impl) {
+                    return impl;
+                }
+                return () => {
+                    throw new Error(
+                        `"${pluginName}.${prop}()" is not implemented on ${platform}`
+                    );
+                };
+            }
+        }
+    );
+}
+
+describe('notificationPermission — Capacitor proxy thenable trap regression', () => {
+    afterEach(() => {
+        vi.resetModules();
+        vi.doUnmock('@capacitor/push-notifications');
+    });
+
+    async function importWithCapacitorProxy({
+        platform,
+        checkPermissions,
+        requestPermissions
+    }) {
+        vi.resetModules();
+        globalThis.window = {
+            Capacitor: { isNativePlatform: () => true }
+        };
+        const proxy = createCapacitorProxy('PushNotifications', platform, {
+            checkPermissions: () => Promise.resolve(checkPermissions),
+            requestPermissions: () => Promise.resolve(requestPermissions)
+        });
+        vi.doMock('@capacitor/push-notifications', () => ({
+            PushNotifications: proxy
+        }));
+        return import('./notificationPermission.js');
+    }
+
+    it('requestNotificationPermission resolves to granted on android (no .then() trap)', async () => {
+        const { requestNotificationPermission } = await importWithCapacitorProxy({
+            platform: 'android',
+            checkPermissions: { receive: 'denied' },
+            requestPermissions: { receive: 'granted' }
+        });
+        await expect(requestNotificationPermission()).resolves.toBe('granted');
+    });
+
+    it('requestNotificationPermission resolves to denied on android when denied', async () => {
+        const { requestNotificationPermission } = await importWithCapacitorProxy({
+            platform: 'android',
+            checkPermissions: { receive: 'denied' },
+            requestPermissions: { receive: 'denied' }
+        });
+        await expect(requestNotificationPermission()).resolves.toBe('denied');
+    });
+
+    it('getNotificationPermissionStatus reads checkPermissions on android (no .then() trap)', async () => {
+        const { getNotificationPermissionStatus } = await importWithCapacitorProxy({
+            platform: 'android',
+            checkPermissions: { receive: 'prompt' },
+            requestPermissions: { receive: 'granted' }
+        });
+        await expect(getNotificationPermissionStatus()).resolves.toBe('prompt');
+    });
+
+    it('requestNotificationPermission resolves to granted on ios', async () => {
+        const { requestNotificationPermission } = await importWithCapacitorProxy({
+            platform: 'ios',
+            checkPermissions: { receive: 'denied' },
+            requestPermissions: { receive: 'granted' }
+        });
+        await expect(requestNotificationPermission()).resolves.toBe('granted');
+    });
+});

--- a/src/utils/notificationPermission.js
+++ b/src/utils/notificationPermission.js
@@ -31,15 +31,20 @@ export function isPlainWeb() {
     return !isNativePlatform() && !isPWA();
 }
 
-async function loadPushNotifications() {
-    const module = await import('@capacitor/push-notifications');
-    return module.PushNotifications;
+// Returns the dynamic module (a non-thenable ES module namespace), NOT the
+// plugin object. The @capacitor/push-notifications export is a Capacitor Proxy
+// that returns a wrapper for every property — including `then` — so awaiting
+// that proxy makes the engine call `.then()` and throws
+// "PushNotifications.then() is not implemented on android/ios". Awaiting the
+// module namespace is safe; access `.PushNotifications` synchronously.
+async function loadPushNotificationsModule() {
+    return import('@capacitor/push-notifications');
 }
 
 export async function getNotificationPermissionStatus() {
     if (isNativePlatform()) {
         try {
-            const PushNotifications = await loadPushNotifications();
+            const { PushNotifications } = await loadPushNotificationsModule();
             const result = await PushNotifications.checkPermissions();
             return result.receive;
         } catch (error) {
@@ -65,7 +70,7 @@ export async function getNotificationPermissionStatus() {
 export async function requestNotificationPermission() {
     if (isNativePlatform()) {
         try {
-            const PushNotifications = await loadPushNotifications();
+            const { PushNotifications } = await loadPushNotificationsModule();
             const result = await PushNotifications.requestPermissions();
             return result.receive;
         } catch (error) {


### PR DESCRIPTION
## Summary

- The **"Otorgar permisos"** button on `/trips` failed on Android with `Uncaught (in promise) s: "PushNotifications.then()" is not implemented on android`.
- Root cause: `notificationPermission.js` awaited the `@capacitor/push-notifications` export, which is a Capacitor plugin **Proxy** whose `get` trap returns a wrapper for *every* property — including `then` (no special case). Awaiting it made the engine call `proxy.then()`, hitting Capacitor's `notImplemented` path.
- Fix: await the dynamic **module namespace** (non-thenable) and access `.PushNotifications` synchronously instead of awaiting the proxy. The existing correct pattern in `push-capacitor.js` already does this.

## Platforms

- Android: fixed (was throwing).
- iOS: fixed (same native Capacitor path).
- Web / PWA: unchanged — still uses `window.Notification.requestPermission()` / `.permission`.

## Test plan

- [x] TDD red: added `notificationPermission.capacitorProxy.test.js` with a faithful Capacitor-style Proxy mock (including a `then` trap) reproducing the Android error. Verified tests failed for the expected reason before implementing.
- [x] TDD green: minimal fix; all 18 notification-permission tests pass (4 new + 14 existing).
- [x] `npm run lint` clean.
- [x] `npm run build` passes (`✓ built in 9.37s`).
- [ ] Manual: on an Android device, open `/trips`, tap **"Otorgar permisos"** and confirm the permission prompt appears (no `PushNotifications.then()` error in console).
- [ ] Manual: same flow on iOS.
- [ ] Manual: on web/PWA, confirm the browser notification permission prompt still appears.