### PR TITLE
Sort manual verification list by support tickets

### DIFF
--- a/src/utils/adminManualIdentityValidationsList.js
+++ b/src/utils/adminManualIdentityValidationsList.js
@@ -142,6 +142,36 @@ function getReviewStatusSortRank(item) {
     return REVIEW_STATUS_SORT_ORDER[status] ?? REVIEW_STATUS_SORT_ORDER.pending;
 }
 
+const WORKFLOW_STATE_SORT_ORDER = {
+    unpaid: 0,
+    awaitingPhotos: 1,
+    pendingReview: 2,
+    approved: 3,
+    rejected: 4
+};
+
+function getManualIdentityValidationWorkflowStateSortRank(item) {
+    if (!item?.paid) {
+        return WORKFLOW_STATE_SORT_ORDER.unpaid;
+    }
+
+    if (!item.submitted_at) {
+        return WORKFLOW_STATE_SORT_ORDER.awaitingPhotos;
+    }
+
+    const status = item.review_status;
+
+    if (status === 'approved' || status === 'approve') {
+        return WORKFLOW_STATE_SORT_ORDER.approved;
+    }
+
+    if (status === 'rejected' || status === 'reject') {
+        return WORKFLOW_STATE_SORT_ORDER.rejected;
+    }
+
+    return WORKFLOW_STATE_SORT_ORDER.pendingReview;
+}
+
 const SORT_COMPARATORS = {
     id: (a, b, direction) => compareNumbers(a.id ?? 0, b.id ?? 0, direction),
     user_name: (a, b, direction) => compareNullableValues(
@@ -164,11 +194,23 @@ const SORT_COMPARATORS = {
         getReviewStatusSortRank(b),
         direction
     ),
-    open_account_verification_tickets_count: (a, b, direction) => compareNumbers(
-        Number(a.open_account_verification_tickets_count || 0),
-        Number(b.open_account_verification_tickets_count || 0),
-        direction
-    )
+    open_account_verification_tickets_count: (a, b, direction) => {
+        const ticketCompare = compareNumbers(
+            Number(a.open_account_verification_tickets_count || 0),
+            Number(b.open_account_verification_tickets_count || 0),
+            direction
+        );
+
+        if (ticketCompare !== 0) {
+            return ticketCompare;
+        }
+
+        return compareNumbers(
+            getManualIdentityValidationWorkflowStateSortRank(a),
+            getManualIdentityValidationWorkflowStateSortRank(b),
+            direction
+        );
+    }
 };
 
 export function sortManualIdentityValidationsList(list, sortKey, sortDir = 'asc', now = Date.now()) {

--- a/src/utils/adminManualIdentityValidationsList.test.js
+++ b/src/utils/adminManualIdentityValidationsList.test.js
@@ -151,6 +151,55 @@ describe('adminManualIdentityValidationsList', () => {
             expect(sortManualIdentityValidationsList(list, 'review_status', 'asc').map((item) => item.id))
                 .toEqual([4, 2, 1, 3]);
         });
+
+        it('sorts by open account verification ticket count descending', () => {
+            const list = [
+                { id: 1, open_account_verification_tickets_count: 0 },
+                { id: 2, open_account_verification_tickets_count: 2 },
+                { id: 3, open_account_verification_tickets_count: 1 }
+            ];
+
+            expect(
+                sortManualIdentityValidationsList(
+                    list,
+                    'open_account_verification_tickets_count',
+                    'desc'
+                ).map((item) => item.id)
+            ).toEqual([2, 3, 1]);
+        });
+
+        it('sorts by open account verification ticket count then workflow state', () => {
+            const list = [
+                {
+                    id: 1,
+                    paid: true,
+                    submitted_at: '2026-06-01 10:00:00',
+                    review_status: 'pending',
+                    open_account_verification_tickets_count: 1
+                },
+                {
+                    id: 2,
+                    paid: false,
+                    review_status: 'pending',
+                    open_account_verification_tickets_count: 1
+                },
+                {
+                    id: 3,
+                    paid: true,
+                    submitted_at: null,
+                    review_status: 'awaiting_photos',
+                    open_account_verification_tickets_count: 1
+                }
+            ];
+
+            expect(
+                sortManualIdentityValidationsList(
+                    list,
+                    'open_account_verification_tickets_count',
+                    'asc'
+                ).map((item) => item.id)
+            ).toEqual([2, 3, 1]);
+        });
     });
 
     describe('MANUAL_IDENTITY_VALIDATION_SORT_COLUMNS', () => {
@@ -193,6 +242,22 @@ describe('adminManualIdentityValidationsList', () => {
                 per_page: 20
             });
         });
+
+        it('includes open account verification ticket sort params for the API', () => {
+            expect(
+                buildManualIdentityValidationListParams({
+                    page: 1,
+                    perPage: 20,
+                    sortKey: 'open_account_verification_tickets_count',
+                    sortDir: 'desc'
+                })
+            ).toEqual({
+                page: 1,
+                per_page: 20,
+                sort: 'open_account_verification_tickets_count',
+                direction: 'desc'
+            });
+        });
     });
 
     describe('parseManualIdentityValidationListFromRoute', () => {
@@ -233,6 +298,16 @@ describe('adminManualIdentityValidationsList', () => {
         it('defaults to ascending when selecting other columns for the first time', () => {
             expect(getNextManualIdentityValidationSortState(null, 'asc', 'user_name')).toEqual({
                 sortKey: 'user_name',
+                sortDir: 'asc'
+            });
+            expect(
+                getNextManualIdentityValidationSortState(
+                    null,
+                    'asc',
+                    'open_account_verification_tickets_count'
+                )
+            ).toEqual({
+                sortKey: 'open_account_verification_tickets_count',
                 sortDir: 'asc'
             });
         });


### PR DESCRIPTION
## Summary
- Add workflow-state tiebreaking when sorting manual identity validations by open account verification ticket count in the frontend util
- Wire API sort params for the tickets column (`open_account_verification_tickets_count`) already exposed in the admin table

## Test plan
- [x] `npm run test:unit -- src/utils/adminManualIdentityValidationsList.test.js`
- [x] `npm run test:unit -- src/components/views/AdminManualIdentityValidations.view.test.js`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Deploy with backend PR and click the tickets column header in admin manual verifications; confirm sort toggles asc/desc and URL query updates

**Depends on:** STS-Rosario/carpoolear_backend PR for API sorting support.