### PR TITLE
Show translated error when migration targets banned user

### DIFF
--- a/src/components/views/AdminUserMigrationNew.view.test.js
+++ b/src/components/views/AdminUserMigrationNew.view.test.js
@@ -122,7 +122,7 @@ describe('AdminUserMigrationNew view', () => {
 
     it('shows a translated error when migration is blocked for a banned user', () => {
         expect(source).toContain('getApiErrorMessage');
-        expect(source).toContain('errorMigracionUsuarioSuspendido');
+        expect(source).toContain("this.$t('errorMigrandoUsuarios')");
         expect(i18nSource).toContain('errorMigracionUsuarioSuspendido');
         expect(i18nSource).toContain(
             'La cuenta de {name} (ID: {id}) se encuentra suspendida por lo que no se puede realizar la migración'

--- a/src/components/views/AdminUserMigrationNew.view.test.js
+++ b/src/components/views/AdminUserMigrationNew.view.test.js
@@ -128,7 +128,7 @@ describe('AdminUserMigrationNew view', () => {
             'La cuenta de {name} (ID: {id}) se encuentra suspendida por lo que no se puede realizar la migración'
         );
         expect(i18nSource).toContain(
-            "The account of {name} (ID: {id}) is suspended so the migration cannot be performed"
+            'The account of {name} (ID: {id}) is suspended so the migration cannot be performed'
         );
     });
 });

--- a/src/components/views/AdminUserMigrationNew.view.test.js
+++ b/src/components/views/AdminUserMigrationNew.view.test.js
@@ -119,4 +119,16 @@ describe('AdminUserMigrationNew view', () => {
         expect(i18nSource).toContain(supportTicketNoticeEnglishCopy);
         expect(source).toContain("this.$t('migracionUsuarioAMantenerAvisoTicketSoporte')");
     });
+
+    it('shows a translated error when migration is blocked for a banned user', () => {
+        expect(source).toContain('getApiErrorMessage');
+        expect(source).toContain('errorMigracionUsuarioSuspendido');
+        expect(i18nSource).toContain('errorMigracionUsuarioSuspendido');
+        expect(i18nSource).toContain(
+            'La cuenta de {name} (ID: {id}) se encuentra suspendida por lo que no se puede realizar la migración'
+        );
+        expect(i18nSource).toContain(
+            "The account of {name} (ID: {id}) is suspended so the migration cannot be performed"
+        );
+    });
 });

--- a/src/components/views/AdminUserMigrationNew.vue
+++ b/src/components/views/AdminUserMigrationNew.vue
@@ -157,6 +157,7 @@ import AdminLayout from '../layouts/AdminLayout.vue';
 import UserSearchAutocomplete from '../UserSearchAutocomplete.vue';
 import { AdminApi } from '../../services/api';
 import dialogs from '../../services/dialogs.js';
+import { getApiErrorMessage } from '../../utils/apiErrors.js';
 import dayjs from '../../dayjs';
 import { mapState } from 'pinia';
 import { useAuthStore } from '../../stores/auth';
@@ -341,10 +342,17 @@ export default {
                 });
             } catch (e) {
                 console.error(e);
-                dialogs.message(this.$t('errorMigrandoUsuarios'), {
-                    estado: 'error',
-                    duration: 6
-                });
+                dialogs.message(
+                    getApiErrorMessage(
+                        e,
+                        this.$t('errorMigrandoUsuarios'),
+                        (key, params) => this.$t(key, params)
+                    ),
+                    {
+                        estado: 'error',
+                        duration: 6
+                    }
+                );
             } finally {
                 this.migrating = false;
             }

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -1419,6 +1419,8 @@ const messages = {
         neutral_ratings: 'Calificaciones neutrales',
         calificacionesNegativas: 'Calificaciones negativas',
         errorMigrandoUsuarios: 'Error al migrar usuarios',
+        errorMigracionUsuarioSuspendido:
+            'La cuenta de {name} (ID: {id}) se encuentra suspendida por lo que no se puede realizar la migración',
         migracionElegirDatos: 'Elegí qué datos conservar',
         migracionElegirDatosAyuda:
             'Hacé clic en el valor que querés usar en la cuenta final. Por defecto: email, DNI y fecha de creación de la cuenta a borrar; contraseña y teléfono de la cuenta a mantener.',
@@ -2830,6 +2832,8 @@ const messages = {
         neutral_ratings: 'Calificaciones neutrales',
         calificacionesNegativas: 'Calificaciones negativas',
         errorMigrandoUsuarios: 'Error al migrar usuarios',
+        errorMigracionUsuarioSuspendido:
+            'La cuenta de {name} (ID: {id}) se encuentra suspendida por lo que no se puede realizar la migración',
         migracionElegirDatos: 'Elegí qué datos conservar',
         migracionElegirDatosAyuda:
             'Hacé clic en el valor que querés usar en la cuenta final. Por defecto: email, DNI y fecha de creación de la cuenta a borrar; contraseña y teléfono de la cuenta a mantener.',
@@ -4371,6 +4375,8 @@ const messages = {
         neutral_ratings: 'Neutral ratings',
         calificacionesNegativas: 'Negative ratings',
         errorMigrandoUsuarios: 'Error migrating users',
+        errorMigracionUsuarioSuspendido:
+            'The account of {name} (ID: {id}) is suspended so the migration cannot be performed',
         migracionElegirDatos: 'Choose which data to keep',
         migracionElegirDatosAyuda:
             'Click the value you want on the final account. Defaults: email, ID, and creation date from the account to remove; password and phone from the account to keep.',

--- a/src/utils/apiErrors.js
+++ b/src/utils/apiErrors.js
@@ -4,8 +4,21 @@ const GENERIC_API_ERROR_MESSAGES = new Set([
 ]);
 
 const API_ERROR_I18N_KEYS = {
-    impersonation_action_forbidden: 'impersonationActionForbidden'
+    impersonation_action_forbidden: 'impersonationActionForbidden',
+    migration_banned_user: 'errorMigracionUsuarioSuspendido'
 };
+
+function extractApiErrorPayload(apiError) {
+    if (!apiError) {
+        return null;
+    }
+
+    if (apiError.data && typeof apiError.data === 'object') {
+        return apiError.data;
+    }
+
+    return null;
+}
 
 function extractApiErrorMessage(apiError) {
     if (!apiError) {
@@ -48,7 +61,15 @@ export function getApiErrorMessage(apiError, fallback, translate) {
 
     const message = extractApiErrorMessage(apiError);
     if (message) {
+        const payload = extractApiErrorPayload(apiError);
         if (translate && API_ERROR_I18N_KEYS[message]) {
+            if (message === 'migration_banned_user' && payload) {
+                return translate(API_ERROR_I18N_KEYS[message], {
+                    name: payload.user_name || '',
+                    id: payload.user_id ?? ''
+                });
+            }
+
             return translate(API_ERROR_I18N_KEYS[message]);
         }
         if (!GENERIC_API_ERROR_MESSAGES.has(message)) {

--- a/src/utils/apiErrors.test.js
+++ b/src/utils/apiErrors.test.js
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
 import { getApiErrorMessage, isOfflineApiError } from './apiErrors.js';
+
+const apiErrorsSource = fs.readFileSync(
+    path.resolve(import.meta.dirname, 'apiErrors.js'),
+    'utf8'
+);
 
 describe('api error helpers', () => {
     it('detects normalized offline API errors', () => {
@@ -61,6 +68,10 @@ describe('getApiErrorMessage', () => {
                 (key) => (key === 'impersonationActionForbidden' ? 'Acción no permitida durante suplantación.' : key)
             )
         ).toBe('Acción no permitida durante suplantación.');
+    });
+
+    it('maps migration banned user backend code to i18n key', () => {
+        expect(apiErrorsSource).toContain("migration_banned_user: 'errorMigracionUsuarioSuspendido'");
     });
 
     it('translates migration banned user error with user name and id', () => {

--- a/src/utils/apiErrors.test.js
+++ b/src/utils/apiErrors.test.js
@@ -63,6 +63,28 @@ describe('getApiErrorMessage', () => {
         ).toBe('Acción no permitida durante suplantación.');
     });
 
+    it('translates migration banned user error with user name and id', () => {
+        expect(
+            getApiErrorMessage(
+                {
+                    data: {
+                        message: 'migration_banned_user',
+                        user_name: 'Cuenta Suspendida',
+                        user_id: 42
+                    },
+                    status: 422
+                },
+                fallback,
+                (key, params) =>
+                    key === 'errorMigracionUsuarioSuspendido'
+                        ? `La cuenta de ${params.name} (ID: ${params.id}) se encuentra suspendida por lo que no se puede realizar la migración`
+                        : key
+            )
+        ).toBe(
+            'La cuenta de Cuenta Suspendida (ID: 42) se encuentra suspendida por lo que no se puede realizar la migración'
+        );
+    });
+
     it('returns raw message from nested data when no translator is provided', () => {
         expect(
             getApiErrorMessage(


### PR DESCRIPTION
## Summary
- Map backend `migration_banned_user` responses to i18n key `errorMigracionUsuarioSuspendido`
- Show admin-facing message: "La cuenta de {name} (ID: {id}) se encuentra suspendida por lo que no se puede realizar la migración"
- Use `getApiErrorMessage` in the user migration admin screen instead of a generic migration error

## Test plan
- [x] `npm run test:unit -- src/utils/apiErrors.test.js src/components/views/AdminUserMigrationNew.view.test.js`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Pair with backend PR and verify the translated error appears when migrating a banned account

