### PR TITLE
Add AppPrimaryLink for admin navigation actions

### DIFF
--- a/src/components/ui/AppPrimaryLink.test.js
+++ b/src/components/ui/AppPrimaryLink.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const componentPath = path.resolve(__dirname, 'AppPrimaryLink.vue');
+const source = fs.readFileSync(componentPath, 'utf8');
+
+describe('AppPrimaryLink', () => {
+    it('renders as a router-link with primary button styles', () => {
+        expect(source).toContain('<router-link');
+        expect(source).toContain('app-button--primary');
+        expect(source).toContain(':to="to"');
+    });
+
+    it('supports size variants', () => {
+        expect(source).toContain("default: 'sm'");
+        expect(source).toMatch(/app-button--\$\{this\.size\}/);
+    });
+
+    it('supports external href links', () => {
+        expect(source).toContain('<a');
+        expect(source).toContain(':href="href"');
+    });
+});

--- a/src/components/ui/AppPrimaryLink.vue
+++ b/src/components/ui/AppPrimaryLink.vue
@@ -1,0 +1,59 @@
+<template>
+    <router-link
+        v-if="to"
+        :to="to"
+        :class="linkClasses"
+        v-bind="extraAttrs"
+    >
+        <slot />
+    </router-link>
+    <a
+        v-else
+        :href="href"
+        :class="linkClasses"
+        v-bind="extraAttrs"
+    >
+        <slot />
+    </a>
+</template>
+
+<script>
+export default {
+    name: 'AppPrimaryLink',
+    inheritAttrs: false,
+    props: {
+        to: {
+            type: [String, Object],
+            default: null
+        },
+        href: {
+            type: String,
+            default: ''
+        },
+        size: {
+            type: String,
+            default: 'sm',
+            validator: (value) => ['sm', 'md', 'lg'].includes(value)
+        }
+    },
+    computed: {
+        extraAttrs() {
+            const { class: _class, ...attrs } = this.$attrs;
+            return attrs;
+        },
+        linkClasses() {
+            const classes = [
+                'app-button',
+                'app-button--primary',
+                `app-button--${this.size}`
+            ];
+
+            if (this.$attrs.class) {
+                classes.push(this.$attrs.class);
+            }
+
+            return classes;
+        }
+    }
+};
+</script>

--- a/src/components/views/AdminChangelogs.vue
+++ b/src/components/views/AdminChangelogs.vue
@@ -2,9 +2,9 @@
     <AdminLayout>
         <h3>{{ $t('adminNavChangelog') }}</h3>
         <p class="mb-2">
-            <AppButton variant="primary" :to="{ name: 'admin-changelog-new' }">
+            <AppPrimaryLink size="md" :to="{ name: 'admin-changelog-new' }">
                 {{ $t('nuevoChangelog') }}
-            </AppButton>
+            </AppPrimaryLink>
         </p>
         <p v-if="loading" class="alert alert-info">{{ $t('cargandoNotificaciones') }}</p>
         <p v-else-if="error" class="alert alert-danger">{{ error }}</p>
@@ -59,6 +59,7 @@
 <script>
 import { mapActions, mapState } from 'pinia';
 import AdminLayout from '../layouts/AdminLayout.vue';
+import AppPrimaryLink from '../ui/AppPrimaryLink.vue';
 import AppButton from '../ui/AppButton.vue';
 import { useChangelogStore } from '../../stores/changelog';
 import dayjs from '../../dayjs';
@@ -117,7 +118,8 @@ export default {
     },
     components: {
         AdminLayout,
-        AppButton
+        AppButton,
+        AppPrimaryLink
     }
 };
 </script>

--- a/src/components/views/AdminExcesoContribucion.vue
+++ b/src/components/views/AdminExcesoContribucion.vue
@@ -67,13 +67,11 @@
                                         </span>
                                     </td>
                                     <td>
-                                        <AppButton
-                                            variant="primary"
-                                            size="sm"
+                                        <AppPrimaryLink
                                             :to="adminExcessContributionDetailRoute(item.id)"
                                         >
                                             {{ $t('verDetalle') }}
-                                        </AppButton>
+                                        </AppPrimaryLink>
                                         <router-link
                                             v-if="item.user_id"
                                             :to="getAdminUserProfileRoute(item.user_id)"
@@ -116,7 +114,7 @@
 import AdminLayout from '../layouts/AdminLayout.vue';
 import AdminPaginationBar from '../AdminPaginationBar.vue';
 import Loading from '../Loading';
-import AppButton from '../ui/AppButton.vue';
+import AppPrimaryLink from '../ui/AppPrimaryLink.vue';
 import { AdminApi } from '../../services/api';
 import { getAdminUserProfileRoute } from '../../utils/adminProfileRoute';
 import { DEFAULT_ADMIN_PER_PAGE } from '../../utils/adminPagination';
@@ -261,7 +259,7 @@ export default {
         AdminLayout,
         AdminPaginationBar,
         Loading,
-        AppButton
+        AppPrimaryLink
     }
 };
 </script>

--- a/src/components/views/AdminManualIdentityValidations.vue
+++ b/src/components/views/AdminManualIdentityValidations.vue
@@ -79,13 +79,11 @@
                                     >
                                         {{ $t('verPerfil') }}
                                     </router-link>
-                                    <AppButton
-                                        variant="primary"
-                                        size="sm"
+                                    <AppPrimaryLink
                                         :to="{ name: 'admin-manual-identity-validation-review', params: { id: item.id } }"
                                     >
                                         {{ $t('revisarSolicitud') }}
-                                    </AppButton>
+                                    </AppPrimaryLink>
                                 </td>
                             </tr>
                         </tbody>
@@ -117,7 +115,7 @@
 import AdminLayout from '../layouts/AdminLayout.vue';
 import AdminPaginationBar from '../AdminPaginationBar.vue';
 import Loading from '../Loading';
-import AppButton from '../ui/AppButton.vue';
+import AppPrimaryLink from '../ui/AppPrimaryLink.vue';
 import { AdminApi } from '../../services/api';
 import { getAdminUserProfileRoute } from '../../utils/adminProfileRoute';
 import { adminUserSupportTicketsRoute } from '../../utils/adminUserSupportTicketsLink';
@@ -278,7 +276,7 @@ export default {
         AdminLayout,
         AdminPaginationBar,
         Loading,
-        AppButton
+        AppPrimaryLink
     }
 };
 </script>

--- a/src/components/views/AdminMpRejectedValidations.vue
+++ b/src/components/views/AdminMpRejectedValidations.vue
@@ -39,13 +39,11 @@
                                     >
                                         {{ $t('verPerfil') }}
                                     </router-link>
-                                    <AppButton
-                                        variant="primary"
-                                        size="sm"
+                                    <AppPrimaryLink
                                         :to="{ name: 'admin-mp-rejected-validation-detail', params: { id: item.id } }"
                                     >
                                         {{ $t('verDetalle') }}
-                                    </AppButton>
+                                    </AppPrimaryLink>
                                 </td>
                             </tr>
                         </tbody>
@@ -78,7 +76,7 @@ import { mapState } from 'pinia';
 import AdminLayout from '../layouts/AdminLayout.vue';
 import AdminPaginationBar from '../AdminPaginationBar.vue';
 import Loading from '../Loading';
-import AppButton from '../ui/AppButton.vue';
+import AppPrimaryLink from '../ui/AppPrimaryLink.vue';
 import { useAuthStore } from '../../stores/auth';
 import { AdminApi } from '../../services/api';
 import { getAdminUserProfileRoute } from '../../utils/adminProfileRoute';
@@ -161,7 +159,7 @@ export default {
         AdminLayout,
         AdminPaginationBar,
         Loading,
-        AppButton
+        AppPrimaryLink
     }
 };
 </script>

--- a/src/components/views/AdminSupportReplyTemplates.vue
+++ b/src/components/views/AdminSupportReplyTemplates.vue
@@ -5,12 +5,9 @@
         </p>
         <h3>{{ $t('plantillasRespuestas') }}</h3>
         <p class="mb-2">
-            <AppButton
-                variant="primary"
-                :to="{ name: 'admin-support-reply-template-new' }"
-            >
+            <AppPrimaryLink size="md" :to="{ name: 'admin-support-reply-template-new' }">
                 {{ $t('nuevaPlantillaRespuesta') }}
-            </AppButton>
+            </AppPrimaryLink>
         </p>
         <p v-if="loading" class="alert alert-info">{{ $t('cargandoNotificaciones') }}</p>
         <p v-else-if="error" class="alert alert-danger">{{ error }}</p>
@@ -66,6 +63,7 @@
 <script>
 import { mapActions, mapState } from 'pinia';
 import AdminLayout from '../layouts/AdminLayout.vue';
+import AppPrimaryLink from '../ui/AppPrimaryLink.vue';
 import AppButton from '../ui/AppButton.vue';
 import { useReplyTemplatesStore } from '../../stores/replyTemplates';
 import dayjs from '../../dayjs';
@@ -128,7 +126,8 @@ export default {
     },
     components: {
         AdminLayout,
-        AppButton
+        AppButton,
+        AppPrimaryLink
     }
 };
 </script>

--- a/src/components/views/AdminSupportTickets.vue
+++ b/src/components/views/AdminSupportTickets.vue
@@ -2,12 +2,9 @@
     <AdminLayout>
         <h3>{{ $t('soporte') }}</h3>
         <p class="mb-2 support-tickets-admin-actions">
-            <AppButton
-                variant="primary"
-                :to="{ name: 'admin-support-ticket-new' }"
-            >
+            <AppPrimaryLink size="md" :to="{ name: 'admin-support-ticket-new' }">
                 {{ $t('crearTicket') }}
-            </AppButton>
+            </AppPrimaryLink>
             <AppButton
                 variant="secondary"
                 class="mleft-6"
@@ -134,6 +131,7 @@
 import { mapActions, mapState } from 'pinia';
 import AdminLayout from '../layouts/AdminLayout.vue';
 import AdminPaginationBar from '../AdminPaginationBar.vue';
+import AppPrimaryLink from '../ui/AppPrimaryLink.vue';
 import AppButton from '../ui/AppButton.vue';
 import AppField from '../ui/AppField.vue';
 import { useTicketsStore } from '../../stores/tickets';
@@ -397,7 +395,8 @@ export default {
         AdminLayout,
         AdminPaginationBar,
         AppButton,
-        AppField
+        AppField,
+        AppPrimaryLink
     }
 };
 </script>

--- a/src/components/views/AdminUserDetail.vue
+++ b/src/components/views/AdminUserDetail.vue
@@ -152,15 +152,15 @@
                             </AppButton>
                         </p>
                         <p class="user-admin-view-actions">
-                            <AppButton
-                                variant="primary"
+                            <AppPrimaryLink
+                                size="md"
                                 :to="{
                                     name: 'admin-users-edit',
                                     params: { userId: String(user.id) }
                                 }"
                             >
                                 {{ $t('adminUsuariosEditar') }}
-                            </AppButton>
+                            </AppPrimaryLink>
                             <AppButton
                                 variant="secondary"
                                 :to="supportTicketRoute(user)"
@@ -202,6 +202,7 @@ import { mapActions, mapState } from 'pinia';
 import { useConversationsStore } from '../../stores/conversations';
 import { useAuthStore } from '../../stores/auth';
 import AdminLayout from '../layouts/AdminLayout.vue';
+import AppPrimaryLink from '../ui/AppPrimaryLink.vue';
 import AppButton from '../ui/AppButton.vue';
 import { adminUserSupportTicketsRoute } from '../../utils/adminUserSupportTicketsLink';
 import { formatAdminUserNavLabelFromKey } from '../../utils/adminUserNavLabel';
@@ -363,7 +364,8 @@ export default {
     },
     components: {
         AdminLayout,
-        AppButton
+        AppButton,
+        AppPrimaryLink
     }
 };
 </script>

--- a/src/components/views/AdminUserMigrationsList.vue
+++ b/src/components/views/AdminUserMigrationsList.vue
@@ -5,12 +5,9 @@
                 <div class="col-md-22 col-md-offset-1">
                     <div class="admin-user-migrations__header">
                         <h3 class="admin-user-migrations__title">{{ $t('migrarUsuarios') }}</h3>
-                        <AppButton
-                            variant="primary"
-                            :to="{ name: 'admin-user-migration-new' }"
-                        >
+                        <AppPrimaryLink size="md" :to="{ name: 'admin-user-migration-new' }">
                             {{ $t('nuevaMigracionDeUsuario') }}
-                        </AppButton>
+                        </AppPrimaryLink>
                     </div>
                     <div v-if="listLoading" class="alert alert-info">
                         <img
@@ -77,7 +74,7 @@
 <script>
 import AdminLayout from '../layouts/AdminLayout.vue';
 import AdminPaginationBar from '../AdminPaginationBar.vue';
-import AppButton from '../ui/AppButton.vue';
+import AppPrimaryLink from '../ui/AppPrimaryLink.vue';
 import { AdminApi } from '../../services/api';
 import dialogs from '../../services/dialogs.js';
 import dayjs from '../../dayjs';
@@ -157,7 +154,7 @@ export default {
     components: {
         AdminLayout,
         AdminPaginationBar,
-        AppButton
+        AppPrimaryLink
     }
 };
 </script>


### PR DESCRIPTION
## Summary
- Add reusable `AppPrimaryLink` component: a `router-link` styled as a primary button, so admins can right-click and open destinations in a new tab.
- Replace primary `AppButton` navigation links across admin lists and related admin pages (manual verifications, MP rejections, excess contribution, changelogs, support tickets, reply templates, user migrations, user detail).

## Test plan
- [x] Open Admin → Verificaciones manuales and confirm "Revisar solicitud" looks like a primary button and opens the review page; right-click → "Open in new tab" works.
- [x] Repeat for "Ver detalle" in Exceso de contribución and Rechazos MercadoPago lists.
- [x] Confirm header actions (Crear ticket, Nuevo changelog, etc.) still look correct with `size="md"`.
- [x] Run `npm run test:unit -- --run src/components/ui/AppPrimaryLink.test.js`