### PR TITLE
Fix server-side sorting for paginated manual identity validations

### DIFF
--- a/src/components/views/AdminManualIdentityValidations.view.test.js
+++ b/src/components/views/AdminManualIdentityValidations.view.test.js
@@ -33,12 +33,20 @@ describe('AdminManualIdentityValidations view', () => {
 
     it('renders sortable column headers for manual validation rows', () => {
         expect(viewSource).toContain('MANUAL_IDENTITY_VALIDATION_SORT_COLUMNS');
-        expect(viewSource).toContain('sortManualIdentityValidationsList');
+        expect(viewSource).toContain('buildManualIdentityValidationListParams');
+        expect(viewSource).toContain('parseManualIdentityValidationListFromRoute');
         expect(viewSource).toContain('getNextManualIdentityValidationSortState');
         expect(viewSource).toContain('toggleSort(');
         expect(viewSource).toContain('admin-manual-th-sort');
         expect(viewSource).toContain('sortKey === column.key');
         expect(viewSource).toContain('toggleSort(column.key)');
         expect(viewSource).not.toContain("@click=\"toggleSort('acciones')\"");
+    });
+
+    it('sends sort and pagination params to the API instead of sorting locally', () => {
+        expect(viewSource).not.toContain('sortManualIdentityValidationsList');
+        expect(viewSource).toContain('syncRouteQuery');
+        expect(viewSource).toContain('params.sort = this.sortKey');
+        expect(viewSource).toContain('params.direction = this.sortDir');
     });
 });

--- a/src/components/views/AdminManualIdentityValidations.view.test.js
+++ b/src/components/views/AdminManualIdentityValidations.view.test.js
@@ -27,8 +27,8 @@ describe('AdminManualIdentityValidations view', () => {
         expect(viewSource).toContain('getShowResolvedManualIdentityValidations');
         expect(viewSource).toContain('saveShowResolvedManualIdentityValidations');
         expect(viewSource).toContain('show_resolved');
-        expect(viewSource).toContain(':data="displayedList"');
-        expect(viewSource).toContain('v-for="item in displayedList"');
+        expect(viewSource).toContain(':data="list"');
+        expect(viewSource).toContain('v-for="item in list"');
     });
 
     it('renders sortable column headers for manual validation rows', () => {
@@ -46,7 +46,8 @@ describe('AdminManualIdentityValidations view', () => {
     it('sends sort and pagination params to the API instead of sorting locally', () => {
         expect(viewSource).not.toContain('sortManualIdentityValidationsList');
         expect(viewSource).toContain('syncRouteQuery');
-        expect(viewSource).toContain('params.sort = this.sortKey');
-        expect(viewSource).toContain('params.direction = this.sortDir');
+        expect(viewSource).toContain('buildManualIdentityValidationListParams');
+        expect(viewSource).toContain('sortKey: this.sortKey');
+        expect(viewSource).toContain('sortDir: this.sortDir');
     });
 });

--- a/src/components/views/AdminManualIdentityValidations.vue
+++ b/src/components/views/AdminManualIdentityValidations.vue
@@ -9,7 +9,7 @@
                         {{ $t('mostrarResueltos') }}
                     </label>
                 </div>
-                <Loading :data="displayedList">
+                <Loading :data="list">
                     <div class="table-responsive">
                     <table class="table table-hover table-bordered">
                         <thead>
@@ -31,7 +31,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            <tr v-for="item in displayedList" :key="item.id">
+                            <tr v-for="item in list" :key="item.id">
                                 <th scope="row">{{ item.id }}</th>
                                 <td>{{ item.user_name || $t('na') }}</td>
                                 <td>{{ item.paid_at ? formatDate(item.paid_at) : '-' }}</td>
@@ -98,11 +98,12 @@ import Loading from '../Loading';
 import { AdminApi } from '../../services/api';
 import { getAdminUserProfileRoute } from '../../utils/adminProfileRoute';
 import {
+    buildManualIdentityValidationListParams,
     getNextManualIdentityValidationSortState,
     getShowResolvedManualIdentityValidations,
     MANUAL_IDENTITY_VALIDATION_SORT_COLUMNS,
-    saveShowResolvedManualIdentityValidations,
-    sortManualIdentityValidationsList
+    parseManualIdentityValidationListFromRoute,
+    saveShowResolvedManualIdentityValidations
 } from '../../utils/adminManualIdentityValidationsList';
 import { DEFAULT_ADMIN_PER_PAGE } from '../../utils/adminPagination';
 import {
@@ -125,20 +126,18 @@ export default {
             sortableColumns: MANUAL_IDENTITY_VALIDATION_SORT_COLUMNS
         };
     },
-    computed: {
-        displayedList() {
-            if (!Array.isArray(this.list)) {
-                return this.list;
-            }
-
-            return sortManualIdentityValidationsList(this.list, this.sortKey, this.sortDir);
-        }
-    },
     watch: {
+        '$route.query': {
+            deep: true,
+            handler() {
+                this.initFromRouteQuery();
+                this.fetchList();
+            }
+        },
         showResolved(value) {
             saveShowResolvedManualIdentityValidations(value);
             this.listPage = 1;
-            this.fetchList();
+            this.syncRouteQuery();
         }
     },
     methods: {
@@ -161,6 +160,33 @@ export default {
             const approved = status === 'approved' || status === 'approve';
             return approved && item.has_images === true;
         },
+        initFromRouteQuery() {
+            const parsed = parseManualIdentityValidationListFromRoute(this.$route.query || {});
+            this.listPage = parsed.page;
+            this.listPerPage = parsed.perPage;
+            this.sortKey = parsed.sortKey;
+            this.sortDir = parsed.sortDir;
+            if (this.$route.query.show_resolved != null) {
+                this.showResolved = parsed.showResolved;
+            }
+        },
+        syncRouteQuery() {
+            const query = {};
+            if (this.listPage > 1) {
+                query.page = String(this.listPage);
+            }
+            if (this.listPerPage !== DEFAULT_ADMIN_PER_PAGE) {
+                query.per_page = String(this.listPerPage);
+            }
+            if (this.showResolved) {
+                query.show_resolved = '1';
+            }
+            if (this.sortKey) {
+                query.sort = this.sortKey;
+                query.direction = this.sortDir;
+            }
+            this.$router.replace({ query });
+        },
         toggleSort(column) {
             const next = getNextManualIdentityValidationSortState(
                 this.sortKey,
@@ -170,16 +196,19 @@ export default {
 
             this.sortKey = next.sortKey;
             this.sortDir = next.sortDir;
+            this.listPage = 1;
+            this.syncRouteQuery();
         },
         fetchList() {
             const api = new AdminApi();
-            const params = {
+            const params = buildManualIdentityValidationListParams({
                 page: this.listPage,
-                per_page: this.listPerPage
-            };
-            if (this.showResolved) {
-                params.show_resolved = '1';
-            }
+                perPage: this.listPerPage,
+                showResolved: this.showResolved,
+                sortKey: this.sortKey,
+                sortDir: this.sortDir
+            });
+
             return api.getManualIdentityValidations(params).then((res) => {
                 this.list = res.data || [];
                 this.listMeta = res.meta || null;
@@ -194,7 +223,7 @@ export default {
                 return;
             }
             this.listPage = pagination.current_page - 1;
-            this.fetchList();
+            this.syncRouteQuery();
         },
         goNextPage() {
             const pagination = this.listMeta && this.listMeta.pagination;
@@ -202,15 +231,16 @@ export default {
                 return;
             }
             this.listPage = pagination.current_page + 1;
-            this.fetchList();
+            this.syncRouteQuery();
         },
         onPerPageChange(perPage) {
             this.listPerPage = perPage;
             this.listPage = 1;
-            this.fetchList();
+            this.syncRouteQuery();
         }
     },
     mounted() {
+        this.initFromRouteQuery();
         this.fetchList();
     },
     components: {

--- a/src/utils/adminManualIdentityValidationsList.js
+++ b/src/utils/adminManualIdentityValidationsList.js
@@ -1,3 +1,5 @@
+import { parseAdminPaginationFromRoute } from './adminPagination';
+
 export const ADMIN_MANUAL_IDENTITY_VALIDATIONS_SHOW_RESOLVED_KEY =
     'adminManualIdentityValidationsShowResolved';
 
@@ -187,5 +189,48 @@ export function getNextManualIdentityValidationSortState(currentKey, currentDir,
     return {
         sortKey: column,
         sortDir: column === 'id' ? 'desc' : 'asc'
+    };
+}
+
+export function buildManualIdentityValidationListParams({
+    page,
+    perPage,
+    showResolved = false,
+    sortKey = null,
+    sortDir = 'asc'
+} = {}) {
+    const params = {};
+
+    if (page) {
+        params.page = page;
+    }
+    if (perPage) {
+        params.per_page = perPage;
+    }
+    if (showResolved) {
+        params.show_resolved = '1';
+    }
+    if (sortKey) {
+        params.sort = sortKey;
+        params.direction = sortDir === 'desc' ? 'desc' : 'asc';
+    }
+
+    return params;
+}
+
+export function parseManualIdentityValidationListFromRoute(query = {}) {
+    const pagination = parseAdminPaginationFromRoute(query);
+    const showResolved = query.show_resolved != null
+        && ['1', 'true', 'yes'].includes(String(query.show_resolved).toLowerCase());
+
+    const sortKey = query.sort ? String(query.sort) : null;
+    const sortDir = String(query.direction || '').toLowerCase() === 'desc' ? 'desc' : 'asc';
+
+    return {
+        page: pagination.page,
+        perPage: pagination.perPage,
+        showResolved,
+        sortKey,
+        sortDir
     };
 }

--- a/src/utils/adminManualIdentityValidationsList.js
+++ b/src/utils/adminManualIdentityValidationsList.js
@@ -220,8 +220,8 @@ export function buildManualIdentityValidationListParams({
 
 export function parseManualIdentityValidationListFromRoute(query = {}) {
     const pagination = parseAdminPaginationFromRoute(query);
-    const showResolved = query.show_resolved != null
-        && ['1', 'true', 'yes'].includes(String(query.show_resolved).toLowerCase());
+    const showResolved = query.show_resolved != null &&
+        ['1', 'true', 'yes'].includes(String(query.show_resolved).toLowerCase());
 
     const sortKey = query.sort ? String(query.sort) : null;
     const sortDir = String(query.direction || '').toLowerCase() === 'desc' ? 'desc' : 'asc';

--- a/src/utils/adminManualIdentityValidationsList.test.js
+++ b/src/utils/adminManualIdentityValidationsList.test.js
@@ -1,11 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
     ADMIN_MANUAL_IDENTITY_VALIDATIONS_SHOW_RESOLVED_KEY,
+    buildManualIdentityValidationListParams,
     filterManualIdentityValidationsList,
     getNextManualIdentityValidationSortState,
     getShowResolvedManualIdentityValidations,
     isManualIdentityValidationResolved,
     MANUAL_IDENTITY_VALIDATION_SORT_COLUMNS,
+    parseManualIdentityValidationListFromRoute,
     saveShowResolvedManualIdentityValidations,
     sortManualIdentityValidationsList
 } from './adminManualIdentityValidationsList.js';
@@ -162,6 +164,53 @@ describe('adminManualIdentityValidationsList', () => {
                 'paid',
                 'review_status'
             ]);
+        });
+    });
+
+    describe('buildManualIdentityValidationListParams', () => {
+        it('includes pagination, show_resolved and sort params for the API', () => {
+            expect(
+                buildManualIdentityValidationListParams({
+                    page: 2,
+                    perPage: 30,
+                    showResolved: true,
+                    sortKey: 'id',
+                    sortDir: 'desc'
+                })
+            ).toEqual({
+                page: 2,
+                per_page: 30,
+                show_resolved: '1',
+                sort: 'id',
+                direction: 'desc'
+            });
+        });
+
+        it('omits sort params when no column is selected', () => {
+            expect(buildManualIdentityValidationListParams({ page: 1, perPage: 20 })).toEqual({
+                page: 1,
+                per_page: 20
+            });
+        });
+    });
+
+    describe('parseManualIdentityValidationListFromRoute', () => {
+        it('reads pagination, show_resolved and sort from route query', () => {
+            expect(
+                parseManualIdentityValidationListFromRoute({
+                    page: '3',
+                    per_page: '50',
+                    show_resolved: '1',
+                    sort: 'user_name',
+                    direction: 'asc'
+                })
+            ).toEqual({
+                page: 3,
+                perPage: 50,
+                showResolved: true,
+                sortKey: 'user_name',
+                sortDir: 'asc'
+            });
         });
     });
 


### PR DESCRIPTION
## Summary
- Send `sort` and `direction` to the manual identity validations API instead of sorting only the current page in the browser
- Persist sort, pagination, and `show_resolved` in the route query for shareable admin URLs
- Reset to page 1 when the active sort column changes

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test:unit -- --run` (1276/1280 pass; 4 unrelated `customSplash` failures)

## Related PR
- Backend: will link after creation