### PR TITLE
Improve Resultados cercanos header and description

### DIFF
--- a/src/components/views/Trips.view.test.js
+++ b/src/components/views/Trips.view.test.js
@@ -230,4 +230,18 @@ describe('Trips.vue nearby results header', () => {
             /isComplementary\(\s*trip,\s*searchParams,\s*trips,\s*index\s*\)/
         );
     });
+
+    it('shows a description under the nearby results heading', () => {
+        const complementaryBlocks = [
+            ...viewSource.matchAll(
+                /class="trip-complementary"[\s\S]*?<\/div>/g
+            )
+        ].map((match) => match[0]);
+
+        expect(complementaryBlocks.length).toBeGreaterThan(0);
+        complementaryBlocks.forEach((block) => {
+            expect(block).toContain("$t('resultadosCercanos')");
+            expect(block).toContain("$t('resultadosCercanosDescripcion')");
+        });
+    });
 });

--- a/src/components/views/Trips.view.test.js
+++ b/src/components/views/Trips.view.test.js
@@ -204,3 +204,30 @@ describe('Trips.vue donation modal', () => {
         expect(viewSource).not.toContain('value="10000"');
     });
 });
+
+describe('Trips.vue nearby results header', () => {
+    it('delegates complementary header visibility to shouldShowNearbyResultsHeader', () => {
+        expect(viewSource).toContain(
+            "from '../../utils/nearbyTripResults.js'"
+        );
+        expect(viewSource).toContain('shouldShowNearbyResultsHeader');
+        const methodBlock = viewSource.match(
+            /isComplementary\([^)]*\)\s*\{[\s\S]*?\n\s*\},/
+        );
+        expect(methodBlock).not.toBeNull();
+        expect(methodBlock[0]).toContain('shouldShowNearbyResultsHeader');
+        expect(methodBlock[0]).toContain('previousTrips');
+    });
+
+    it('passes each section trip list so only the first nearby trip shows the header', () => {
+        expect(viewSource).toContain(
+            'isComplementary(trip, searchParams, friendTripsList, index)'
+        );
+        expect(viewSource).toContain(
+            'isComplementary(trip, searchParams, otherTripsList, index)'
+        );
+        expect(viewSource).toMatch(
+            /isComplementary\(\s*trip,\s*searchParams,\s*trips,\s*index\s*\)/
+        );
+    });
+});

--- a/src/components/views/Trips.view.test.js
+++ b/src/components/views/Trips.view.test.js
@@ -244,4 +244,16 @@ describe('Trips.vue nearby results header', () => {
             expect(block).toContain("$t('resultadosCercanosDescripcion')");
         });
     });
+
+    it('styles the nearby heading without bottom margin and a smaller spaced description', () => {
+        expect(viewSource).toMatch(
+            /\.trip-complementary h2\s*\{[^}]*margin-bottom:\s*0;/
+        );
+        expect(viewSource).toMatch(
+            /\.trip-complementary p\s*\{[^}]*font-size:\s*1\.2rem;/
+        );
+        expect(viewSource).toMatch(
+            /\.trip-complementary p\s*\{[^}]*margin:[^}]*0\.75rem;/
+        );
+    });
 });

--- a/src/components/views/Trips.vue
+++ b/src/components/views/Trips.vue
@@ -1199,9 +1199,13 @@ export default {
     margin-bottom: 1.5rem;
 }
 
+.trip-complementary h2 {
+    margin-bottom: 0;
+}
+
 .trip-complementary p {
-    margin: 0.5rem 0 0;
-    font-size: 1.4rem;
+    margin: 0.35rem 0 0.75rem;
+    font-size: 1.2rem;
     line-height: 1.4;
     color: #555;
 }

--- a/src/components/views/Trips.vue
+++ b/src/components/views/Trips.vue
@@ -191,6 +191,7 @@
                                     >
                                         <div class="trip-complementary">
                                             <h2>{{ $t('resultadosCercanos') }}</h2>
+                                            <p>{{ $t('resultadosCercanosDescripcion') }}</p>
                                         </div>
                                     </div>
                                     <Trip :trip="trip" :user="user"></Trip>
@@ -217,6 +218,7 @@
                                     >
                                         <div class="trip-complementary">
                                             <h2>{{ $t('resultadosCercanos') }}</h2>
+                                            <p>{{ $t('resultadosCercanosDescripcion') }}</p>
                                         </div>
                                     </div>
                                     <Trip :trip="trip" :user="user"></Trip>
@@ -240,6 +242,7 @@
                             >
                                 <div class="trip-complementary">
                                     <h2>{{ $t('resultadosCercanos') }}</h2>
+                                    <p>{{ $t('resultadosCercanosDescripcion') }}</p>
                                 </div>
                             </div>
                             <Trip :trip="trip" :user="user"></Trip>
@@ -302,6 +305,7 @@
                             <div class="col-xs-24">
                                 <div class="trip-complementary">
                                     <h2>{{ $t('resultadosCercanos') }}</h2>
+                                    <p>{{ $t('resultadosCercanosDescripcion') }}</p>
                                 </div>
                             </div>
                         </template>

--- a/src/components/views/Trips.vue
+++ b/src/components/views/Trips.vue
@@ -185,11 +185,7 @@
                                 >
                                     <div
                                         v-if="
-                                            isComplementary(
-                                                trip,
-                                                searchParams,
-                                                index
-                                            )
+                                            isComplementary(trip, searchParams, friendTripsList, index)
                                         "
                                         class="col-xs-24"
                                     >
@@ -215,11 +211,7 @@
                                 >
                                     <div
                                         v-if="
-                                            isComplementary(
-                                                trip,
-                                                searchParams,
-                                                friendTripsList.length + index
-                                            )
+                                            isComplementary(trip, searchParams, otherTripsList, index)
                                         "
                                         class="col-xs-24"
                                     >
@@ -242,7 +234,7 @@
                         >
                             <div
                                 v-if="
-                                    isComplementary(trip, searchParams, index)
+                                    isComplementary(trip, searchParams, otherTripsList, index)
                                 "
                                 class="col-xs-24"
                             >
@@ -305,7 +297,7 @@
                             </div>
                         </template>
                         <template
-                            v-if="isComplementary(trip, searchParams, index)"
+                            v-if="isComplementary(trip, searchParams, trips, index)"
                         >
                             <div class="col-xs-24">
                                 <div class="trip-complementary">
@@ -445,6 +437,7 @@ import {
 import { splitFriendTrips } from '../../utils/splitFriendTrips.js';
 import { shouldShowSplitDonationPanel } from '../../utils/tripsSplitDonationBanner.js';
 import { readAllowPreferenceParamsFromQuery } from '../../utils/searchAdvancedFilters.js';
+import { shouldShowNearbyResultsHeader } from '../../utils/nearbyTripResults.js';
 
 export default {
     name: 'trips',
@@ -716,21 +709,17 @@ export default {
                 });
             });
         },
-        isComplementary(trip, searchParams, index) {
-            let isComplementary = false;
-            if (searchParams.data && searchParams.data.date) {
-                var searchDate = dayjs(searchParams.data.date).toDate();
-                var tripDate = dayjs(trip.trip_date).toDate();
-                tripDate.setHours(0);
-                tripDate.setMinutes(0);
-                tripDate.setSeconds(0);
-                if (searchDate.getTime() === tripDate.getTime()) {
-                    isComplementary = false;
-                } else {
-                    isComplementary = true;
-                }
-            }
-            return isComplementary;
+        isComplementary(trip, searchParams, sectionTrips, index) {
+            const searchDate =
+                searchParams.data && searchParams.data.date
+                    ? searchParams.data.date
+                    : null;
+            const previousTrips = (sectionTrips || []).slice(0, index);
+            return shouldShowNearbyResultsHeader(
+                trip,
+                searchDate,
+                previousTrips
+            );
         },
         // TODO filter trips that not are main route
         // REVIEW wich is the best way to do it?

--- a/src/components/views/Trips.vue
+++ b/src/components/views/Trips.vue
@@ -1205,7 +1205,7 @@ export default {
 
 .trip-complementary p {
     margin: 0.35rem 0 0.75rem;
-    font-size: 1.2rem;
+    font-size: 1rem;
     line-height: 1.4;
     color: #555;
 }

--- a/src/components/views/Trips.vue
+++ b/src/components/views/Trips.vue
@@ -1198,4 +1198,11 @@ export default {
     width: 100%;
     margin-bottom: 1.5rem;
 }
+
+.trip-complementary p {
+    margin: 0.5rem 0 0;
+    font-size: 1.4rem;
+    line-height: 1.4;
+    color: #555;
+}
 </style>

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -258,6 +258,8 @@ const messages = {
         porQueDonar: 'Por qué donar a Carpoolear',
         oCreandoUnaCuentaCon: 'o creando una cuenta con',
         resultadosCercanos: 'Resultados cercanos',
+        resultadosCercanosDescripcion:
+            'Viajes cercanos a la fecha que elegiste (+- 3 días), revisá bien la fecha del viaje',
         podesSubscribirte:
             'Ahora podés suscribirte para que te avisemos cuando haya un nuevo viaje que concuerde con lo que estas buscando.',
         crearAlerta: 'Crear Alerta',
@@ -1929,6 +1931,8 @@ const messages = {
         oNuestrasRedesSociales: 'o nuestras redes sociales.',
         porQueDonar: 'Por qué donar a Apalan-car',
         resultadosCercanos: 'Resultados cercanos',
+        resultadosCercanosDescripcion:
+            'Viajes cercanos a la fecha que elegiste (+- 3 días), revisá bien la fecha del viaje',
         podesSubscribirte:
             'Ahora podés suscribirte para que te avisemos cuando haya un nuevo viaje que concuerde con lo que estas buscando.',
         crearAlerta: 'Crear Alerta',
@@ -3254,6 +3258,8 @@ const messages = {
         porQueDonar: 'Why donate to Carpoolear',
         oCreandoUnaCuentaCon: 'or by creating an account with',
         resultadosCercanos: 'Nearby results',
+        resultadosCercanosDescripcion:
+            'Nearby trips around the date you chose (± 3 days), double-check the trip date',
         podesSubscribirte:
             'If you subscribe we can let you know when a new trip matches your query.',
         crearAlerta: 'Create Alert',

--- a/src/language/nearbyResultsI18n.test.js
+++ b/src/language/nearbyResultsI18n.test.js
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import messages from './i18n';
+
+describe('resultadosCercanosDescripcion i18n', () => {
+    it.each(['arg', 'chl'])(
+        '%s locale explains nearby results are ±3 days from the chosen date',
+        (locale) => {
+            expect(messages[locale].resultadosCercanosDescripcion).toBe(
+                'Viajes cercanos a la fecha que elegiste (+- 3 días), revisá bien la fecha del viaje'
+            );
+        }
+    );
+
+    it('en locale explains nearby results are ±3 days from the chosen date', () => {
+        expect(messages.en.resultadosCercanosDescripcion).toBe(
+            'Nearby trips around the date you chose (± 3 days), double-check the trip date'
+        );
+    });
+});

--- a/src/utils/nearbyTripResults.js
+++ b/src/utils/nearbyTripResults.js
@@ -1,0 +1,22 @@
+import dayjs from '../dayjs';
+
+function isNearbyTrip(trip, searchDate) {
+    if (!searchDate || !trip?.trip_date) {
+        return false;
+    }
+
+    return (
+        dayjs(trip.trip_date).format('YYYY-MM-DD') !==
+        dayjs(searchDate).format('YYYY-MM-DD')
+    );
+}
+
+export function shouldShowNearbyResultsHeader(trip, searchDate, previousTrips = []) {
+    if (!isNearbyTrip(trip, searchDate)) {
+        return false;
+    }
+
+    return !previousTrips.some((previousTrip) =>
+        isNearbyTrip(previousTrip, searchDate)
+    );
+}

--- a/src/utils/nearbyTripResults.js
+++ b/src/utils/nearbyTripResults.js
@@ -1,7 +1,7 @@
 import dayjs from '../dayjs';
 
 export function isNearbyTrip(trip, searchDate) {
-    if (!searchDate || !trip?.trip_date) {
+    if (!searchDate || !trip || !trip.trip_date) {
         return false;
     }
 

--- a/src/utils/nearbyTripResults.js
+++ b/src/utils/nearbyTripResults.js
@@ -1,6 +1,6 @@
 import dayjs from '../dayjs';
 
-function isNearbyTrip(trip, searchDate) {
+export function isNearbyTrip(trip, searchDate) {
     if (!searchDate || !trip?.trip_date) {
         return false;
     }

--- a/src/utils/nearbyTripResults.test.js
+++ b/src/utils/nearbyTripResults.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { shouldShowNearbyResultsHeader } from './nearbyTripResults.js';
+
+describe('shouldShowNearbyResultsHeader', () => {
+    const searchDate = '2026-08-01';
+
+    it('returns false when there is no search date', () => {
+        expect(
+            shouldShowNearbyResultsHeader(
+                { trip_date: '2026-08-02 12:00:00' },
+                null,
+                []
+            )
+        ).toBe(false);
+    });
+
+    it('returns false for a trip on the searched calendar day', () => {
+        expect(
+            shouldShowNearbyResultsHeader(
+                { trip_date: '2026-08-01 09:30:00' },
+                searchDate,
+                []
+            )
+        ).toBe(false);
+    });
+
+    it('returns true for the first nearby trip in the section', () => {
+        expect(
+            shouldShowNearbyResultsHeader(
+                { trip_date: '2026-07-30 09:30:00' },
+                searchDate,
+                [{ trip_date: '2026-08-01 08:00:00' }]
+            )
+        ).toBe(true);
+    });
+
+    it('returns false for later nearby trips so only one header is shown', () => {
+        expect(
+            shouldShowNearbyResultsHeader(
+                { trip_date: '2026-08-02 10:00:00' },
+                searchDate,
+                [
+                    { trip_date: '2026-08-01 08:00:00' },
+                    { trip_date: '2026-07-30 09:30:00' }
+                ]
+            )
+        ).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- Show a single **Resultados cercanos** heading per trip section (instead of repeating it before every nearby trip).
- Add an i18n description under the heading clarifying that nearby results are ±3 days from the chosen date and asking users to double-check the trip date.
- Tighten heading/description spacing so the section is clearer and less easy to confuse with exact-date results.

## Test plan
- [x] Search trips with a date that has both same-day and nearby (±3 days) results
- [x] Confirm exact-date trips appear first without the nearby heading
- [x] Confirm **one** “Resultados cercanos” heading, then all nearby trips under it
- [x] Confirm the description text appears under the heading (Spanish and English locales)
- [x] Spot-check friend/other split sections still show at most one nearby heading each
- [x] `npm run lint` and `npm run test:unit -- --run src/utils/nearbyTripResults.test.js src/language/nearbyResultsI18n.test.js src/components/views/Trips.view.test.js`