### PR TITLE
Route purged manual validation notification to upload page

### DIFF
--- a/src/components/views/Notifications.view.test.js
+++ b/src/components/views/Notifications.view.test.js
@@ -36,7 +36,7 @@ describe('Notifications view', () => {
         expect(viewSource).toContain("case 'identity_validation_manual':");
         expect(viewSource).toContain("name: 'identity_validation_manual'");
         expect(viewSource).toContain('request_id: n.extras.request_id');
-        expect(viewSource).toContain("resubmit: n.extras.resubmit");
+        expect(viewSource).toContain('resubmit: n.extras.resubmit');
     });
 
     it('routes friend trip alert notifications through trip detail resolver', () => {

--- a/src/components/views/Notifications.view.test.js
+++ b/src/components/views/Notifications.view.test.js
@@ -32,6 +32,13 @@ describe('Notifications view', () => {
         expect(viewSource).toContain("name: 'identity_validation'");
     });
 
+    it('routes identity_validation_manual notifications to manual validation upload page', () => {
+        expect(viewSource).toContain("case 'identity_validation_manual':");
+        expect(viewSource).toContain("name: 'identity_validation_manual'");
+        expect(viewSource).toContain('request_id: n.extras.request_id');
+        expect(viewSource).toContain("resubmit: n.extras.resubmit");
+    });
+
     it('routes friend trip alert notifications through trip detail resolver', () => {
         expect(viewSource).toContain(
             "import { resolveTripDetailRoute } from '../../utils/notificationNavigation.js'"

--- a/src/components/views/Notifications.vue
+++ b/src/components/views/Notifications.vue
@@ -201,6 +201,15 @@ export default {
                     case 'identity_validation':
                         router.push({ name: 'identity_validation' });
                         break;
+                    case 'identity_validation_manual':
+                        router.push({
+                            name: 'identity_validation_manual',
+                            query: {
+                                request_id: n.extras.request_id,
+                                resubmit: n.extras.resubmit
+                            }
+                        });
+                        break;
                     case 'announcement':
                         // open external url
                         if (n.extras.external_url) {


### PR DESCRIPTION
## Summary
- Handles `identity_validation_manual` notification type in the notifications list
- Routes users to the manual validation upload page with `request_id` and `resubmit=1` query params when photos were auto-purged after rejection

## Test plan
- [x] `npm run test:unit` for Notifications view test
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] Tap a "photos purged" notification and confirm it opens the manual validation upload flow