### PR TITLE
Add bottom margin to Continuar sin donar on donation page

### DIFF
--- a/src/components/views/DonationAfterRating.view.test.js
+++ b/src/components/views/DonationAfterRating.view.test.js
@@ -32,6 +32,15 @@ describe('DonationAfterRating page content', () => {
         expect(viewSource).toMatch(/name:\s*'trips'/);
     });
 
+    it('adds bottom spacing on the skip action so it clears the mobile tab bar', () => {
+        expect(viewSource).toMatch(
+            /donation-after-rating__skip[\s\S]*safe-area-inset-bottom/
+        );
+        expect(viewSource).toMatch(
+            /donation-after-rating__skip[\s\S]*52px/
+        );
+    });
+
     it.each(['arg', 'en'])('defines continuarSinDonar in %s locale', (locale) => {
         expect(messages[locale].continuarSinDonar).toBeTruthy();
     });

--- a/src/components/views/DonationAfterRating.vue
+++ b/src/components/views/DonationAfterRating.vue
@@ -183,6 +183,7 @@ export default {
     margin-bottom: 0.5rem;
 }
 
+/* Clear fixed .actionbar-bottom (52px + safe area) on mobile */
 .donation-after-rating__skip {
     margin-top: 1.5rem;
     margin-bottom: calc(52px + constant(safe-area-inset-bottom, 0px));

--- a/src/components/views/DonationAfterRating.vue
+++ b/src/components/views/DonationAfterRating.vue
@@ -185,5 +185,7 @@ export default {
 
 .donation-after-rating__skip {
     margin-top: 1.5rem;
+    margin-bottom: calc(52px + constant(safe-area-inset-bottom, 0px));
+    margin-bottom: calc(52px + env(safe-area-inset-bottom, 0px));
 }
 </style>


### PR DESCRIPTION
## Summary
- Adds bottom margin to the "Continuar sin donar" section on the post-rating donation page so it clears the fixed mobile tab bar (52px + safe area inset).
- Follows the same spacing pattern already used on `LiveLocationShare`.
- Adds a view test to prevent regression.

## Test plan
- [x] Unit test: `DonationAfterRating.view.test.js` passes
- [x] Frontend lint passes
- [x] Frontend production build passes
- [x] Backend test suite passes (no backend changes)