### PR TITLE
Allow foreign intermediate stops when creating trips outside Argentina

### DIFF
--- a/src/components/views/NewTrip.view.test.js
+++ b/src/components/views/NewTrip.view.test.js
@@ -5,6 +5,18 @@ import path from 'node:path';
 const viewPath = path.resolve(__dirname, 'NewTrip.vue');
 const viewSource = fs.readFileSync(viewPath, 'utf8');
 
+describe('NewTrip.vue foreign endpoints validation', () => {
+    it('validates foreign endpoints only at origin and destination', () => {
+        expect(viewSource).toContain(
+            "from '../../utils/tripForeignEndpointsValidation.js'"
+        );
+        expect(viewSource).toContain('hasTooManyForeignTripEndpoints');
+        expect(viewSource).toMatch(
+            /validate\(\)[\s\S]*?hasTooManyForeignTripEndpoints\(\s*this\.points,\s*this\.config\.osm_country/s
+        );
+    });
+});
+
 describe('NewTrip.vue negative contribution validation', () => {
     it('imports negative seat price helper and blocks negative values on save', () => {
         expect(viewSource).toMatch(/from '\.\.\/\.\.\/utils\/tripSeatPrice\.js'/);

--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -2111,6 +2111,7 @@ import {
     shouldShowTripPointDetailInputs,
     applyTripPointDetailValidation
 } from '../../utils/tripPointDetailValidation.js';
+import { hasTooManyForeignTripEndpoints } from '../../utils/tripForeignEndpointsValidation.js';
 import {
     restoreTripPointDetailsFromTrip,
     syncReturnTripPointDetailsFromOutbound
@@ -2877,7 +2878,6 @@ export default {
 
         validate() {
             let globalError = false;
-            let foreignPoints = 0;
             let validTime = false;
             let validDate = false;
             let validOtherTripTime = false;
@@ -2896,12 +2896,38 @@ export default {
                     p.error.state = true;
                     p.error.message = this.$t('localidadValida');
                     globalError = true;
-                } else {
-                    foreignPoints +=
-                        p.json.country === this.config.osm_country ? 0 : 1;
                 }
             });
-            if (foreignPoints > 1) {
+            // #region agent log
+            const outboundAllPointsForeignCount = this.points.filter(
+                (p) => p.json && p.json.country !== this.config.osm_country
+            ).length;
+            const outboundEndpointsInvalid = hasTooManyForeignTripEndpoints(
+                this.points,
+                this.config.osm_country
+            );
+            fetch('http://127.0.0.1:7606/ingest/e65c7dbd-3b9f-4cb7-9135-310a836ba96d', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Debug-Session-Id': '17ba99'
+                },
+                body: JSON.stringify({
+                    sessionId: '17ba99',
+                    location: 'NewTrip.vue:validate',
+                    message: 'outbound foreign endpoints check',
+                    data: {
+                        allPointsForeignCount: outboundAllPointsForeignCount,
+                        endpointsInvalid: outboundEndpointsInvalid,
+                        osmCountry: this.config.osm_country,
+                        pointCountries: this.points.map((p) => p.json?.country)
+                    },
+                    timestamp: Date.now(),
+                    hypothesisId: 'A'
+                })
+            }).catch(() => {});
+            // #endregion
+            if (outboundEndpointsInvalid) {
                 globalError = true;
                 this.points[0].error.state = true;
                 this.points[0].error.message = this.$t(
@@ -2910,18 +2936,45 @@ export default {
             }
 
             if (this.showReturnTrip) {
-                foreignPoints = 0;
                 this.otherTrip.points.forEach((p) => {
                     if (!p.json) {
                         p.error.state = true;
                         p.error.message = this.$t('seleccioneLocalidadValida');
                         globalError = true;
-                    } else {
-                        foreignPoints +=
-                            p.json.country === this.config.osm_country ? 0 : 1;
                     }
                 });
-                if (foreignPoints > 1) {
+                // #region agent log
+                const returnAllPointsForeignCount = this.otherTrip.points.filter(
+                    (p) => p.json && p.json.country !== this.config.osm_country
+                ).length;
+                const returnEndpointsInvalid = hasTooManyForeignTripEndpoints(
+                    this.otherTrip.points,
+                    this.config.osm_country
+                );
+                fetch('http://127.0.0.1:7606/ingest/e65c7dbd-3b9f-4cb7-9135-310a836ba96d', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-Debug-Session-Id': '17ba99'
+                    },
+                    body: JSON.stringify({
+                        sessionId: '17ba99',
+                        location: 'NewTrip.vue:validate',
+                        message: 'return foreign endpoints check',
+                        data: {
+                            allPointsForeignCount: returnAllPointsForeignCount,
+                            endpointsInvalid: returnEndpointsInvalid,
+                            osmCountry: this.config.osm_country,
+                            pointCountries: this.otherTrip.points.map(
+                                (p) => p.json?.country
+                            )
+                        },
+                        timestamp: Date.now(),
+                        hypothesisId: 'A'
+                    })
+                }).catch(() => {});
+                // #endregion
+                if (returnEndpointsInvalid) {
                     globalError = true;
                     this.otherTrip.points[0].error.state = true;
                     this.otherTrip.points[0].error.message = this.$t(

--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -2898,36 +2898,12 @@ export default {
                     globalError = true;
                 }
             });
-            // #region agent log
-            const outboundAllPointsForeignCount = this.points.filter(
-                (p) => p.json && p.json.country !== this.config.osm_country
-            ).length;
-            const outboundEndpointsInvalid = hasTooManyForeignTripEndpoints(
-                this.points,
-                this.config.osm_country
-            );
-            fetch('http://127.0.0.1:7606/ingest/e65c7dbd-3b9f-4cb7-9135-310a836ba96d', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-Debug-Session-Id': '17ba99'
-                },
-                body: JSON.stringify({
-                    sessionId: '17ba99',
-                    location: 'NewTrip.vue:validate',
-                    message: 'outbound foreign endpoints check',
-                    data: {
-                        allPointsForeignCount: outboundAllPointsForeignCount,
-                        endpointsInvalid: outboundEndpointsInvalid,
-                        osmCountry: this.config.osm_country,
-                        pointCountries: this.points.map((p) => p.json?.country)
-                    },
-                    timestamp: Date.now(),
-                    hypothesisId: 'A'
-                })
-            }).catch(() => {});
-            // #endregion
-            if (outboundEndpointsInvalid) {
+            if (
+                hasTooManyForeignTripEndpoints(
+                    this.points,
+                    this.config.osm_country
+                )
+            ) {
                 globalError = true;
                 this.points[0].error.state = true;
                 this.points[0].error.message = this.$t(
@@ -2943,38 +2919,12 @@ export default {
                         globalError = true;
                     }
                 });
-                // #region agent log
-                const returnAllPointsForeignCount = this.otherTrip.points.filter(
-                    (p) => p.json && p.json.country !== this.config.osm_country
-                ).length;
-                const returnEndpointsInvalid = hasTooManyForeignTripEndpoints(
-                    this.otherTrip.points,
-                    this.config.osm_country
-                );
-                fetch('http://127.0.0.1:7606/ingest/e65c7dbd-3b9f-4cb7-9135-310a836ba96d', {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-Debug-Session-Id': '17ba99'
-                    },
-                    body: JSON.stringify({
-                        sessionId: '17ba99',
-                        location: 'NewTrip.vue:validate',
-                        message: 'return foreign endpoints check',
-                        data: {
-                            allPointsForeignCount: returnAllPointsForeignCount,
-                            endpointsInvalid: returnEndpointsInvalid,
-                            osmCountry: this.config.osm_country,
-                            pointCountries: this.otherTrip.points.map(
-                                (p) => p.json?.country
-                            )
-                        },
-                        timestamp: Date.now(),
-                        hypothesisId: 'A'
-                    })
-                }).catch(() => {});
-                // #endregion
-                if (returnEndpointsInvalid) {
+                if (
+                    hasTooManyForeignTripEndpoints(
+                        this.otherTrip.points,
+                        this.config.osm_country
+                    )
+                ) {
                     globalError = true;
                     this.otherTrip.points[0].error.state = true;
                     this.otherTrip.points[0].error.message = this.$t(

--- a/src/utils/tripForeignEndpointsValidation.js
+++ b/src/utils/tripForeignEndpointsValidation.js
@@ -1,0 +1,23 @@
+export function isTripPointInHomeCountry(point, osmCountry) {
+    return point?.json?.country === osmCountry;
+}
+
+export function hasTooManyForeignTripEndpoints(points, osmCountry) {
+    if (!Array.isArray(points) || points.length < 2) {
+        return false;
+    }
+
+    const origin = points[0];
+    const destination = points[points.length - 1];
+    let foreignEndpoints = 0;
+
+    if (!isTripPointInHomeCountry(origin, osmCountry)) {
+        foreignEndpoints += 1;
+    }
+
+    if (!isTripPointInHomeCountry(destination, osmCountry)) {
+        foreignEndpoints += 1;
+    }
+
+    return foreignEndpoints > 1;
+}

--- a/src/utils/tripForeignEndpointsValidation.test.js
+++ b/src/utils/tripForeignEndpointsValidation.test.js
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { hasTooManyForeignTripEndpoints } from './tripForeignEndpointsValidation.js';
+
+const ARG = 'ARG';
+const URY = 'URY';
+
+function point(country) {
+    return { json: { country } };
+}
+
+describe('tripForeignEndpointsValidation', () => {
+    describe('hasTooManyForeignTripEndpoints', () => {
+        it('returns false when origin is in home country and destination is foreign', () => {
+            expect(
+                hasTooManyForeignTripEndpoints(
+                    [point(ARG), point(ARG), point(URY), point(URY)],
+                    ARG
+                )
+            ).toBe(false);
+        });
+
+        it('returns false when both endpoints are in home country with foreign intermediate stops', () => {
+            expect(
+                hasTooManyForeignTripEndpoints(
+                    [point(ARG), point(URY), point(ARG)],
+                    ARG
+                )
+            ).toBe(false);
+        });
+
+        it('returns true when both origin and destination are outside home country', () => {
+            expect(
+                hasTooManyForeignTripEndpoints([point(URY), point(URY)], ARG)
+            ).toBe(true);
+        });
+
+        it('returns false when both endpoints are in home country', () => {
+            expect(
+                hasTooManyForeignTripEndpoints([point(ARG), point(ARG)], ARG)
+            ).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Fix trip creation validation that incorrectly rejected trips with an Argentine origin, foreign intermediate stops, and a foreign destination when "Origen o destino fuera de Argentina" was enabled.
- Extract `hasTooManyForeignTripEndpoints` helper so only origin and destination count toward the home-country rule; intermediate stops are ignored.
- Add unit tests covering Rosario → Argentina → Uruguay → Uruguay and related edge cases.

## Test plan
- [x] `npm run test:unit -- --run src/utils/tripForeignEndpointsValidation.test.js`
- [x] `npm run test:unit -- --run src/components/views/NewTrip.view.test.js`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Manual: create trip with Argentine origin, Argentine + Uruguayan intermediate stops, Uruguayan destination (with foreign checkbox enabled) — succeeds without "origen o destino en Argentina" error