### PR TITLE
Add admin list pagination (frontend)

### DIFF
--- a/src/components/AdminPaginationBar.view.test.js
+++ b/src/components/AdminPaginationBar.view.test.js
@@ -13,11 +13,12 @@ describe('AdminPaginationBar component', () => {
         expect(componentSource).toContain("emit('update:perPage'");
     });
 
-    it('renders prev/next pager controls when multiple pages exist', () => {
-        expect(componentSource).toContain('pagination.total_pages > 1');
+    it('renders pager before per-page selector so pagination stays on the left', () => {
+        const pagerIndex = componentSource.indexOf('admin-pagination-bar__pager');
+        const perPageIndex = componentSource.indexOf('admin-pagination-bar__per-page');
+        expect(pagerIndex).toBeGreaterThan(-1);
+        expect(perPageIndex).toBeGreaterThan(pagerIndex);
         expect(componentSource).toContain("{{ $t('anterior') }}");
         expect(componentSource).toContain("{{ $t('siguiente') }}");
-        expect(componentSource).toContain("emit('prev')");
-        expect(componentSource).toContain("emit('next')");
     });
 });

--- a/src/components/AdminPaginationBar.view.test.js
+++ b/src/components/AdminPaginationBar.view.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const componentPath = path.resolve(__dirname, 'AdminPaginationBar.vue');
+const componentSource = fs.readFileSync(componentPath, 'utf8');
+
+describe('AdminPaginationBar component', () => {
+    it('renders per-page selector with allowed options', () => {
+        expect(componentSource).toContain("{{ $t('adminItemsPerPage') }}");
+        expect(componentSource).toContain('ADMIN_PER_PAGE_OPTIONS');
+        expect(componentSource).toContain('@change="onPerPageChange"');
+        expect(componentSource).toContain("emit('update:perPage'");
+    });
+
+    it('renders prev/next pager controls when multiple pages exist', () => {
+        expect(componentSource).toContain('pagination.total_pages > 1');
+        expect(componentSource).toContain("{{ $t('anterior') }}");
+        expect(componentSource).toContain("{{ $t('siguiente') }}");
+        expect(componentSource).toContain("emit('prev')");
+        expect(componentSource).toContain("emit('next')");
+    });
+});

--- a/src/components/AdminPaginationBar.vue
+++ b/src/components/AdminPaginationBar.vue
@@ -3,26 +3,6 @@
         v-if="pagination"
         class="admin-pagination-bar"
     >
-        <div class="admin-pagination-bar__per-page">
-            <label :for="perPageSelectId" class="admin-pagination-bar__per-page-label">
-                {{ $t('adminItemsPerPage') }}
-            </label>
-            <select
-                :id="perPageSelectId"
-                class="form-control input-sm admin-pagination-bar__per-page-select"
-                :value="perPage"
-                :disabled="loading"
-                @change="onPerPageChange"
-            >
-                <option
-                    v-for="option in perPageOptions"
-                    :key="option"
-                    :value="option"
-                >
-                    {{ option }}
-                </option>
-            </select>
-        </div>
         <div
             v-if="pagination.total_pages > 1"
             class="admin-pagination-bar__pager"
@@ -51,6 +31,26 @@
             >
                 {{ $t('siguiente') }}
             </button>
+        </div>
+        <div class="admin-pagination-bar__per-page">
+            <label :for="perPageSelectId" class="admin-pagination-bar__per-page-label">
+                {{ $t('adminItemsPerPage') }}
+            </label>
+            <select
+                :id="perPageSelectId"
+                class="form-control input-sm admin-pagination-bar__per-page-select"
+                :value="perPage"
+                :disabled="loading"
+                @change="onPerPageChange"
+            >
+                <option
+                    v-for="option in perPageOptions"
+                    :key="option"
+                    :value="option"
+                >
+                    {{ option }}
+                </option>
+            </select>
         </div>
     </div>
 </template>
@@ -110,6 +110,7 @@ export default {
     display: flex;
     align-items: center;
     gap: 8px;
+    margin-left: auto;
 }
 
 .admin-pagination-bar__per-page-label {

--- a/src/components/AdminPaginationBar.vue
+++ b/src/components/AdminPaginationBar.vue
@@ -56,7 +56,7 @@
 </template>
 
 <script>
-import { ADMIN_PER_PAGE_OPTIONS } from '../../utils/adminPagination';
+import { ADMIN_PER_PAGE_OPTIONS } from '../utils/adminPagination';
 
 let nextPerPageSelectId = 0;
 

--- a/src/components/AdminPaginationBar.vue
+++ b/src/components/AdminPaginationBar.vue
@@ -102,6 +102,8 @@ export default {
     justify-content: space-between;
     gap: 12px;
     margin-top: 12px;
+    width: 100%;
+    min-width: min(100%, 20rem);
 }
 
 .admin-pagination-bar__per-page {
@@ -123,14 +125,16 @@ export default {
 
 .admin-pagination-bar__pager {
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     align-items: center;
     gap: 8px;
+    flex-shrink: 0;
 }
 
 .admin-pagination-bar__pager-label {
-    flex: 1;
+    flex: 0 1 auto;
     text-align: center;
     font-size: 12px;
+    white-space: nowrap;
 }
 </style>

--- a/src/components/AdminPaginationBar.vue
+++ b/src/components/AdminPaginationBar.vue
@@ -1,0 +1,136 @@
+<template>
+    <div
+        v-if="pagination"
+        class="admin-pagination-bar"
+    >
+        <div class="admin-pagination-bar__per-page">
+            <label :for="perPageSelectId" class="admin-pagination-bar__per-page-label">
+                {{ $t('adminItemsPerPage') }}
+            </label>
+            <select
+                :id="perPageSelectId"
+                class="form-control input-sm admin-pagination-bar__per-page-select"
+                :value="perPage"
+                :disabled="loading"
+                @change="onPerPageChange"
+            >
+                <option
+                    v-for="option in perPageOptions"
+                    :key="option"
+                    :value="option"
+                >
+                    {{ option }}
+                </option>
+            </select>
+        </div>
+        <div
+            v-if="pagination.total_pages > 1"
+            class="admin-pagination-bar__pager"
+        >
+            <button
+                type="button"
+                class="btn btn-default btn-sm"
+                :disabled="loading || pagination.current_page <= 1"
+                @click="$emit('prev')"
+            >
+                {{ $t('anterior') }}
+            </button>
+            <span class="admin-pagination-bar__pager-label text-muted">
+                {{
+                    $t('adminUsuariosPagina', {
+                        current: pagination.current_page,
+                        total: pagination.total_pages
+                    })
+                }}
+            </span>
+            <button
+                type="button"
+                class="btn btn-default btn-sm"
+                :disabled="loading || pagination.current_page >= pagination.total_pages"
+                @click="$emit('next')"
+            >
+                {{ $t('siguiente') }}
+            </button>
+        </div>
+    </div>
+</template>
+
+<script>
+import { ADMIN_PER_PAGE_OPTIONS } from '../../utils/adminPagination';
+
+let nextPerPageSelectId = 0;
+
+export default {
+    name: 'AdminPaginationBar',
+    props: {
+        pagination: {
+            type: Object,
+            default: null
+        },
+        perPage: {
+            type: Number,
+            default: 20
+        },
+        loading: {
+            type: Boolean,
+            default: false
+        }
+    },
+    emits: ['prev', 'next', 'update:perPage'],
+    data() {
+        nextPerPageSelectId += 1;
+
+        return {
+            perPageOptions: ADMIN_PER_PAGE_OPTIONS,
+            perPageSelectId: `admin-per-page-${nextPerPageSelectId}`
+        };
+    },
+    methods: {
+        onPerPageChange(event) {
+            const value = parseInt(event.target.value, 10);
+            this.$emit('update:perPage', value);
+        }
+    }
+};
+</script>
+
+<style scoped>
+.admin-pagination-bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-top: 12px;
+}
+
+.admin-pagination-bar__per-page {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.admin-pagination-bar__per-page-label {
+    margin: 0;
+    font-size: 12px;
+    font-weight: normal;
+}
+
+.admin-pagination-bar__per-page-select {
+    width: auto;
+    min-width: 72px;
+}
+
+.admin-pagination-bar__pager {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+}
+
+.admin-pagination-bar__pager-label {
+    flex: 1;
+    text-align: center;
+    font-size: 12px;
+}
+</style>

--- a/src/components/layouts/AdminLayout.view.test.js
+++ b/src/components/layouts/AdminLayout.view.test.js
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const layoutPath = path.resolve(__dirname, 'AdminLayout.vue');
+const layoutSource = fs.readFileSync(layoutPath, 'utf8');
+
+describe('AdminLayout', () => {
+    it('allows horizontal scrolling in the main admin content area', () => {
+        expect(layoutSource).toContain('admin-layout-content');
+        expect(layoutSource).toContain('overflow-x: auto');
+        expect(layoutSource).toContain('min-width: 0');
+    });
+});

--- a/src/components/layouts/AdminLayout.vue
+++ b/src/components/layouts/AdminLayout.vue
@@ -25,6 +25,10 @@ export default {
 <style scoped>
 .admin-layout-content {
     margin-top: 72px;
+    min-width: 0;
+    max-width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
 }
 
 @media (max-width: 767px) {

--- a/src/components/views/AdminManualIdentityValidations.view.test.js
+++ b/src/components/views/AdminManualIdentityValidations.view.test.js
@@ -23,10 +23,10 @@ describe('AdminManualIdentityValidations view', () => {
         expect(viewSource).toContain('show_resolved');
     });
 
-    it('filters the displayed list using resolved-case helpers', () => {
-        expect(viewSource).toContain('filterManualIdentityValidationsList');
+    it('reloads list from API when show-resolved preference changes', () => {
         expect(viewSource).toContain('getShowResolvedManualIdentityValidations');
         expect(viewSource).toContain('saveShowResolvedManualIdentityValidations');
+        expect(viewSource).toContain('show_resolved');
         expect(viewSource).toContain(':data="displayedList"');
         expect(viewSource).toContain('v-for="item in displayedList"');
     });

--- a/src/components/views/AdminManualIdentityValidations.view.test.js
+++ b/src/components/views/AdminManualIdentityValidations.view.test.js
@@ -17,6 +17,12 @@ describe('AdminManualIdentityValidations view', () => {
         expect(viewSource.indexOf('mostrarResueltos')).toBeLessThan(viewSource.indexOf('<table'));
     });
 
+    it('renders admin pagination bar with per-page selector', () => {
+        expect(viewSource).toContain('AdminPaginationBar');
+        expect(viewSource).toContain('getManualIdentityValidations');
+        expect(viewSource).toContain('show_resolved');
+    });
+
     it('filters the displayed list using resolved-case helpers', () => {
         expect(viewSource).toContain('filterManualIdentityValidationsList');
         expect(viewSource).toContain('getShowResolvedManualIdentityValidations');

--- a/src/components/views/AdminManualIdentityValidations.vue
+++ b/src/components/views/AdminManualIdentityValidations.vue
@@ -75,6 +75,15 @@
                         <p>{{ $t('cargando') }}</p>
                     </div></template>
                 </Loading>
+                <AdminPaginationBar
+                    v-if="listMeta && listMeta.pagination"
+                    :pagination="listMeta.pagination"
+                    :per-page="listPerPage"
+                    :loading="list === null"
+                    @prev="goPrevPage"
+                    @next="goNextPage"
+                    @update:per-page="onPerPageChange"
+                />
             </div>
         </div>
     </AdminLayout>
@@ -82,17 +91,18 @@
 
 <script>
 import AdminLayout from '../layouts/AdminLayout.vue';
+import AdminPaginationBar from '../AdminPaginationBar.vue';
 import Loading from '../Loading';
 import { AdminApi } from '../../services/api';
 import { getAdminUserProfileRoute } from '../../utils/adminProfileRoute';
 import {
-    filterManualIdentityValidationsList,
     getNextManualIdentityValidationSortState,
     getShowResolvedManualIdentityValidations,
     MANUAL_IDENTITY_VALIDATION_SORT_COLUMNS,
     saveShowResolvedManualIdentityValidations,
     sortManualIdentityValidationsList
 } from '../../utils/adminManualIdentityValidationsList';
+import { DEFAULT_ADMIN_PER_PAGE } from '../../utils/adminPagination';
 import {
     formatManualIdentityValidationWaitingTime,
     getManualIdentityValidationStatusBadgeClass,
@@ -104,6 +114,9 @@ export default {
     data() {
         return {
             list: null,
+            listMeta: null,
+            listPage: 1,
+            listPerPage: DEFAULT_ADMIN_PER_PAGE,
             showResolved: getShowResolvedManualIdentityValidations(),
             sortKey: null,
             sortDir: 'asc',
@@ -116,14 +129,14 @@ export default {
                 return this.list;
             }
 
-            const filtered = filterManualIdentityValidationsList(this.list, this.showResolved);
-
-            return sortManualIdentityValidationsList(filtered, this.sortKey, this.sortDir);
+            return sortManualIdentityValidationsList(this.list, this.sortKey, this.sortDir);
         }
     },
     watch: {
         showResolved(value) {
             saveShowResolvedManualIdentityValidations(value);
+            this.listPage = 1;
+            this.fetchList();
         }
     },
     methods: {
@@ -158,12 +171,41 @@ export default {
         },
         fetchList() {
             const api = new AdminApi();
-            return api.getManualIdentityValidations().then((res) => {
-                const data = res.data || res;
-                this.list = Array.isArray(data) ? data : (data.data || []);
+            const params = {
+                page: this.listPage,
+                per_page: this.listPerPage
+            };
+            if (this.showResolved) {
+                params.show_resolved = '1';
+            }
+            return api.getManualIdentityValidations(params).then((res) => {
+                this.list = res.data || [];
+                this.listMeta = res.meta || null;
             }).catch(() => {
                 this.list = [];
+                this.listMeta = null;
             });
+        },
+        goPrevPage() {
+            const pagination = this.listMeta && this.listMeta.pagination;
+            if (!pagination || pagination.current_page <= 1) {
+                return;
+            }
+            this.listPage = pagination.current_page - 1;
+            this.fetchList();
+        },
+        goNextPage() {
+            const pagination = this.listMeta && this.listMeta.pagination;
+            if (!pagination || pagination.current_page >= pagination.total_pages) {
+                return;
+            }
+            this.listPage = pagination.current_page + 1;
+            this.fetchList();
+        },
+        onPerPageChange(perPage) {
+            this.listPerPage = perPage;
+            this.listPage = 1;
+            this.fetchList();
         }
     },
     mounted() {
@@ -171,6 +213,7 @@ export default {
     },
     components: {
         AdminLayout,
+        AdminPaginationBar,
         Loading
     }
 };

--- a/src/components/views/AdminManualIdentityValidations.vue
+++ b/src/components/views/AdminManualIdentityValidations.vue
@@ -10,6 +10,7 @@
                     </label>
                 </div>
                 <Loading :data="displayedList">
+                    <div class="table-responsive">
                     <table class="table table-hover table-bordered">
                         <thead>
                             <tr>
@@ -67,6 +68,7 @@
                             </tr>
                         </tbody>
                     </table>
+                    </div>
                     <template #no-data><div class="text-center" style="margin-top: 20px;">
                         <div class="alert alert-info">{{ $t('noHayValidacionesManuales') }}</div>
                     </div></template>

--- a/src/components/views/AdminMpRejectedValidations.view.test.js
+++ b/src/components/views/AdminMpRejectedValidations.view.test.js
@@ -6,6 +6,11 @@ const viewPath = path.resolve(__dirname, 'AdminMpRejectedValidations.vue');
 const viewSource = fs.readFileSync(viewPath, 'utf8');
 
 describe('AdminMpRejectedValidations view', () => {
+    it('renders admin pagination bar with per-page selector', () => {
+        expect(viewSource).toContain('AdminPaginationBar');
+        expect(viewSource).toContain('getMercadoPagoRejectedValidations');
+    });
+
     it('links user profile action to the admin user profile route', () => {
         expect(viewSource).toContain('getAdminUserProfileRoute');
         expect(viewSource).not.toContain("name: 'profile'");

--- a/src/components/views/AdminMpRejectedValidations.vue
+++ b/src/components/views/AdminMpRejectedValidations.vue
@@ -56,6 +56,15 @@
                         <p>{{ $t('cargando') }}</p>
                     </div></template>
                 </Loading>
+                <AdminPaginationBar
+                    v-if="listMeta && listMeta.pagination"
+                    :pagination="listMeta.pagination"
+                    :per-page="listPerPage"
+                    :loading="list === null"
+                    @prev="goPrevPage"
+                    @next="goNextPage"
+                    @update:per-page="onPerPageChange"
+                />
             </div>
         </div>
     </AdminLayout>
@@ -64,11 +73,13 @@
 <script>
 import { mapState } from 'pinia';
 import AdminLayout from '../layouts/AdminLayout.vue';
+import AdminPaginationBar from '../AdminPaginationBar.vue';
 import Loading from '../Loading';
 import { useAuthStore } from '../../stores/auth';
 import { AdminApi } from '../../services/api';
 import { getAdminUserProfileRoute } from '../../utils/adminProfileRoute';
 import { displayDniOrDash as formatDisplayDniOrDash } from '../../utils/formatDisplayDni';
+import { DEFAULT_ADMIN_PER_PAGE } from '../../utils/adminPagination';
 
 export default {
     name: 'AdminMpRejectedValidations',
@@ -79,7 +90,10 @@ export default {
     },
     data() {
         return {
-            list: null
+            list: null,
+            listMeta: null,
+            listPage: 1,
+            listPerPage: DEFAULT_ADMIN_PER_PAGE
         };
     },
     methods: {
@@ -103,12 +117,37 @@ export default {
         },
         fetchList() {
             const api = new AdminApi();
-            return api.getMercadoPagoRejectedValidations().then((res) => {
-                const data = res.data || res;
-                this.list = Array.isArray(data) ? data : (data.data || []);
+            return api.getMercadoPagoRejectedValidations({
+                page: this.listPage,
+                per_page: this.listPerPage
+            }).then((res) => {
+                this.list = res.data || [];
+                this.listMeta = res.meta || null;
             }).catch(() => {
                 this.list = [];
+                this.listMeta = null;
             });
+        },
+        goPrevPage() {
+            const pagination = this.listMeta && this.listMeta.pagination;
+            if (!pagination || pagination.current_page <= 1) {
+                return;
+            }
+            this.listPage = pagination.current_page - 1;
+            this.fetchList();
+        },
+        goNextPage() {
+            const pagination = this.listMeta && this.listMeta.pagination;
+            if (!pagination || pagination.current_page >= pagination.total_pages) {
+                return;
+            }
+            this.listPage = pagination.current_page + 1;
+            this.fetchList();
+        },
+        onPerPageChange(perPage) {
+            this.listPerPage = perPage;
+            this.listPage = 1;
+            this.fetchList();
         }
     },
     mounted() {
@@ -116,6 +155,7 @@ export default {
     },
     components: {
         AdminLayout,
+        AdminPaginationBar,
         Loading
     }
 };

--- a/src/components/views/AdminMpRejectedValidations.vue
+++ b/src/components/views/AdminMpRejectedValidations.vue
@@ -4,6 +4,7 @@
             <div class="col-md-22 col-md-offset-1">
                 <h2>{{ $t('rechazosMercadoPago') }}</h2>
                 <Loading :data="list">
+                    <div class="table-responsive">
                     <table class="table table-hover table-bordered">
                         <thead>
                             <tr>
@@ -48,6 +49,7 @@
                             </tr>
                         </tbody>
                     </table>
+                    </div>
                     <template #no-data><div class="text-center" style="margin-top: 20px;">
                         <div class="alert alert-info">{{ $t('noHayRechazosMp') }}</div>
                     </div></template>

--- a/src/components/views/AdminSupportTickets.view.test.js
+++ b/src/components/views/AdminSupportTickets.view.test.js
@@ -98,6 +98,13 @@ describe('AdminSupportTickets view', () => {
         expect(viewSource).toContain("{{ $t('filtroTicketsRequiereRespuesta') }}");
     });
 
+    it('renders admin pagination bar with per-page selector', () => {
+        expect(viewSource).toContain('AdminPaginationBar');
+        expect(viewSource).toContain(':pagination="listPagination"');
+        expect(viewSource).toContain(':per-page="listPerPage"');
+        expect(viewSource).toContain('@update:per-page="onPerPageChange"');
+    });
+
     it('loads admin list using route query filters', () => {
         expect(viewSource).toContain('parseAdminSupportTicketListFiltersFromRoute');
         expect(viewSource).toContain('fetchAdminList(this.listFilters)');

--- a/src/components/views/AdminSupportTickets.vue
+++ b/src/components/views/AdminSupportTickets.vue
@@ -93,12 +93,22 @@
                 </tbody>
             </table>
         </div>
+        <AdminPaginationBar
+            v-if="!loading && listPagination"
+            :pagination="listPagination"
+            :per-page="listPerPage"
+            :loading="loading"
+            @prev="goPrevPage"
+            @next="goNextPage"
+            @update:per-page="onPerPageChange"
+        />
     </AdminLayout>
 </template>
 
 <script>
 import { mapActions, mapState } from 'pinia';
 import AdminLayout from '../layouts/AdminLayout.vue';
+import AdminPaginationBar from '../AdminPaginationBar.vue';
 import { useTicketsStore } from '../../stores/tickets';
 import dayjs from '../../dayjs';
 import { TICKET_TYPE_LABEL_KEYS, TICKET_PRIORITY_LABEL_KEYS } from '../../utils/supportTicketLabels';
@@ -113,6 +123,7 @@ import {
 import { getUpdatedAgeAttentionClass, hasUnreadUserReplyIndicator } from '../../utils/supportTicketUpdatedAgeAttention';
 import { assignedAdminDisplayName } from '../../utils/adminSupportTicketAssignment';
 import { getAdminUserProfileRoute } from '../../utils/adminProfileRoute';
+import { DEFAULT_ADMIN_PER_PAGE } from '../../utils/adminPagination';
 
 const ticketTypeOptions = USER_TICKET_TYPE_OPTIONS;
 
@@ -126,23 +137,31 @@ export default {
             filterPriority: '',
             filterNeedsReply: false,
             filterUserId: null,
+            listPage: 1,
+            listPerPage: DEFAULT_ADMIN_PER_PAGE,
             ticketTypeOptions,
             listPollTimer: null
         };
     },
     computed: {
         ...mapState(useTicketsStore, {
-            tickets: 'adminList'
+            tickets: 'adminList',
+            listMeta: 'adminListMeta'
         }),
         safeTickets() {
             return Array.isArray(this.tickets) ? this.tickets : [];
+        },
+        listPagination() {
+            return this.listMeta && this.listMeta.pagination ? this.listMeta.pagination : null;
         },
         listFilters() {
             return {
                 type: this.filterType,
                 priority: this.filterPriority,
                 needsReply: this.filterNeedsReply,
-                userId: this.filterUserId
+                userId: this.filterUserId,
+                page: this.listPage,
+                perPage: this.listPerPage
             };
         }
     },
@@ -166,6 +185,8 @@ export default {
             this.filterPriority = parsed.priority;
             this.filterNeedsReply = parsed.needsReply;
             this.filterUserId = parsed.userId;
+            this.listPage = parsed.page;
+            this.listPerPage = parsed.perPage;
         },
         syncFiltersToRoute() {
             const query = {};
@@ -181,9 +202,16 @@ export default {
             if (this.filterUserId) {
                 query.user_id = String(this.filterUserId);
             }
+            if (this.listPage > 1) {
+                query.page = String(this.listPage);
+            }
+            if (this.listPerPage !== DEFAULT_ADMIN_PER_PAGE) {
+                query.per_page = String(this.listPerPage);
+            }
             this.$router.replace({ query });
         },
         applyFilters() {
+            this.listPage = 1;
             this.syncFiltersToRoute();
         },
         loadTickets(options = {}) {
@@ -291,6 +319,27 @@ export default {
         assignedAdminLabel(ticket) {
             const name = assignedAdminDisplayName(ticket);
             return name || '-';
+        },
+        goPrevPage() {
+            const pagination = this.listPagination;
+            if (!pagination || pagination.current_page <= 1) {
+                return;
+            }
+            this.listPage = pagination.current_page - 1;
+            this.syncFiltersToRoute();
+        },
+        goNextPage() {
+            const pagination = this.listPagination;
+            if (!pagination || pagination.current_page >= pagination.total_pages) {
+                return;
+            }
+            this.listPage = pagination.current_page + 1;
+            this.syncFiltersToRoute();
+        },
+        onPerPageChange(perPage) {
+            this.listPerPage = perPage;
+            this.listPage = 1;
+            this.syncFiltersToRoute();
         }
     },
     mounted() {
@@ -306,7 +355,8 @@ export default {
         }
     },
     components: {
-        AdminLayout
+        AdminLayout,
+        AdminPaginationBar
     }
 };
 </script>

--- a/src/components/views/AdminUserMigrationsList.vue
+++ b/src/components/views/AdminUserMigrationsList.vue
@@ -59,35 +59,15 @@
                             {{ $t('noSeEncontroNingunUsuario') }}
                         </p>
                     </div>
-                    <div
-                        v-if="!listLoading && pagination && pagination.total_pages > 1"
-                        class="admin-user-migrations__pager"
-                    >
-                        <button
-                            type="button"
-                            class="btn btn-default btn-sm"
-                            :disabled="pagination.current_page <= 1"
-                            @click="goPrevPage"
-                        >
-                            {{ $t('anterior') }}
-                        </button>
-                        <span class="text-muted admin-user-migrations__pager-label">
-                            {{
-                                $t('adminUsuariosPagina', {
-                                    current: pagination.current_page,
-                                    total: pagination.total_pages
-                                })
-                            }}
-                        </span>
-                        <button
-                            type="button"
-                            class="btn btn-default btn-sm"
-                            :disabled="pagination.current_page >= pagination.total_pages"
-                            @click="goNextPage"
-                        >
-                            {{ $t('siguiente') }}
-                        </button>
-                    </div>
+                    <AdminPaginationBar
+                        v-if="!listLoading && pagination"
+                        :pagination="pagination"
+                        :per-page="listPerPage"
+                        :loading="listLoading"
+                        @prev="goPrevPage"
+                        @next="goNextPage"
+                        @update:per-page="onPerPageChange"
+                    />
                 </div>
             </div>
         </div>
@@ -96,9 +76,11 @@
 
 <script>
 import AdminLayout from '../layouts/AdminLayout.vue';
+import AdminPaginationBar from '../AdminPaginationBar.vue';
 import { AdminApi } from '../../services/api';
 import dialogs from '../../services/dialogs.js';
 import dayjs from '../../dayjs';
+import { DEFAULT_ADMIN_PER_PAGE } from '../../utils/adminPagination';
 
 export default {
     name: 'admin-user-migrations-list',
@@ -108,6 +90,7 @@ export default {
             rows: [],
             listMeta: null,
             listPage: 1,
+            listPerPage: DEFAULT_ADMIN_PER_PAGE,
             adminApi: null
         };
     },
@@ -135,7 +118,7 @@ export default {
             try {
                 const body = await this.adminApi.getUserMigrations({
                     page: this.listPage,
-                    per_page: 20
+                    per_page: this.listPerPage
                 });
                 this.rows = body.data || [];
                 this.listMeta = body.meta || null;
@@ -160,6 +143,10 @@ export default {
             const p = this.pagination;
             if (!p || p.current_page >= p.total_pages) return;
             this.fetchList(p.current_page + 1);
+        },
+        onPerPageChange(perPage) {
+            this.listPerPage = perPage;
+            this.fetchList(1);
         }
     },
     mounted() {
@@ -167,7 +154,8 @@ export default {
         this.fetchList(1);
     },
     components: {
-        AdminLayout
+        AdminLayout,
+        AdminPaginationBar
     }
 };
 </script>
@@ -184,20 +172,5 @@ export default {
 
 .admin-user-migrations__title {
     margin: 0;
-}
-
-.admin-user-migrations__pager {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: space-between;
-    gap: 8px;
-    margin-top: 12px;
-}
-
-.admin-user-migrations__pager-label {
-    flex: 1;
-    text-align: center;
-    font-size: 12px;
 }
 </style>

--- a/src/components/views/AdminUsersList.vue
+++ b/src/components/views/AdminUsersList.vue
@@ -107,35 +107,15 @@
                             {{ $t('noSeEncontroNingunUsuario') }}
                         </p>
                     </div>
-                    <div
-                        v-if="!listLoading && listMeta && listMeta.pagination && listMeta.pagination.total_pages > 1"
-                        class="admin-users-pager-bar"
-                    >
-                        <button
-                            type="button"
-                            class="btn btn-default btn-sm"
-                            :disabled="!listMeta.pagination || listMeta.pagination.current_page <= 1"
-                            @click="goPrevPage"
-                        >
-                            {{ $t('anterior') }}
-                        </button>
-                        <span class="user-admin-pager-label text-muted">
-                            {{
-                                $t('adminUsuariosPagina', {
-                                    current: listMeta.pagination.current_page,
-                                    total: listMeta.pagination.total_pages
-                                })
-                            }}
-                        </span>
-                        <button
-                            type="button"
-                            class="btn btn-default btn-sm"
-                            :disabled="!listMeta.pagination || listMeta.pagination.current_page >= listMeta.pagination.total_pages"
-                            @click="goNextPage"
-                        >
-                            {{ $t('siguiente') }}
-                        </button>
-                    </div>
+                    <AdminPaginationBar
+                        v-if="!listLoading && listMeta && listMeta.pagination"
+                        :pagination="listMeta.pagination"
+                        :per-page="listPerPage"
+                        :loading="listLoading"
+                        @prev="goPrevPage"
+                        @next="goNextPage"
+                        @update:per-page="onPerPageChange"
+                    />
                 </div>
             </div>
         </div>
@@ -145,10 +125,12 @@
 <script>
 import { mapState } from 'pinia';
 import AdminLayout from '../layouts/AdminLayout.vue';
+import AdminPaginationBar from '../AdminPaginationBar.vue';
 import { useAuthStore } from '../../stores/auth';
 import { AdminApi } from '../../services/api';
 import dialogs from '../../services/dialogs.js';
 import { displayDniOrDash as formatDisplayDniOrDash } from '../../utils/formatDisplayDni';
+import { DEFAULT_ADMIN_PER_PAGE, resolveAdminPerPage } from '../../utils/adminPagination';
 
 const DEFAULT_SORT = { key: 'id', dir: 'desc' };
 
@@ -166,6 +148,7 @@ export default {
             listLoading: false,
             listMeta: null,
             listPage: 1,
+            listPerPage: DEFAULT_ADMIN_PER_PAGE,
             sortKey: DEFAULT_SORT.key,
             sortDir: DEFAULT_SORT.dir,
             keyUpTimerId: 0,
@@ -208,6 +191,9 @@ export default {
                 sort: this.sortKey,
                 direction: this.sortDir
             };
+            if (this.listPerPage !== DEFAULT_ADMIN_PER_PAGE) {
+                query.per_page = String(this.listPerPage);
+            }
             const q = this.normalizedSearchQuery();
             if (q) {
                 query.name = q;
@@ -229,13 +215,16 @@ export default {
             if (query.name) {
                 this.textSearch = String(query.name);
             }
+            if (query.per_page) {
+                this.listPerPage = resolveAdminPerPage(query.per_page);
+            }
         },
         async fetchList(page) {
             this.listLoading = true;
             this.listPage = page || 1;
             const params = {
                 page: this.listPage,
-                per_page: 30,
+                per_page: this.listPerPage,
                 sort: this.sortKey,
                 direction: this.sortDir
             };
@@ -270,6 +259,10 @@ export default {
             if (!p || p.current_page >= p.total_pages) return;
             this.fetchList(p.current_page + 1);
         },
+        onPerPageChange(perPage) {
+            this.listPerPage = perPage;
+            this.fetchList(1);
+        },
     },
     mounted() {
         this.adminApi = new AdminApi();
@@ -277,7 +270,8 @@ export default {
         this.fetchList(this.listPage || 1);
     },
     components: {
-        AdminLayout
+        AdminLayout,
+        AdminPaginationBar
     }
 };
 </script>
@@ -302,20 +296,5 @@ export default {
     margin-left: 4px;
     font-size: 12px;
     color: #666;
-}
-
-.admin-users-pager-bar {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: space-between;
-    gap: 8px;
-    margin-top: 12px;
-}
-
-.user-admin-pager-label {
-    flex: 1;
-    text-align: center;
-    font-size: 12px;
 }
 </style>

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -1557,6 +1557,7 @@ const messages = {
         adminPage: 'Admin Page',
         adminUsers: 'Admin users',
         adminUsuariosPagina: 'Página {current} de {total}',
+        adminItemsPerPage: 'Ítems por página',
         adminUsuariosEditar: 'Editar datos',
         adminUsuariosImpersonate: 'Suplantar usuario',
         adminUsuariosImpersonateConfirm:
@@ -2960,6 +2961,7 @@ const messages = {
         adminPage: 'Admin Page',
         adminUsers: 'Admin users',
         adminUsuariosPagina: 'Página {current} de {total}',
+        adminItemsPerPage: 'Ítems por página',
         adminUsuariosEditar: 'Editar datos',
         adminUsuariosImpersonate: 'Suplantar usuario',
         adminUsuariosImpersonateConfirm:
@@ -4525,6 +4527,7 @@ const messages = {
         adminPage: 'Admin Page',
         adminUsers: 'Admin users',
         adminUsuariosPagina: 'Page {current} of {total}',
+        adminItemsPerPage: 'Items per page',
         adminUsuariosEditar: 'Edit details',
         adminUsuariosImpersonate: 'Impersonate user',
         adminUsuariosImpersonateConfirm:

--- a/src/services/api/Admin.js
+++ b/src/services/api/Admin.js
@@ -59,8 +59,8 @@ class AdminApi extends TaggedApi {
         );
     }
 
-    getManualIdentityValidations() {
-        return this.get('/api/admin/manual-identity-validations', {});
+    getManualIdentityValidations(params = {}) {
+        return this.get('/api/admin/manual-identity-validations', params);
     }
 
     getDashboard() {
@@ -102,8 +102,8 @@ class AdminApi extends TaggedApi {
         );
     }
 
-    getMercadoPagoRejectedValidations() {
-        return this.get('/api/admin/mercado-pago-rejected-validations', {});
+    getMercadoPagoRejectedValidations(params = {}) {
+        return this.get('/api/admin/mercado-pago-rejected-validations', params);
     }
 
     getMercadoPagoRejectedValidation(id) {

--- a/src/stores/tickets.js
+++ b/src/stores/tickets.js
@@ -8,7 +8,8 @@ export const useTicketsStore = defineStore('tickets', {
     state: () => ({
         list: null,
         selected: null,
-        adminList: null
+        adminList: null,
+        adminListMeta: null
     }),
     actions: {
         fetchList() {
@@ -36,12 +37,15 @@ export const useTicketsStore = defineStore('tickets', {
         },
         fetchAdminList(filters) {
             this.adminList = null;
+            this.adminListMeta = null;
             const params = buildAdminSupportTicketListParams(filters);
             return ticketsApi.adminList(params).then((response) => {
                 this.adminList = response.data || [];
-                return this.adminList;
+                this.adminListMeta = response.meta || null;
+                return response;
             }).catch((error) => {
                 this.adminList = [];
+                this.adminListMeta = null;
                 return Promise.reject(error);
             });
         },

--- a/src/stores/tickets.test.js
+++ b/src/stores/tickets.test.js
@@ -35,18 +35,25 @@ describe('tickets store', () => {
         Object.values(apiMock).forEach((fn) => fn.mockReset());
     });
 
-    it('stores admin list response array', async () => {
+    it('stores admin list response array and pagination meta', async () => {
         const { useTicketsStore } = await import('./tickets');
-        apiMock.adminList.mockResolvedValue({ data: [{ id: 10 }] });
+        apiMock.adminList.mockResolvedValue({
+            data: [{ id: 10 }],
+            meta: { pagination: { current_page: 1, per_page: 20, total: 1, total_pages: 1 } }
+        });
 
         const store = useTicketsStore();
-        const list = await store.fetchAdminList();
+        const result = await store.fetchAdminList();
 
-        expect(list).toEqual([{ id: 10 }]);
+        expect(result.data).toEqual([{ id: 10 }]);
+        expect(result.meta.pagination.total).toBe(1);
         expect(store.adminList).toEqual([{ id: 10 }]);
+        expect(store.adminListMeta).toEqual({
+            pagination: { current_page: 1, per_page: 20, total: 1, total_pages: 1 }
+        });
     });
 
-    it('fetchAdminList passes filter params to adminList API', async () => {
+    it('fetchAdminList passes filter and pagination params to adminList API', async () => {
         const { useTicketsStore } = await import('./tickets');
         apiMock.adminList.mockResolvedValue({ data: [{ id: 3 }] });
 
@@ -54,13 +61,17 @@ describe('tickets store', () => {
         await store.fetchAdminList({
             type: 'contact',
             priority: 'high',
-            needsReply: true
+            needsReply: true,
+            page: 2,
+            perPage: 30
         });
 
         expect(apiMock.adminList).toHaveBeenCalledWith({
             type: 'contact',
             priority: 'high',
-            needs_reply: '1'
+            needs_reply: '1',
+            page: 2,
+            per_page: 30
         });
     });
 
@@ -71,6 +82,7 @@ describe('tickets store', () => {
         const store = useTicketsStore();
         await expect(store.fetchAdminList()).rejects.toThrow('network error');
         expect(store.adminList).toEqual([]);
+        expect(store.adminListMeta).toBeNull();
     });
 
     it('creates support ticket from admin and returns payload data', async () => {

--- a/src/utils/adminPagination.js
+++ b/src/utils/adminPagination.js
@@ -1,0 +1,44 @@
+export const DEFAULT_ADMIN_PER_PAGE = 20;
+
+export const ADMIN_PER_PAGE_OPTIONS = [10, 20, 30, 50, 100];
+
+export function resolveAdminPerPage(value) {
+    const perPage = parseInt(value, 10);
+
+    if (ADMIN_PER_PAGE_OPTIONS.includes(perPage)) {
+        return perPage;
+    }
+
+    return DEFAULT_ADMIN_PER_PAGE;
+}
+
+export function resolveAdminPage(value) {
+    const page = parseInt(value, 10);
+
+    if (Number.isNaN(page) || page < 1) {
+        return 1;
+    }
+
+    return page;
+}
+
+export function parseAdminPaginationFromRoute(query = {}) {
+    return {
+        page: resolveAdminPage(query.page),
+        perPage: resolveAdminPerPage(query.per_page)
+    };
+}
+
+export function buildAdminPaginationQuery(page, perPage, baseQuery = {}) {
+    return {
+        ...baseQuery,
+        page: String(page),
+        per_page: String(perPage)
+    };
+}
+
+export function readPaginationMeta(response) {
+    return response && response.meta && response.meta.pagination
+        ? response.meta.pagination
+        : null;
+}

--- a/src/utils/adminPagination.test.js
+++ b/src/utils/adminPagination.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import {
+    ADMIN_PER_PAGE_OPTIONS,
+    DEFAULT_ADMIN_PER_PAGE,
+    buildAdminPaginationQuery,
+    parseAdminPaginationFromRoute,
+    readPaginationMeta,
+    resolveAdminPage,
+    resolveAdminPerPage
+} from './adminPagination';
+
+describe('adminPagination', () => {
+    it('exposes default per page and allowed options', () => {
+        expect(DEFAULT_ADMIN_PER_PAGE).toBe(20);
+        expect(ADMIN_PER_PAGE_OPTIONS).toEqual([10, 20, 30, 50, 100]);
+    });
+
+    it('resolveAdminPerPage accepts allowed values and falls back to default', () => {
+        expect(resolveAdminPerPage(10)).toBe(10);
+        expect(resolveAdminPerPage('30')).toBe(30);
+        expect(resolveAdminPerPage(15)).toBe(20);
+        expect(resolveAdminPerPage(undefined)).toBe(20);
+    });
+
+    it('resolveAdminPage defaults to one and clamps invalid values', () => {
+        expect(resolveAdminPage(undefined)).toBe(1);
+        expect(resolveAdminPage(0)).toBe(1);
+        expect(resolveAdminPage('3')).toBe(3);
+    });
+
+    it('parseAdminPaginationFromRoute reads page and per_page query params', () => {
+        expect(parseAdminPaginationFromRoute({ page: '2', per_page: '50' })).toEqual({
+            page: 2,
+            perPage: 50
+        });
+    });
+
+    it('buildAdminPaginationQuery serializes pagination into route query', () => {
+        expect(buildAdminPaginationQuery(2, 30, { type: 'bug_report' })).toEqual({
+            type: 'bug_report',
+            page: '2',
+            per_page: '30'
+        });
+    });
+
+    it('readPaginationMeta returns pagination meta from API body', () => {
+        expect(readPaginationMeta({
+            data: [],
+            meta: {
+                pagination: {
+                    current_page: 1,
+                    per_page: 20,
+                    total: 0,
+                    total_pages: 1
+                }
+            }
+        })).toEqual({
+            current_page: 1,
+            per_page: 20,
+            total: 0,
+            total_pages: 1
+        });
+    });
+});

--- a/src/utils/adminSupportTicketListFilters.js
+++ b/src/utils/adminSupportTicketListFilters.js
@@ -1,3 +1,5 @@
+import { parseAdminPaginationFromRoute } from './adminPagination';
+
 const TRUTHY_QUERY_VALUES = new Set(['1', 'true', 'yes']);
 
 export function buildAdminSupportTicketListParams(filters = {}) {
@@ -14,17 +16,26 @@ export function buildAdminSupportTicketListParams(filters = {}) {
     if (filters.userId) {
         params.user_id = String(filters.userId);
     }
+    if (filters.page) {
+        params.page = filters.page;
+    }
+    if (filters.perPage) {
+        params.per_page = filters.perPage;
+    }
     return params;
 }
 
 export function parseAdminSupportTicketListFiltersFromRoute(query = {}) {
     const needsReplyRaw = query.needs_reply != null ? String(query.needs_reply).toLowerCase() : '';
     const userIdRaw = query.user_id != null ? parseInt(String(query.user_id), 10) : NaN;
+    const pagination = parseAdminPaginationFromRoute(query);
     return {
         type: query.type ? String(query.type) : '',
         priority: query.priority ? String(query.priority) : '',
         needsReply: TRUTHY_QUERY_VALUES.has(needsReplyRaw),
-        userId: Number.isNaN(userIdRaw) || userIdRaw <= 0 ? null : userIdRaw
+        userId: Number.isNaN(userIdRaw) || userIdRaw <= 0 ? null : userIdRaw,
+        page: pagination.page,
+        perPage: pagination.perPage
     };
 }
 

--- a/src/utils/adminSupportTicketListFilters.test.js
+++ b/src/utils/adminSupportTicketListFilters.test.js
@@ -12,13 +12,17 @@ describe('adminSupportTicketListFilters', () => {
                 type: 'bug_report',
                 priority: 'high',
                 needsReply: true,
-                userId: 42
+                userId: 42,
+                page: 2,
+                perPage: 50
             })
         ).toEqual({
             type: 'bug_report',
             priority: 'high',
             needs_reply: '1',
-            user_id: '42'
+            user_id: '42',
+            page: 2,
+            per_page: 50
         });
     });
 
@@ -33,13 +37,17 @@ describe('adminSupportTicketListFilters', () => {
                 type: 'contact',
                 priority: 'low',
                 needs_reply: '1',
-                user_id: '99'
+                user_id: '99',
+                page: '3',
+                per_page: '30'
             })
         ).toEqual({
             type: 'contact',
             priority: 'low',
             needsReply: true,
-            userId: 99
+            userId: 99,
+            page: 3,
+            perPage: 30
         });
     });
 


### PR DESCRIPTION
## Summary
- Add shared `AdminPaginationBar` component with per-page selector (10, 20, 30, 50, 100; default 20)
- Wire pagination into support tickets, manual identity validations, Mercado Pago rejections, admin users, and user migrations
- Sync support ticket page/per_page with route query for shareable URLs
- Send `show_resolved` to API for manual validations instead of client-side filtering

## Test plan
- [x] `npm run test:unit -- --run` (1271/1275 pass; 4 unrelated `customSplash` failures pre-existing)
- [x] `npm run lint`
- [x] `npm run build` (Vite production build succeeds)

## Related PR
- Backend: https://github.com/STS-Rosario/carpoolear_backend/pull/new/admin-pagination