### PR TITLE
Update carpoodatos pricing modal coordination copy

### DIFF
--- a/src/components/views/Trip.view.test.js
+++ b/src/components/views/Trip.view.test.js
@@ -48,8 +48,23 @@ describe('Trip.vue carpoodatos mesa de ayuda contact', () => {
             /showModalPricing[\s\S]*?matcheosDelViaje/
         )[0];
 
-        expect(pricingModal).toMatch(mesaAyudaLinkPattern);
+        const pricingMesaAyudaLinkPattern =
+            /<span>\{\{\s*\$t\('carpoodatosAntesConfirmarDudaLead'\)\s*\}\}<\/span>\s*<router-link\s+:to="\{\s*name:\s*'tickets'\s*\}">\{\{\s*\$t\('carpoodatosAntesConfirmarDudaLink'\)\s*\}\}<\/router-link>\{\{\s*\$t\('carpoodatosAntesConfirmarDudaTail'\)\s*\}\}/;
+
+        expect(pricingModal).toMatch(pricingMesaAyudaLinkPattern);
         expect(pricingModal).not.toContain('carpoodatosContactoRedes');
+        expect(pricingModal).not.toMatch(mesaAyudaLinkPattern);
+    });
+
+    it('lists coordination topics in the pricing carpoodatos modal', () => {
+        const pricingModal = viewSource.match(
+            /showModalPricing[\s\S]*?matcheosDelViaje/
+        )[0];
+
+        expect(pricingModal).toContain("$t('carpoodatosAntesConfirmarBullet1')");
+        expect(pricingModal).toContain("$t('carpoodatosAntesConfirmarBullet5')");
+        expect(pricingModal).toContain("$t('carpoodatosContribucionComprobantes')");
+        expect(pricingModal).toMatch(/<ul>[\s\S]*?<\/ul>/);
     });
 });
 

--- a/src/components/views/Trip.vue
+++ b/src/components/views/Trip.vue
@@ -201,12 +201,22 @@
                                         <p>
                                             {{ $t('carpoodatosAntesConfirmar') }}
                                         </p>
+                                        <ul>
+                                            <li>{{ $t('carpoodatosAntesConfirmarBullet1') }}</li>
+                                            <li>{{ $t('carpoodatosAntesConfirmarBullet2') }}</li>
+                                            <li>{{ $t('carpoodatosAntesConfirmarBullet3') }}</li>
+                                            <li>{{ $t('carpoodatosAntesConfirmarBullet4') }}</li>
+                                            <li>{{ $t('carpoodatosAntesConfirmarBullet5') }}</li>
+                                        </ul>
                                         <p>
                                             {{ $t('carpoodatosContribucionMaxima') }}
                                         </p>
                                         <p>
-                                            <span>{{ $t('mesaAyudaContactoLead') }}</span>
-                                            <router-link :to="{ name: 'tickets' }">{{ $t('mesaAyuda') }}</router-link>{{ $t('mesaAyudaContactoTail') }}
+                                            {{ $t('carpoodatosContribucionComprobantes') }}
+                                        </p>
+                                        <p>
+                                            <span>{{ $t('carpoodatosAntesConfirmarDudaLead') }}</span>
+                                            <router-link :to="{ name: 'tickets' }">{{ $t('carpoodatosAntesConfirmarDudaLink') }}</router-link>{{ $t('carpoodatosAntesConfirmarDudaTail') }}
                                         </p>
                                     </div>
                                     <div

--- a/src/language/carpoodatosPricingModal.test.js
+++ b/src/language/carpoodatosPricingModal.test.js
@@ -46,10 +46,13 @@ describe('carpoodatos pricing modal copy', () => {
     });
 
     it('en locale defines the pricing modal coordination keys', () => {
-        const keys = Object.keys(EXPECTED_COPY);
+        const keys = Object.keys(EXPECTED_COPY).filter(
+            (key) => key !== 'carpoodatosAntesConfirmarDudaTail'
+        );
 
         keys.forEach((key) => {
             expect(messages.en[key]).toBeTruthy();
         });
+        expect(messages.en.carpoodatosAntesConfirmarDudaTail).toBe('');
     });
 });

--- a/src/language/carpoodatosPricingModal.test.js
+++ b/src/language/carpoodatosPricingModal.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import messages from './i18n';
+
+const SPANISH_LOCALES = ['arg', 'chl'];
+
+const EXPECTED_COPY = {
+    carpoodatosAntesConfirmar:
+        'Antes de solicitar asiento, revisá el detalle del viaje y coordiná :',
+    carpoodatosAntesConfirmarBullet1:
+        'Punto de encuentro para la salida y la llegada.',
+    carpoodatosAntesConfirmarBullet2: 'Horario de salida.',
+    carpoodatosAntesConfirmarBullet3: 'Tamaño del equipaje.',
+    carpoodatosAntesConfirmarBullet4:
+        'Contribución para combustible y peajes.',
+    carpoodatosAntesConfirmarBullet5:
+        'Cualquier otra cuestión que consideren importante para compartir el viaje.',
+    carpoodatosContribucionMaxima:
+        'La contribución máxima es el costo del combustible y los peajes dividido por la cantidad de asientos del vehículo.',
+    carpoodatosContribucionComprobantes:
+        'Durante la coordinación previa al viaje, cualquiera de las personas participantes puede solicitar que ese cálculo se realice con los comprobantes de combustible y peajes.',
+    carpoodatosAntesConfirmarDudaLead:
+        'Si tenés alguna duda o surge algún inconveniente, ',
+    carpoodatosAntesConfirmarDudaLink: 'escribinos a la Mesa de Ayuda',
+    carpoodatosAntesConfirmarDudaTail: ''
+};
+
+describe('carpoodatos pricing modal copy', () => {
+    it.each(SPANISH_LOCALES)(
+        '%s locale uses the updated seat-request coordination copy',
+        (locale) => {
+            Object.entries(EXPECTED_COPY).forEach(([key, value]) => {
+                expect(messages[locale][key]).toBe(value);
+            });
+        }
+    );
+
+    it('does not keep the old confirm-trip intro copy in Spanish locales', () => {
+        const oldCopy =
+            'Antes de confirmar el viaje y para evitar sorpresas, tené en cuenta de coordinar y acordar el punto de encuentro, el horario, la disponibilidad de espacio para equipaje, la cantidad total de pasajeros y la contribución por los gastos de combustible y peaje.';
+
+        SPANISH_LOCALES.forEach((locale) => {
+            expect(messages[locale].carpoodatosAntesConfirmar).not.toBe(
+                oldCopy
+            );
+        });
+    });
+
+    it('en locale defines the pricing modal coordination keys', () => {
+        const keys = Object.keys(EXPECTED_COPY);
+
+        keys.forEach((key) => {
+            expect(messages.en[key]).toBeTruthy();
+        });
+    });
+});

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -1094,9 +1094,23 @@ const messages = {
         noVolverAMostrarMensaje: 'No volver a mostrar mensaje',
         solicitarAsiento: 'Solicitar asiento',
         carpoodatosAntesConfirmar:
-            'Antes de confirmar el viaje y para evitar sorpresas, tené en cuenta de coordinar y acordar el punto de encuentro, el horario, la disponibilidad de espacio para equipaje, la cantidad total de pasajeros y la contribución por los gastos de combustible y peaje.',
+            'Antes de solicitar asiento, revisá el detalle del viaje y coordiná :',
+        carpoodatosAntesConfirmarBullet1:
+            'Punto de encuentro para la salida y la llegada.',
+        carpoodatosAntesConfirmarBullet2: 'Horario de salida.',
+        carpoodatosAntesConfirmarBullet3: 'Tamaño del equipaje.',
+        carpoodatosAntesConfirmarBullet4:
+            'Contribución para combustible y peajes.',
+        carpoodatosAntesConfirmarBullet5:
+            'Cualquier otra cuestión que consideren importante para compartir el viaje.',
         carpoodatosContribucionMaxima:
-            'La contribución máxima que puede pedir un conductor es igual a gastos de combustible + peaje dividido la cantidad de personas viajando en el auto. Durante la coordinación previa al viaje, cualquier persona puede pedir hacer la división con tickets de combustible y peaje en mano.',
+            'La contribución máxima es el costo del combustible y los peajes dividido por la cantidad de asientos del vehículo.',
+        carpoodatosContribucionComprobantes:
+            'Durante la coordinación previa al viaje, cualquiera de las personas participantes puede solicitar que ese cálculo se realice con los comprobantes de combustible y peajes.',
+        carpoodatosAntesConfirmarDudaLead:
+            'Si tenés alguna duda o surge algún inconveniente, ',
+        carpoodatosAntesConfirmarDudaLink: 'escribinos a la Mesa de Ayuda',
+        carpoodatosAntesConfirmarDudaTail: '',
         matcheosDelViaje: 'Matcheos del viaje',
         viajaEl: 'Viaja el',
         mensajeParaUsuariosSeleccionados:
@@ -2467,9 +2481,23 @@ const messages = {
         enviarMensaje: 'Enviar mensaje',
         solicitarAsiento: 'Solicitar asiento',
         carpoodatosAntesConfirmar:
-            'Antes de confirmar el viaje y para evitar sorpresas, tené en cuenta de coordinar y acordar el punto de encuentro, el horario, la disponibilidad de espacio para equipaje, la cantidad total de pasajeros y la contribución por los gastos de combustible y peaje.',
+            'Antes de solicitar asiento, revisá el detalle del viaje y coordiná :',
+        carpoodatosAntesConfirmarBullet1:
+            'Punto de encuentro para la salida y la llegada.',
+        carpoodatosAntesConfirmarBullet2: 'Horario de salida.',
+        carpoodatosAntesConfirmarBullet3: 'Tamaño del equipaje.',
+        carpoodatosAntesConfirmarBullet4:
+            'Contribución para combustible y peajes.',
+        carpoodatosAntesConfirmarBullet5:
+            'Cualquier otra cuestión que consideren importante para compartir el viaje.',
         carpoodatosContribucionMaxima:
-            'La contribución máxima que puede pedir un conductor es igual a gastos de combustible + peaje dividido la cantidad de personas viajando en el auto. Durante la coordinación previa al viaje, cualquier persona puede pedir hacer la división con tickets de combustible y peaje en mano.',
+            'La contribución máxima es el costo del combustible y los peajes dividido por la cantidad de asientos del vehículo.',
+        carpoodatosContribucionComprobantes:
+            'Durante la coordinación previa al viaje, cualquiera de las personas participantes puede solicitar que ese cálculo se realice con los comprobantes de combustible y peajes.',
+        carpoodatosAntesConfirmarDudaLead:
+            'Si tenés alguna duda o surge algún inconveniente, ',
+        carpoodatosAntesConfirmarDudaLink: 'escribinos a la Mesa de Ayuda',
+        carpoodatosAntesConfirmarDudaTail: '',
         matcheosDelViaje: 'Matcheos del viaje',
         viajaEl: 'Viaja el',
         mensajeParaUsuariosSeleccionados:
@@ -4021,9 +4049,23 @@ const messages = {
         noVolverAMostrarMensaje: 'Do not show message again',
         solicitarAsiento: 'Request seat',
         carpoodatosAntesConfirmar:
-            'Before confirming the trip and to avoid surprises, make sure to coordinate and agree on the meeting point, time, luggage space availability, total number of passengers, and contribution for fuel and toll expenses.',
+            'Before requesting a seat, review the trip details and coordinate:',
+        carpoodatosAntesConfirmarBullet1:
+            'Meeting point for departure and arrival.',
+        carpoodatosAntesConfirmarBullet2: 'Departure time.',
+        carpoodatosAntesConfirmarBullet3: 'Luggage size.',
+        carpoodatosAntesConfirmarBullet4:
+            'Contribution for fuel and tolls.',
+        carpoodatosAntesConfirmarBullet5:
+            'Any other issue you consider important for sharing the trip.',
         carpoodatosContribucionMaxima:
-            'The maximum contribution a driver can request equals fuel costs + tolls divided by the number of people traveling in the car. During pre-trip coordination, anyone can request to do the division with fuel and toll receipts in hand.',
+            'The maximum contribution is the cost of fuel and tolls divided by the number of seats in the vehicle.',
+        carpoodatosContribucionComprobantes:
+            'During pre-trip coordination, any participant can request that this calculation be done with fuel and toll receipts.',
+        carpoodatosAntesConfirmarDudaLead:
+            'If you have any questions or run into any issues, ',
+        carpoodatosAntesConfirmarDudaLink: 'contact us through the Help desk',
+        carpoodatosAntesConfirmarDudaTail: '',
         matcheosDelViaje: 'Trip matches',
         viajaEl: 'Travels on',
         mensajeParaUsuariosSeleccionados: 'Message for selected users',

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -3229,7 +3229,8 @@
  }
 
   @media (max-width: 800px) {
-      .carpoodatos p {
+      .carpoodatos p,
+      .carpoodatos ul {
           font-size: 11px;
       }
       .carpoodatos {


### PR DESCRIPTION
## Summary
- Updates the pricing carpoodatos modal copy shown before sending a message to emphasize seat-request coordination topics (meeting points, schedule, luggage, contribution, etc.).
- Adds bullet list structure and refreshed contribution guidance, including the option to calculate with fuel/toll receipts.
- Links "escribinos a la Mesa de Ayuda" to the help desk tickets page, consistent with other modals.

## Test plan
- [x] `npm run test:unit -- --run src/language/carpoodatosPricingModal.test.js src/components/views/Trip.view.test.js`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Backend `composer test`
- [x] Manual: open a trip as passenger, trigger the pricing carpoodatos modal and verify copy + Mesa de Ayuda link