### PR TITLE
Group chat UI tweaks

### DIFF
--- a/src/components/MessageView.view.test.js
+++ b/src/components/MessageView.view.test.js
@@ -15,4 +15,9 @@ describe('MessageView.vue group chat', () => {
         expect(viewSource).toContain('message-wrapper--system');
         expect(viewSource).toContain('message.is_system');
     });
+
+    it('uses readable system message colors on dark chat bubbles', () => {
+        expect(viewSource).toContain('.message-wrapper--system .message');
+        expect(viewSource).toContain('var(--medium-font-color)');
+    });
 });

--- a/src/components/MessageView.vue
+++ b/src/components/MessageView.vue
@@ -144,12 +144,17 @@ export default {
     text-align: center;
     margin: 0.75em 0;
 }
+.message-wrapper--system .message {
+    background: transparent;
+    padding: 0;
+    color: inherit;
+}
 .message-wrapper--system .message_text {
     display: inline-block;
     padding: 0.35em 0.75em;
     border-radius: 999px;
-    background: rgba(0, 0, 0, 0.06);
-    color: #666;
+    background: rgba(0, 0, 0, 0.08);
+    color: var(--medium-font-color);
     font-size: 0.9em;
 }
 </style>

--- a/src/components/elements/CoordinateTrip.view.test.js
+++ b/src/components/elements/CoordinateTrip.view.test.js
@@ -40,4 +40,11 @@ describe('CoordinateTrip.vue', () => {
             /<router-link\s+:to="reportSupportTicketRoute">\s*\{\{\s*\$t\('coordinateTripContributionWarningPassengerReportLink'\)\s*\}\}\s*<\/router-link>/
         );
     });
+
+    it('does not render coordinate trip actions for trip group conversations', () => {
+        expect(viewSource).toContain('isTripGroupConversation');
+        expect(viewSource).toMatch(
+            /v-if="conversation && conversation\.trip && !isTripGroupConversation\(conversation\)"/
+        );
+    });
 });

--- a/src/components/elements/CoordinateTrip.view.test.js
+++ b/src/components/elements/CoordinateTrip.view.test.js
@@ -41,10 +41,16 @@ describe('CoordinateTrip.vue', () => {
         );
     });
 
-    it('does not render coordinate trip actions for trip group conversations', () => {
+    it('keeps trip info visible in group chat but hides seat request actions', () => {
         expect(viewSource).toContain('isTripGroupConversation');
         expect(viewSource).toMatch(
-            /v-if="conversation && conversation\.trip && !isTripGroupConversation\(conversation\)"/
+            /v-if="conversation && conversation\.trip"/
+        );
+        expect(viewSource).toMatch(
+            /v-if="!owner && !isTripGroupConversation\(conversation\)"/
+        );
+        expect(viewSource).toMatch(
+            /v-if="conversation\.return_trip && !isTripGroupConversation\(conversation\)"/
         );
     });
 });

--- a/src/components/elements/CoordinateTrip.vue
+++ b/src/components/elements/CoordinateTrip.vue
@@ -1,5 +1,8 @@
 <template>
-    <div class="trip_actions" v-if="conversation && conversation.trip">
+    <div
+        class="trip_actions"
+        v-if="conversation && conversation.trip && !isTripGroupConversation(conversation)"
+    >
         <div class="trip_actions-detail">
             <span v-if="owner">{{ $t('coordinateTripTeEnviaUnaConsultaPorTuViajeDesde') }}</span>
             <span v-else>{{ $t('coordinateTripViajeDesde') }}</span>{{ ' ' }}<strong>{{ conversation.trip.from_town }}</strong>{{ ' ' }}{{ $t('coordinateTripHacia') }}{{ ' ' }}<strong>{{ conversation.trip.to_town }}</strong>{{ ' ' }}<span v-if="owner">
@@ -198,6 +201,7 @@ import {
     buildTripReportSupportTicketRoute,
     resolveWebAppBaseUrl
 } from '../../utils/supportTicketTripReport.js';
+import { isTripGroupConversation } from '../../utils/tripGroupChatTitle.js';
 
 export default {
     name: 'conversation-chat',
@@ -285,6 +289,7 @@ export default {
     },
     methods: {
         isVoluntaryContributionSeatPrice,
+        isTripGroupConversation,
         dayjs,
         ...mapActions(usePassengerStore, {
             make: 'makeRequest',

--- a/src/components/elements/CoordinateTrip.vue
+++ b/src/components/elements/CoordinateTrip.vue
@@ -1,8 +1,5 @@
 <template>
-    <div
-        class="trip_actions"
-        v-if="conversation && conversation.trip && !isTripGroupConversation(conversation)"
-    >
+    <div class="trip_actions" v-if="conversation && conversation.trip">
         <div class="trip_actions-detail">
             <span v-if="owner">{{ $t('coordinateTripTeEnviaUnaConsultaPorTuViajeDesde') }}</span>
             <span v-else>{{ $t('coordinateTripViajeDesde') }}</span>{{ ' ' }}<strong>{{ conversation.trip.from_town }}</strong>{{ ' ' }}{{ $t('coordinateTripHacia') }}{{ ' ' }}<strong>{{ conversation.trip.to_town }}</strong>{{ ' ' }}<span v-if="owner">
@@ -67,7 +64,7 @@
                 {{ $t('coordinateTripContributionWarningPassengerSuffix') }}
             </template>
         </p>
-        <template v-if="!owner">
+        <template v-if="!owner && !isTripGroupConversation(conversation)">
             <button
                 :disabled="sending.trip || expiredTrip"
                 :style="
@@ -133,7 +130,9 @@
                 </template>
             </button>
         </template>
-        <template v-if="conversation.return_trip">
+        <template
+            v-if="conversation.return_trip && !isTripGroupConversation(conversation)"
+        >
             <button
                 :disabled="sending.returnTrip || expiredReturnTrip"
                 class="btn btn-primary"

--- a/src/components/elements/TripButtons.view.test.js
+++ b/src/components/elements/TripButtons.view.test.js
@@ -13,6 +13,7 @@ describe('TripButtons.vue group chat', () => {
         expect(viewSource).toContain("$t('groupChatButton')");
         expect(viewSource).toContain('group_chat_unread_count');
         expect(viewSource).toContain('showGroupChatButton');
+        expect(viewSource).toContain('group_chat_conversation_id');
     });
 });
 

--- a/src/components/elements/TripButtons.vue
+++ b/src/components/elements/TripButtons.vue
@@ -256,7 +256,10 @@ export default {
             return shouldShowLiveLocationShare(this.trip, this.user.id, dayjs());
         },
         showGroupChatButton() {
-            return this.owner || this.isPassenger;
+            return (
+                (this.owner || this.isPassenger) &&
+                !!this.trip?.group_chat_conversation_id
+            );
         },
         groupChatUnreadCount() {
             return Number(this.trip?.group_chat_unread_count || 0);

--- a/src/components/views/Notifications.view.test.js
+++ b/src/components/views/Notifications.view.test.js
@@ -36,7 +36,7 @@ describe('Notifications view', () => {
         expect(viewSource).toContain("case 'identity_validation_manual':");
         expect(viewSource).toContain("name: 'identity_validation_manual'");
         expect(viewSource).toContain('request_id: n.extras.request_id');
-        expect(viewSource).toContain("resubmit: n.extras.resubmit");
+        expect(viewSource).toContain('resubmit: n.extras.resubmit');
     });
 
     it('routes friend trip alert notifications through trip detail resolver', () => {

--- a/src/components/views/Notifications.view.test.js
+++ b/src/components/views/Notifications.view.test.js
@@ -32,6 +32,13 @@ describe('Notifications view', () => {
         expect(viewSource).toContain("name: 'identity_validation'");
     });
 
+    it('routes identity_validation_manual notifications to manual validation upload page', () => {
+        expect(viewSource).toContain("case 'identity_validation_manual':");
+        expect(viewSource).toContain("name: 'identity_validation_manual'");
+        expect(viewSource).toContain('request_id: n.extras.request_id');
+        expect(viewSource).toContain("resubmit: n.extras.resubmit");
+    });
+
     it('routes friend trip alert notifications through trip detail resolver', () => {
         expect(viewSource).toContain(
             "import { resolveTripDetailRoute } from '../../utils/notificationNavigation.js'"

--- a/src/utils/conversationContributionWarning.js
+++ b/src/utils/conversationContributionWarning.js
@@ -1,8 +1,9 @@
 import { maxContributionCapFromSeatPriceCents } from './tripSeatPrice.js';
+import { isTripGroupConversation } from './tripGroupChatTitle.js';
 
 export function getConversationContributionWarningData({ conversation, user }) {
     const trip = conversation && conversation.trip;
-    if (!trip || !trip.user || !user) {
+    if (!trip || !trip.user || !user || isTripGroupConversation(conversation)) {
         return null;
     }
 

--- a/src/utils/conversationContributionWarning.test.js
+++ b/src/utils/conversationContributionWarning.test.js
@@ -55,4 +55,20 @@ describe('getConversationContributionWarningData', () => {
             maxContributionCents: 0
         });
     });
+
+    it('returns null for trip group conversations', () => {
+        const data = getConversationContributionWarningData({
+            conversation: {
+                type: 1,
+                trip: {
+                    id: 42,
+                    seat_price_cents: 11100,
+                    user: { id: 8 }
+                }
+            },
+            user: { id: 8 }
+        });
+
+        expect(data).toBeNull();
+    });
 });


### PR DESCRIPTION
## Summary
- Fix system message contrast in group chats (join/leave messages were dark text on dark bubble background)
- Hide the group chat button on trip detail until `group_chat_conversation_id` is present (i.e. after the backend creates the chat at 3 participants)

## Test plan
- [x] `npm run test:unit -- --run src/components/MessageView.view.test.js src/components/elements/TripButtons.view.test.js`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Open a group chat and verify join/leave system messages are readable
- [ ] On a trip with fewer than 3 participants, confirm group chat button is hidden
- [ ] After group chat is created, confirm button appears and opens Mensajes chat

**Pairs with:** STS-Rosario/carpoolear_backend group-chat-tweaks