### PR TITLE
Fix trip edit date format (avoid 21:00:00:00)

### DIFF
--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -123,6 +123,7 @@ import {
     removeEmptyIntermediatePoints
 } from '../../utils/tripCreationPoints.js';
 import { TRIP_INFO_STATUS } from '../../utils/tripCreationTripInfo.js';
+import { buildTripDateForApi } from '../../utils/tripDateForApi.js';
 import NewTripCreationWizard from './NewTripCreationWizard.vue';
 import TripCreationSuccess from './TripCreationSuccess.vue';
 
@@ -792,7 +793,7 @@ export default {
             if (trip.trip_date) {
                 this.date = dayjs(trip.trip_date.split(' ')[0]).format('YYYY-MM-DD');
                 this.dateAnswer = dayjs(trip.trip_date.split(' ')[0]).format('YYYY-MM-DD');
-                this.time = trip.trip_date.split(' ')[1];
+                this.time = dayjs(trip.trip_date).format('HH:mm');
             }
         }
         
@@ -1311,7 +1312,10 @@ export default {
 
             if (!useWeeklySchedule) {
                 // Only include trip_date when in specific date view (not using weekly schedule)
-                tripInfo.trip_date = tripObj.dateAnswer + ' ' + tripObj.time + ':00';
+                tripInfo.trip_date = buildTripDateForApi(
+                    tripObj.dateAnswer,
+                    tripObj.time
+                );
             } else {
                 // Only include weekly_schedule when in weekly schedule view
                 tripInfo.weekly_schedule = this.weeklySchedule;

--- a/src/utils/tripDateForApi.js
+++ b/src/utils/tripDateForApi.js
@@ -1,0 +1,9 @@
+export function buildTripDateForApi(dateAnswer, time) {
+    const trimmedTime = String(time).trim();
+
+    if (/^\d{1,2}:\d{2}:\d{2}$/.test(trimmedTime)) {
+        return `${dateAnswer} ${trimmedTime}`;
+    }
+
+    return `${dateAnswer} ${trimmedTime}:00`;
+}

--- a/src/utils/tripDateForApi.test.js
+++ b/src/utils/tripDateForApi.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { buildTripDateForApi } from './tripDateForApi.js';
+
+describe('buildTripDateForApi', () => {
+    it('builds trip_date with seconds from date and HH:mm time', () => {
+        expect(buildTripDateForApi('2026-08-16', '21:00')).toBe(
+            '2026-08-16 21:00:00'
+        );
+    });
+
+    it('does not add extra seconds when time already includes them', () => {
+        expect(buildTripDateForApi('2026-08-16', '21:00:00')).toBe(
+            '2026-08-16 21:00:00'
+        );
+    });
+});


### PR DESCRIPTION
## Summary
- Fixes trip edit failing with invalid `trip_date` when the form loaded time as `HH:mm:ss` and submit appended `:00`, producing values like `2026-08-16 21:00:00:00`.
- Adds `buildTripDateForApi` to format `trip_date` as `Y-m-d H:i:s` for both create (`HH:mm`) and edit (`HH:mm:ss`) flows.
- Normalizes loaded edit time to `HH:mm` in `NewTrip.vue` for consistency with the time picker.

## Test plan
- [x] `npm run test:unit -- --run src/utils/tripDateForApi.test.js`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Edit an existing trip and save without changing date/time — API should receive `trip_date` with three time segments (e.g. `2026-08-16 21:00:00`)
- [x] Create a new trip with a specific date/time — `trip_date` should still be valid