### PR TITLE
Update MP both-mismatch rejection warning copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build-dev:android": "node movilizame build --platform=android",
     "build-capacitor-android-local": "npm run build:android && cp -r dist/default/production/www/* www/ && npx cap run android --target d59fb3c7",
     "cap:sync:android": "npx cap sync android && node scripts/fix-capacitor-cordova-gradle.js",
+    "preview:mp-rejection-warning": "node scripts/print-mp-rejection-preview-url.mjs",
     "lint": "eslint --ext .js src",
     "lint:fix": "eslint --ext .js --fix src",
     "check": "npm run lint && npm run test:unit -- --run",

--- a/scripts/print-mp-rejection-preview-url.mjs
+++ b/scripts/print-mp-rejection-preview-url.mjs
@@ -1,0 +1,8 @@
+import { buildIdentityValidationMpBothMismatchPreviewUrl } from '../src/utils/identityValidationMpRejectionPreview.js';
+
+const previewUrl = buildIdentityValidationMpBothMismatchPreviewUrl({
+    origin: 'http://localhost:8080'
+});
+
+console.log('Open while running npm run dev:');
+console.log(previewUrl);

--- a/src/components/sections/IdentityValidation.view.test.js
+++ b/src/components/sections/IdentityValidation.view.test.js
@@ -74,6 +74,13 @@ describe('IdentityValidation rejection warnings', () => {
         expect(viewSource).toContain('$t(mismatchSupportWarningParts.tailKey)');
     });
 
+    it('renders two-paragraph both-mismatch warning with ticket link in second paragraph', () => {
+        expect(viewSource).toContain("mismatchSupportWarningParts.layout === 'twoParagraph'");
+        expect(viewSource).toContain('$t(mismatchSupportWarningParts.paragraph1Key)');
+        expect(viewSource).toContain('$t(mismatchSupportWarningParts.paragraph2LeadKey)');
+        expect(viewSource).toContain('$t(mismatchSupportWarningParts.paragraph2TailKey)');
+    });
+
     it('shows warning icon and translated mismatch warning placeholder in rejected flow', () => {
         expect(viewSource).toContain('identity-validation-rejection-notice__support-warning');
         expect(viewSource).toContain('fa fa-exclamation-triangle');

--- a/src/components/sections/IdentityValidation.view.test.js
+++ b/src/components/sections/IdentityValidation.view.test.js
@@ -76,6 +76,8 @@ describe('IdentityValidation rejection warnings', () => {
 
     it('renders two-paragraph both-mismatch warning with ticket link in second paragraph', () => {
         expect(viewSource).toContain("mismatchSupportWarningParts.layout === 'twoParagraph'");
+        expect(viewSource).toContain('identity-validation-mismatch-support-warning--stacked');
+        expect(viewSource).toContain('identity-validation-mismatch-support-warning__paragraph');
         expect(viewSource).toContain('$t(mismatchSupportWarningParts.paragraph1Key)');
         expect(viewSource).toContain('$t(mismatchSupportWarningParts.paragraph2LeadKey)');
         expect(viewSource).toContain('$t(mismatchSupportWarningParts.paragraph2TailKey)');

--- a/src/components/sections/IdentityValidation.vue
+++ b/src/components/sections/IdentityValidation.vue
@@ -47,19 +47,22 @@
                 <strong>{{ $t('nombreEnMercadoPago') }}:</strong> {{ mismatchDetails.mpName }}
             </p>
             <template v-if="mismatchSupportWarningKey">
-                <template v-if="mismatchSupportWarningParts.layout === 'twoParagraph'">
-                    <p class="identity-validation-mismatch-support-warning">
+                <div
+                    v-if="mismatchSupportWarningParts.layout === 'twoParagraph'"
+                    class="identity-validation-mismatch-support-warning identity-validation-mismatch-support-warning--stacked"
+                >
+                    <p class="identity-validation-mismatch-support-warning__paragraph">
                         <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                         {{ $t(mismatchSupportWarningParts.paragraph1Key) }}
                     </p>
-                    <p class="identity-validation-mismatch-support-warning">
+                    <p class="identity-validation-mismatch-support-warning__paragraph">
                         {{ $t(mismatchSupportWarningParts.paragraph2LeadKey) }}
                         <router-link :to="{ name: 'ticket-new' }">
                             {{ $t('identityValidationMismatchSupportTicketCta') }}
                         </router-link>
                         {{ $t(mismatchSupportWarningParts.paragraph2TailKey) }}
                     </p>
-                </template>
+                </div>
                 <p
                     v-else
                     class="identity-validation-mismatch-support-warning"
@@ -1032,6 +1035,14 @@ export default {
     border: 1px solid #f0c36d;
     background: #fff7e6;
     color: #8a6d3b;
+}
+
+.identity-validation-mismatch-support-warning__paragraph {
+    margin: 0;
+}
+
+.identity-validation-mismatch-support-warning__paragraph + .identity-validation-mismatch-support-warning__paragraph {
+    margin-top: 0.75rem;
 }
 
 .identity-validation-mismatch-support-warning .fa {

--- a/src/components/sections/IdentityValidation.vue
+++ b/src/components/sections/IdentityValidation.vue
@@ -46,19 +46,34 @@
                 <strong>{{ $t('nombreEnCarpoolear') }}:</strong> {{ mismatchDetails.userName }}<br />
                 <strong>{{ $t('nombreEnMercadoPago') }}:</strong> {{ mismatchDetails.mpName }}
             </p>
-            <p
-                v-if="mismatchSupportWarningKey"
-                class="identity-validation-mismatch-support-warning"
-            >
-                <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-                {{ $t(mismatchSupportWarningParts.leadKey) }}
-                <router-link :to="{ name: 'ticket-new' }">
-                    {{ $t('identityValidationMismatchSupportTicketCta') }}
-                </router-link>
-                <span v-if="mismatchSupportWarningParts.tailKey">
-                    {{ $t(mismatchSupportWarningParts.tailKey) }}
-                </span>
-            </p>
+            <template v-if="mismatchSupportWarningKey">
+                <template v-if="mismatchSupportWarningParts.layout === 'twoParagraph'">
+                    <p class="identity-validation-mismatch-support-warning">
+                        <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+                        {{ $t(mismatchSupportWarningParts.paragraph1Key) }}
+                    </p>
+                    <p class="identity-validation-mismatch-support-warning">
+                        {{ $t(mismatchSupportWarningParts.paragraph2LeadKey) }}
+                        <router-link :to="{ name: 'ticket-new' }">
+                            {{ $t('identityValidationMismatchSupportTicketCta') }}
+                        </router-link>
+                        {{ $t(mismatchSupportWarningParts.paragraph2TailKey) }}
+                    </p>
+                </template>
+                <p
+                    v-else
+                    class="identity-validation-mismatch-support-warning"
+                >
+                    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+                    {{ $t(mismatchSupportWarningParts.leadKey) }}
+                    <router-link :to="{ name: 'ticket-new' }">
+                        {{ $t('identityValidationMismatchSupportTicketCta') }}
+                    </router-link>
+                    <span v-if="mismatchSupportWarningParts.tailKey">
+                        {{ $t(mismatchSupportWarningParts.tailKey) }}
+                    </span>
+                </p>
+            </template>
         </div>
 
             <div v-if="!identityValidationAvailable" class="alert alert-info">
@@ -427,7 +442,8 @@ import {
 import {
     getIdentityValidationMismatchDetails,
     getManualRejectionSupportWarningKey,
-    getMismatchSupportWarningKey
+    getMismatchSupportWarningKey,
+    getMismatchSupportWarningParts
 } from '../../utils/identityValidationMismatchDetails';
 import {
     getDisplayableManualApprovalReviewNote,
@@ -438,7 +454,7 @@ import { shouldShowIdentityVerificationSuccessBanner } from '../../utils/identit
 import { isManualRejectedWithChoiceCards, canManualResubmitWithoutPayment, getManualValidationResubmitRoute, getManualValidationRestartRoute } from '../../utils/manualIdentityValidationStatus';
 import IdentityValidationAdminReviewNote from '../IdentityValidationAdminReviewNote.vue';
 
-const EMPTY_WARNING_PARTS = { leadKey: null, tailKey: null };
+const EMPTY_WARNING_PARTS = { layout: null, leadKey: null, tailKey: null };
 
 export default {
     name: 'IdentityValidation',
@@ -495,11 +511,10 @@ export default {
             return getMismatchSupportWarningKey(this.resultMessage);
         },
         mismatchSupportWarningParts() {
-            if (!this.mismatchSupportWarningKey) return EMPTY_WARNING_PARTS;
-            return {
-                leadKey: `${this.mismatchSupportWarningKey}Lead`,
-                tailKey: `${this.mismatchSupportWarningKey}Tail`
-            };
+            return (
+                getMismatchSupportWarningParts(this.mismatchSupportWarningKey) ||
+                EMPTY_WARNING_PARTS
+            );
         },
         /**
          * Paid + docs sent + not yet approved/rejected — still in admin queue.

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -704,11 +704,13 @@ const messages = {
         identityValidationRejectionSupportWarningDniMismatchTail:
             ' así te ayudamos a resolverlo.',
         identityValidationRejectionSupportWarningBothMismatch:
-            'Parece que no coincide tu nombre ni DNI, revisá que usaste una cuenta de Mercado Pago del mismo titular. Si necesitás cambiar tu nombre en Carpoolear, creá un ticket de Mesa de Ayuda así te ayudamos a cambiarlo y podés intentar nuevamente.',
-        identityValidationRejectionSupportWarningBothMismatchLead:
-            'Parece que no coincide tu nombre ni DNI, revisá que usaste una cuenta de Mercado Pago del mismo titular. Si necesitás cambiar tu nombre en Carpoolear, ',
-        identityValidationRejectionSupportWarningBothMismatchTail:
-            ' así te ayudamos a cambiarlo y podés intentar nuevamente.',
+            'Parece que no coincide tu nombre ni DNI, revisá si usaste una cuenta de Mercado Pago del mismo titular que la de Carpoolear. Si necesitás modificar tu nombre y/o DNI de tu cuenta Carpoolear podes hacerlo editando tu perfil. Si tenés cuenta duplicada en Carpoolear, creá un ticket de Mesa de Ayuda así te ayudamos a normalizar tu cuenta y puedas terminar el proceso de verificación.',
+        identityValidationRejectionSupportWarningBothMismatchParagraph1:
+            'Parece que no coincide tu nombre ni DNI, revisá si usaste una cuenta de Mercado Pago del mismo titular que la de Carpoolear.',
+        identityValidationRejectionSupportWarningBothMismatchParagraph2Lead:
+            'Si necesitás modificar tu nombre y/o DNI de tu cuenta Carpoolear podes hacerlo editando tu perfil. Si tenés cuenta duplicada en Carpoolear, ',
+        identityValidationRejectionSupportWarningBothMismatchParagraph2Tail:
+            ' así te ayudamos a normalizar tu cuenta y puedas terminar el proceso de verificación.',
         identityValidationMismatchSupportTicketCta: 'creá un ticket de Mesa de Ayuda',
         identityValidationRejectionReasonLabel: 'Razón de rechazo',
         identityValidationAdminReviewNoteLabelApproved: 'Mensaje del equipo',
@@ -2224,11 +2226,13 @@ const messages = {
         identityValidationRejectionSupportWarningDniMismatchTail:
             ' así te ayudamos a resolverlo.',
         identityValidationRejectionSupportWarningBothMismatch:
-            'Parece que no coincide tu nombre ni DNI, revisá que usaste una cuenta de Mercado Pago del mismo titular. Si necesitás cambiar tu nombre en Carpoolear, creá un ticket de Mesa de Ayuda así te ayudamos a cambiarlo y podés intentar nuevamente.',
-        identityValidationRejectionSupportWarningBothMismatchLead:
-            'Parece que no coincide tu nombre ni DNI, revisá que usaste una cuenta de Mercado Pago del mismo titular. Si necesitás cambiar tu nombre en Carpoolear, ',
-        identityValidationRejectionSupportWarningBothMismatchTail:
-            ' así te ayudamos a cambiarlo y podés intentar nuevamente.',
+            'Parece que no coincide tu nombre ni DNI, revisá si usaste una cuenta de Mercado Pago del mismo titular que la de Carpoolear. Si necesitás modificar tu nombre y/o DNI de tu cuenta Carpoolear podes hacerlo editando tu perfil. Si tenés cuenta duplicada en Carpoolear, creá un ticket de Mesa de Ayuda así te ayudamos a normalizar tu cuenta y puedas terminar el proceso de verificación.',
+        identityValidationRejectionSupportWarningBothMismatchParagraph1:
+            'Parece que no coincide tu nombre ni DNI, revisá si usaste una cuenta de Mercado Pago del mismo titular que la de Carpoolear.',
+        identityValidationRejectionSupportWarningBothMismatchParagraph2Lead:
+            'Si necesitás modificar tu nombre y/o DNI de tu cuenta Carpoolear podes hacerlo editando tu perfil. Si tenés cuenta duplicada en Carpoolear, ',
+        identityValidationRejectionSupportWarningBothMismatchParagraph2Tail:
+            ' así te ayudamos a normalizar tu cuenta y puedas terminar el proceso de verificación.',
         identityValidationMismatchSupportTicketCta: 'creá un ticket de Mesa de Ayuda',
         identityValidationRejectionReasonLabel: 'Razón de rechazo',
         identityValidationAdminReviewNoteLabelApproved: 'Mensaje del equipo',
@@ -3578,11 +3582,13 @@ const messages = {
         identityValidationRejectionSupportWarningDniMismatchTail:
             ' so we can help resolve it.',
         identityValidationRejectionSupportWarningBothMismatch:
-            'It looks like neither your name nor DNI matches. Make sure you used a Mercado Pago account belonging to the same holder. If you need to change your name in Carpoolear, create a Help Desk ticket so we can help you update it and try again.',
-        identityValidationRejectionSupportWarningBothMismatchLead:
-            'It looks like neither your name nor DNI matches. Make sure you used a Mercado Pago account belonging to the same holder. If you need to change your name in Carpoolear, ',
-        identityValidationRejectionSupportWarningBothMismatchTail:
-            ' so we can help you update it and try again.',
+            'It looks like neither your name nor DNI matches. Check that you used a Mercado Pago account belonging to the same holder as your Carpoolear account. If you need to update your name and/or DNI on your Carpoolear account, you can do so by editing your profile. If you have a duplicate Carpoolear account, create a Help Desk ticket so we can help you consolidate your account and complete the verification process.',
+        identityValidationRejectionSupportWarningBothMismatchParagraph1:
+            'It looks like neither your name nor DNI matches. Check that you used a Mercado Pago account belonging to the same holder as your Carpoolear account.',
+        identityValidationRejectionSupportWarningBothMismatchParagraph2Lead:
+            'If you need to update your name and/or DNI on your Carpoolear account, you can do so by editing your profile. If you have a duplicate Carpoolear account, ',
+        identityValidationRejectionSupportWarningBothMismatchParagraph2Tail:
+            ' so we can help you consolidate your account and complete the verification process.',
         identityValidationMismatchSupportTicketCta: 'create a Help Desk ticket',
         identityValidationRejectionReasonLabel: 'Reason for rejection',
         identityValidationAdminReviewNoteLabelApproved: 'Message from the team',

--- a/src/language/identityValidationRejectionSupportWarningBothMismatch.test.js
+++ b/src/language/identityValidationRejectionSupportWarningBothMismatch.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import messages from './i18n';
+
+const BOTH_MISMATCH_WARNING_ES = {
+    identityValidationRejectionSupportWarningBothMismatchParagraph1:
+        'Parece que no coincide tu nombre ni DNI, revisá si usaste una cuenta de Mercado Pago del mismo titular que la de Carpoolear.',
+    identityValidationRejectionSupportWarningBothMismatchParagraph2Lead:
+        'Si necesitás modificar tu nombre y/o DNI de tu cuenta Carpoolear podes hacerlo editando tu perfil. Si tenés cuenta duplicada en Carpoolear, ',
+    identityValidationRejectionSupportWarningBothMismatchParagraph2Tail:
+        ' así te ayudamos a normalizar tu cuenta y puedas terminar el proceso de verificación.',
+    identityValidationMismatchSupportTicketCta: 'creá un ticket de Mesa de Ayuda'
+};
+
+const BOTH_MISMATCH_WARNING_BY_LOCALE = {
+    arg: BOTH_MISMATCH_WARNING_ES,
+    chl: BOTH_MISMATCH_WARNING_ES,
+    en: {
+        identityValidationRejectionSupportWarningBothMismatchParagraph1:
+            'It looks like neither your name nor DNI matches. Check that you used a Mercado Pago account belonging to the same holder as your Carpoolear account.',
+        identityValidationRejectionSupportWarningBothMismatchParagraph2Lead:
+            'If you need to update your name and/or DNI on your Carpoolear account, you can do so by editing your profile. If you have a duplicate Carpoolear account, ',
+        identityValidationRejectionSupportWarningBothMismatchParagraph2Tail:
+            ' so we can help you consolidate your account and complete the verification process.',
+        identityValidationMismatchSupportTicketCta: 'create a Help Desk ticket'
+    }
+};
+
+describe('identityValidationRejectionSupportWarningBothMismatch (i18n)', () => {
+    it.each(Object.entries(BOTH_MISMATCH_WARNING_BY_LOCALE))(
+        '%s locale uses two-paragraph MP rejection warning copy',
+        (locale, expected) => {
+            Object.entries(expected).forEach(([key, label]) => {
+                expect(messages[locale][key]).toBe(label);
+            });
+        }
+    );
+});

--- a/src/utils/identityValidationMismatchDetails.js
+++ b/src/utils/identityValidationMismatchDetails.js
@@ -3,6 +3,10 @@ import { formatDisplayDni } from './formatDisplayDni';
 export const MISMATCH_RESULT_DNI = 'dni_mismatch';
 export const MISMATCH_RESULT_NAME = 'name_mismatch';
 export const MISMATCH_RESULT_BOTH = 'both_mismatch';
+export const BOTH_MISMATCH_WARNING_KEY =
+    'identityValidationRejectionSupportWarningBothMismatch';
+export const WARNING_PART_LAYOUT_TWO_PARAGRAPH = 'twoParagraph';
+export const WARNING_PART_LAYOUT_INLINE_LINK = 'inlineLink';
 
 function formatMismatchDni(value, profileIdFormat) {
     if (!value) {
@@ -52,13 +56,10 @@ export function getMismatchSupportWarningKey(mismatchReason) {
         return 'identityValidationRejectionSupportWarningDniMismatch';
     }
     if (mismatchReason === MISMATCH_RESULT_BOTH) {
-        return 'identityValidationRejectionSupportWarningBothMismatch';
+        return BOTH_MISMATCH_WARNING_KEY;
     }
     return null;
 }
-
-const BOTH_MISMATCH_WARNING_KEY =
-    'identityValidationRejectionSupportWarningBothMismatch';
 
 export function getMismatchSupportWarningParts(warningKey) {
     if (!warningKey) {
@@ -66,14 +67,14 @@ export function getMismatchSupportWarningParts(warningKey) {
     }
     if (warningKey === BOTH_MISMATCH_WARNING_KEY) {
         return {
-            layout: 'twoParagraph',
+            layout: WARNING_PART_LAYOUT_TWO_PARAGRAPH,
             paragraph1Key: `${warningKey}Paragraph1`,
             paragraph2LeadKey: `${warningKey}Paragraph2Lead`,
             paragraph2TailKey: `${warningKey}Paragraph2Tail`
         };
     }
     return {
-        layout: 'inlineLink',
+        layout: WARNING_PART_LAYOUT_INLINE_LINK,
         leadKey: `${warningKey}Lead`,
         tailKey: `${warningKey}Tail`
     };

--- a/src/utils/identityValidationMismatchDetails.js
+++ b/src/utils/identityValidationMismatchDetails.js
@@ -57,6 +57,28 @@ export function getMismatchSupportWarningKey(mismatchReason) {
     return null;
 }
 
+const BOTH_MISMATCH_WARNING_KEY =
+    'identityValidationRejectionSupportWarningBothMismatch';
+
+export function getMismatchSupportWarningParts(warningKey) {
+    if (!warningKey) {
+        return null;
+    }
+    if (warningKey === BOTH_MISMATCH_WARNING_KEY) {
+        return {
+            layout: 'twoParagraph',
+            paragraph1Key: `${warningKey}Paragraph1`,
+            paragraph2LeadKey: `${warningKey}Paragraph2Lead`,
+            paragraph2TailKey: `${warningKey}Paragraph2Tail`
+        };
+    }
+    return {
+        layout: 'inlineLink',
+        leadKey: `${warningKey}Lead`,
+        tailKey: `${warningKey}Tail`
+    };
+}
+
 export function getManualRejectionSupportWarningKey(rejectReason) {
     return getMismatchSupportWarningKey(rejectReason);
 }

--- a/src/utils/identityValidationMismatchDetails.test.js
+++ b/src/utils/identityValidationMismatchDetails.test.js
@@ -4,7 +4,9 @@ import {
     getMismatchSupportWarningKey,
     getMismatchSupportWarningParts,
     getManualRejectionSupportWarningKey,
-    MISMATCH_RESULT_BOTH
+    MISMATCH_RESULT_BOTH,
+    WARNING_PART_LAYOUT_INLINE_LINK,
+    WARNING_PART_LAYOUT_TWO_PARAGRAPH
 } from './identityValidationMismatchDetails.js';
 
 describe('getIdentityValidationMismatchDetails', () => {
@@ -68,7 +70,7 @@ describe('getIdentityValidationMismatchDetails', () => {
                 'identityValidationRejectionSupportWarningBothMismatch'
             )
         ).toEqual({
-            layout: 'twoParagraph',
+            layout: WARNING_PART_LAYOUT_TWO_PARAGRAPH,
             paragraph1Key:
                 'identityValidationRejectionSupportWarningBothMismatchParagraph1',
             paragraph2LeadKey:
@@ -84,7 +86,7 @@ describe('getIdentityValidationMismatchDetails', () => {
                 'identityValidationRejectionSupportWarningNameMismatch'
             )
         ).toEqual({
-            layout: 'inlineLink',
+            layout: WARNING_PART_LAYOUT_INLINE_LINK,
             leadKey: 'identityValidationRejectionSupportWarningNameMismatchLead',
             tailKey: 'identityValidationRejectionSupportWarningNameMismatchTail'
         });

--- a/src/utils/identityValidationMismatchDetails.test.js
+++ b/src/utils/identityValidationMismatchDetails.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
     getIdentityValidationMismatchDetails,
     getMismatchSupportWarningKey,
+    getMismatchSupportWarningParts,
     getManualRejectionSupportWarningKey,
     MISMATCH_RESULT_BOTH
 } from './identityValidationMismatchDetails.js';
@@ -59,5 +60,33 @@ describe('getIdentityValidationMismatchDetails', () => {
         expect(getMismatchSupportWarningKey('both_mismatch'))
             .toBe('identityValidationRejectionSupportWarningBothMismatch');
         expect(getMismatchSupportWarningKey('other')).toBe(null);
+    });
+
+    it('returns two-paragraph warning parts for both mismatch', () => {
+        expect(
+            getMismatchSupportWarningParts(
+                'identityValidationRejectionSupportWarningBothMismatch'
+            )
+        ).toEqual({
+            layout: 'twoParagraph',
+            paragraph1Key:
+                'identityValidationRejectionSupportWarningBothMismatchParagraph1',
+            paragraph2LeadKey:
+                'identityValidationRejectionSupportWarningBothMismatchParagraph2Lead',
+            paragraph2TailKey:
+                'identityValidationRejectionSupportWarningBothMismatchParagraph2Tail'
+        });
+    });
+
+    it('returns inline-link warning parts for single-field mismatch', () => {
+        expect(
+            getMismatchSupportWarningParts(
+                'identityValidationRejectionSupportWarningNameMismatch'
+            )
+        ).toEqual({
+            layout: 'inlineLink',
+            leadKey: 'identityValidationRejectionSupportWarningNameMismatchLead',
+            tailKey: 'identityValidationRejectionSupportWarningNameMismatchTail'
+        });
     });
 });

--- a/src/utils/identityValidationMpRejectionPreview.js
+++ b/src/utils/identityValidationMpRejectionPreview.js
@@ -1,0 +1,20 @@
+export const MP_BOTH_MISMATCH_PREVIEW_QUERY = {
+    result: 'both_mismatch',
+    user_name: 'Juan Pérez',
+    mp_name: 'María García',
+    user_dni: '30123456',
+    mp_dni: '30999999'
+};
+
+export function buildIdentityValidationMpBothMismatchPreviewUrl(options = {}) {
+    const basePath = options.basePath ?? '/identity-validation';
+    const params = new URLSearchParams(MP_BOTH_MISMATCH_PREVIEW_QUERY);
+    const query = params.toString();
+    const pathWithQuery = `${basePath}?${query}`;
+
+    if (options.origin) {
+        return `${options.origin}/#${pathWithQuery}`;
+    }
+
+    return pathWithQuery;
+}

--- a/src/utils/identityValidationMpRejectionPreview.test.js
+++ b/src/utils/identityValidationMpRejectionPreview.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+    MP_BOTH_MISMATCH_PREVIEW_QUERY,
+    buildIdentityValidationMpBothMismatchPreviewUrl
+} from './identityValidationMpRejectionPreview.js';
+
+describe('identityValidationMpRejectionPreview', () => {
+    it('exports sample both_mismatch query params for local preview', () => {
+        expect(MP_BOTH_MISMATCH_PREVIEW_QUERY).toEqual({
+            result: 'both_mismatch',
+            user_name: 'Juan Pérez',
+            mp_name: 'María García',
+            user_dni: '30123456',
+            mp_dni: '30999999'
+        });
+    });
+
+    it('builds hash-router preview path with mismatch query string', () => {
+        expect(buildIdentityValidationMpBothMismatchPreviewUrl()).toBe(
+            '/identity-validation?result=both_mismatch&user_name=Juan+P%C3%A9rez&mp_name=Mar%C3%ADa+Garc%C3%ADa&user_dni=30123456&mp_dni=30999999'
+        );
+    });
+
+    it('builds full dev preview url when base origin is provided', () => {
+        expect(
+            buildIdentityValidationMpBothMismatchPreviewUrl({
+                origin: 'http://localhost:8080',
+                hashPrefix: '#'
+            })
+        ).toBe(
+            'http://localhost:8080/#/identity-validation?result=both_mismatch&user_name=Juan+P%C3%A9rez&mp_name=Mar%C3%ADa+Garc%C3%ADa&user_dni=30123456&mp_dni=30999999'
+        );
+    });
+});

--- a/src/utils/identityValidationMpRejectionPreview.test.js
+++ b/src/utils/identityValidationMpRejectionPreview.test.js
@@ -24,8 +24,7 @@ describe('identityValidationMpRejectionPreview', () => {
     it('builds full dev preview url when base origin is provided', () => {
         expect(
             buildIdentityValidationMpBothMismatchPreviewUrl({
-                origin: 'http://localhost:8080',
-                hashPrefix: '#'
+                origin: 'http://localhost:8080'
             })
         ).toBe(
             'http://localhost:8080/#/identity-validation?result=both_mismatch&user_name=Juan+P%C3%A9rez&mp_name=Mar%C3%ADa+Garc%C3%ADa&user_dni=30123456&mp_dni=30999999'


### PR DESCRIPTION
## Summary
- Updates the Mercado Pago `both_mismatch` rejection warning to two paragraphs with clearer guidance about matching account holders, editing profile data, and contacting Mesa de Ayuda for duplicate accounts.
- Keeps "creá un ticket de Mesa de Ayuda" as a link to ticket creation.
- Adds `npm run preview:mp-rejection-warning` to print a local dev URL for quickly previewing the warning card.

## Test plan
- [x] Frontend lint passes
- [x] Frontend production build passes
- [x] New unit tests for i18n copy, warning parts helper, view markup, and preview URL pass
- [x] Backend test suite passes (`composer test`)
- [ ] Run `npm run dev`, then `npm run preview:mp-rejection-warning`, and open the printed URL while logged in to verify the two-paragraph warning card layout