### PR TITLE
Support multiple document ID masks (DNI and passport)

### DIFF
--- a/config/conf.json
+++ b/config/conf.json
@@ -37,11 +37,7 @@
     "trips_auto_search": false,
     "trips_focus_next": false,
     "autocomplete_select_first": false,
-    "profile_id_format": "##.###.###",
-    "profile_id_formats": [
-        { "type": "dni", "pattern": "##.###.###" },
-        { "type": "passport", "pattern": "A########" }
-    ],
+    "profile_id_format": "##.###.###,A########",
     "weekly_schedule": false,
     "web_push_notification": true,
     "price_show_cents": false,

--- a/config/conf.json
+++ b/config/conf.json
@@ -38,6 +38,10 @@
     "trips_focus_next": false,
     "autocomplete_select_first": false,
     "profile_id_format": "##.###.###",
+    "profile_id_formats": [
+        { "type": "dni", "pattern": "##.###.###" },
+        { "type": "passport", "pattern": "A########" }
+    ],
     "weekly_schedule": false,
     "web_push_notification": true,
     "price_show_cents": false,

--- a/e2e-frontend/shared/mocks.js
+++ b/e2e-frontend/shared/mocks.js
@@ -43,11 +43,7 @@ const MOCK_CONFIG = {
   trips_auto_search: false,
   trips_focus_next: false,
   autocomplete_select_first: false,
-  profile_id_format: '##.###.###',
-  profile_id_formats: [
-    { type: 'dni', pattern: '##.###.###' },
-    { type: 'passport', pattern: 'A########' }
-  ],
+  profile_id_format: '##.###.###,A########',
   weekly_schedule: false,
   web_push_notification: false,
   price_show_cents: false,

--- a/e2e-frontend/shared/mocks.js
+++ b/e2e-frontend/shared/mocks.js
@@ -44,6 +44,10 @@ const MOCK_CONFIG = {
   trips_focus_next: false,
   autocomplete_select_first: false,
   profile_id_format: '##.###.###',
+  profile_id_formats: [
+    { type: 'dni', pattern: '##.###.###' },
+    { type: 'passport', pattern: 'A########' }
+  ],
   weekly_schedule: false,
   web_push_notification: false,
   price_show_cents: false,

--- a/src/components/sections/IdentityValidation.vue
+++ b/src/components/sections/IdentityValidation.vue
@@ -538,7 +538,7 @@ export default {
         },
         mismatchDetails() {
             return getIdentityValidationMismatchDetails(this.$route.query || {}, {
-                profileIdFormat: this.config && this.config.profile_id_format
+                profileIdFormat: this.config
             });
         },
         mismatchSupportWarningKey() {

--- a/src/components/sections/ProfileInfo.vue
+++ b/src/components/sections/ProfileInfo.vue
@@ -246,7 +246,7 @@ import { useConversationsStore } from '../../stores/conversations';
 import { useFriendsStore } from '../../stores/friends';
 import router from '../../router';
 import dialogs from '../../services/dialogs.js';
-import { formatId } from '../../services/utility';
+import { formatDocumentIdFromConfig } from '../../utils/documentId';
 import { activeCarsWithPlate } from '../../utils/userCars.js';
 import AppButton from '../ui/AppButton.vue';
 
@@ -272,7 +272,7 @@ export default {
             if (!this.profile || !this.profile.nro_doc) {
                 return '';
             }
-            return formatId(this.profile.nro_doc, this.config.profile_id_format);
+            return formatDocumentIdFromConfig(this.profile.nro_doc, this.config);
         },
         visibleCars() {
             return activeCarsWithPlate(this.profile?.cars);

--- a/src/components/sections/UpdateProfile.vue
+++ b/src/components/sections/UpdateProfile.vue
@@ -159,6 +159,9 @@
                             <span class="description">
                                 {{ $t('incentivoDoc') }} {{ $t('doc') }}
                                 {{ $t('momentoViajar') }}
+                                <span v-if="documentIdPlaceholder">
+                                    ({{ documentIdPlaceholder }})
+                                </span>
                             </span>
                         </template>
                     </AppInput>

--- a/src/components/sections/UpdateProfile.vue
+++ b/src/components/sections/UpdateProfile.vue
@@ -143,8 +143,8 @@
                         type="tel"
                         :model-value="user.nro_doc"
                         @update:modelValue="onDniModelUpdate"
-                        :placeholder="config.profile_id_format"
-                        :maxlength="(config.profile_id_format).length"
+                        :placeholder="documentIdPlaceholder"
+                        :maxlength="documentIdMaxLength"
                         :disabled="isDniLockedByValidation"
                         :title="dniInputTitle"
                         :error="dniError.state ? dniError.message : ''"
@@ -591,7 +591,16 @@ import { mapState, mapActions } from 'pinia';
 import { useAuthStore } from '../../stores/auth';
 import { useDeviceStore } from '../../stores/device';
 import { useProfileStore } from '../../stores/profile';
-import { inputIsNumber, formatId, cleanId } from '../../services/utility';
+import { inputIsNumber } from '../../services/utility';
+import {
+    cleanDocumentIdForStorageFromConfig,
+    formatDocumentIdFromConfig,
+    formatDocumentIdInput,
+    getDocumentIdPlaceholderFromConfig,
+    getMaxDocumentIdInputLengthFromConfig,
+    isValidDocumentIdForConfig,
+    resolveProfileIdFormats
+} from '../../utils/documentId';
 import Uploadfile from '../Uploadfile';
 import DatePicker from '../DatePicker';
 import SvgItem from '../SvgItem';
@@ -671,6 +680,12 @@ export default {
         ...mapState(useDeviceStore, {
             isMobile: 'isMobile'
         }),
+        documentIdMaxLength() {
+            return getMaxDocumentIdInputLengthFromConfig(this.config);
+        },
+        documentIdPlaceholder() {
+            return getDocumentIdPlaceholderFromConfig(this.config);
+        },
         iptUser() {
             if (this.user) {
                 return this.user.name;
@@ -750,9 +765,9 @@ export default {
         syncProfileDraftFromStore() {
             this.user = cloneProfileUser(this.userData);
             if (this.user && this.user.nro_doc) {
-                this.user.nro_doc = formatId(
+                this.user.nro_doc = formatDocumentIdFromConfig(
                     this.user.nro_doc,
-                    this.config.profile_id_format
+                    this.config
                 );
             }
         },
@@ -793,14 +808,11 @@ export default {
             inputIsNumber(value);
         },
         // Handle DNI input - format using pattern
-        handleDniInput(event) {
-            const formatted = formatId(event.target.value, this.config.profile_id_format);
-            event.target.value = formatted;
-            // Update the Vue data model with the formatted value
-            this.user.nro_doc = formatted;
-        },
         onDniModelUpdate(value) {
-            this.user.nro_doc = formatId(value, this.config.profile_id_format);
+            this.user.nro_doc = formatDocumentIdInput(
+                value,
+                resolveProfileIdFormats(this.config)
+            );
         },
         onPhotoChange(data) {
             this.loadingImg = true;
@@ -842,7 +854,10 @@ export default {
             this.loading = true;
             // Ensure user.nro_doc is raw value (no dots) before sending
             if (this.user && this.user.nro_doc) {
-                this.user.nro_doc = cleanId(this.user.nro_doc, this.config.profile_id_format);
+                this.user.nro_doc = cleanDocumentIdForStorageFromConfig(
+                    this.user.nro_doc,
+                    this.config
+                );
             }
             // Only send properties the backend allows for profile edit (email is read-only)
             const allowedProfileUpdateKeys = [
@@ -1018,14 +1033,14 @@ export default {
 
             // Get raw DNI value (strip any dots that might be present)
             const dniRaw = this.user && this.user.nro_doc
-                ? cleanId(this.user.nro_doc, this.config.profile_id_format)
+                ? cleanDocumentIdForStorageFromConfig(this.user.nro_doc, this.config)
                 : '';
-            
+
             if (!dniRaw || dniRaw.length < 1) {
                 this.dniError.state = true;
                 this.dniError.message = this.$t('olvidasteDni');
                 globalError = true;
-            } else if (dniRaw.length > 0 && dniRaw.length < 7) {
+            } else if (!isValidDocumentIdForConfig(this.user.nro_doc, this.config)) {
                 this.dniError.state = true;
                 this.dniError.message = this.$t('dniNoValido');
                 globalError = true;

--- a/src/components/views/AdminManualIdentityValidationReview.vue
+++ b/src/components/views/AdminManualIdentityValidationReview.vue
@@ -324,7 +324,7 @@ export default {
         displayDniOrDash(value) {
             return formatDisplayDniOrDash(
                 value,
-                this.config && this.config.profile_id_format,
+                this.config,
                 '-'
             );
         },

--- a/src/components/views/AdminMpRejectedValidationDetail.vue
+++ b/src/components/views/AdminMpRejectedValidationDetail.vue
@@ -184,7 +184,7 @@ export default {
         displayDniOrDash(value) {
             return formatDisplayDniOrDash(
                 value,
-                this.config && this.config.profile_id_format,
+                this.config,
                 '-'
             );
         },

--- a/src/components/views/AdminMpRejectedValidations.vue
+++ b/src/components/views/AdminMpRejectedValidations.vue
@@ -102,7 +102,7 @@ export default {
         displayDniOrDash(value) {
             return formatDisplayDniOrDash(
                 value,
-                this.config && this.config.profile_id_format,
+                this.config,
                 '-'
             );
         },

--- a/src/components/views/AdminUserDetail.view.test.js
+++ b/src/components/views/AdminUserDetail.view.test.js
@@ -54,8 +54,8 @@ describe('AdminUserDetail view', () => {
         expect(source).toContain("'alert-' + bannedBanner.modifier");
     });
 
-    it('passes profile_id_format when building admin user property rows', () => {
-        expect(source).toContain('profileIdFormat: this.config && this.config.profile_id_format');
+    it('passes app config when building admin user property rows', () => {
+        expect(source).toContain('profileIdFormat: this.config');
     });
 
     it('renders all user properties from the admin profile payload', () => {

--- a/src/components/views/AdminUserDetail.vue
+++ b/src/components/views/AdminUserDetail.vue
@@ -240,7 +240,7 @@ export default {
         propertyRows() {
             return buildAdminUserPropertyRows(this.user, {
                 translate: this.$t.bind(this),
-                profileIdFormat: this.config && this.config.profile_id_format,
+                profileIdFormat: this.config,
                 showFacebookProfileUrl: !!(
                     this.config && this.config.module_facebook_profile_url_enabled
                 ),

--- a/src/components/views/AdminUserMigrationNew.view.test.js
+++ b/src/components/views/AdminUserMigrationNew.view.test.js
@@ -34,7 +34,7 @@ describe('AdminUserMigrationNew view', () => {
 
     it('formats DNI in the migration field comparison table', () => {
         expect(source).toContain('formatMigrationFieldValue');
-        expect(source).toContain('profile_id_format');
+        expect(source).toContain('profileIdFormat: this.config');
     });
 
     it('renders the user email and a friendly join date in the field comparison table', () => {

--- a/src/components/views/AdminUserMigrationNew.vue
+++ b/src/components/views/AdminUserMigrationNew.vue
@@ -275,7 +275,7 @@ export default {
             }
             if (fieldKey === 'nro_doc') {
                 return formatMigrationFieldValue(fieldKey, user, {
-                    profileIdFormat: this.config && this.config.profile_id_format
+                    profileIdFormat: this.config
                 });
             }
             const value = user[fieldKey];

--- a/src/components/views/AdminUsersList.view.test.js
+++ b/src/components/views/AdminUsersList.view.test.js
@@ -15,7 +15,7 @@ describe('AdminUsersList view', () => {
         expect(viewSource).toContain('{{ displayDniOrDash(u.nro_doc) }}');
         expect(viewSource).toContain('{{ displayOrDash(u.mobile_phone) }}');
         expect(viewSource).toContain('displayDniOrDash(value)');
-        expect(viewSource).toContain('profile_id_format');
+        expect(viewSource).toContain('this.config');
     });
 
     it('syncs search, page and sorting in route query for back navigation persistence', () => {

--- a/src/components/views/AdminUsersList.vue
+++ b/src/components/views/AdminUsersList.vue
@@ -161,7 +161,7 @@ export default {
         displayDniOrDash(value) {
             return formatDisplayDniOrDash(
                 value,
-                this.config && this.config.profile_id_format
+                this.config
             );
         },
         normalizedSearchQuery() {

--- a/src/components/views/BannedUsersList.vue
+++ b/src/components/views/BannedUsersList.vue
@@ -76,7 +76,7 @@ export default {
         displayDniOrDash(value) {
             return formatDisplayDniOrDash(
                 value,
-                this.config && this.config.profile_id_format,
+                this.config,
                 '-'
             );
         },

--- a/src/components/views/UsersCrud.view.test.js
+++ b/src/components/views/UsersCrud.view.test.js
@@ -6,13 +6,14 @@ const viewPath = path.resolve(__dirname, 'UsersCrud.vue');
 const source = fs.readFileSync(viewPath, 'utf8');
 
 describe('UsersCrud admin edit view', () => {
-    it('formats DNI via model-value and update handler like UpdateProfile', () => {
+    it('formats document id via model-value and update handler like UpdateProfile', () => {
         expect(source).toMatch(
             /<AppInput[\s\S]*?id="input-dni"[\s\S]*?:model-value="newInfo\.nro_doc"/
         );
         expect(source).toMatch(/@update:modelValue="onDniModelUpdate"/);
         expect(source).toContain('onDniModelUpdate(value)');
-        expect(source).toContain('formatId(value, this.settings.profile_id_format)');
+        expect(source).toContain('formatDocumentIdInput(');
+        expect(source).toContain('resolveProfileIdFormats(this.settings)');
     });
 
     it('keeps phone number keydown and paste guards on AppInput', () => {

--- a/src/components/views/UsersCrud.vue
+++ b/src/components/views/UsersCrud.vue
@@ -101,7 +101,15 @@
                                 :maxlength="documentIdMaxLength"
                                 :error="dniError.state ? dniError.message : ''"
                             >
-                                <template #label>{{ $t('numeroDeDocumento') }}</template>
+                                <template #label>
+                                    {{ $t('numeroDeDocumento') }}
+                                    <span
+                                        v-if="documentIdPlaceholder"
+                                        class="description"
+                                    >
+                                        ({{ documentIdPlaceholder }})
+                                    </span>
+                                </template>
                             </AppInput>
 
                             <AppInput

--- a/src/components/views/UsersCrud.vue
+++ b/src/components/views/UsersCrud.vue
@@ -97,8 +97,8 @@
                                 type="tel"
                                 :model-value="newInfo.nro_doc"
                                 @update:modelValue="onDniModelUpdate"
-                                :placeholder="$t('doc')"
-                                :maxlength="(settings.profile_id_format).length"
+                                :placeholder="documentIdPlaceholder"
+                                :maxlength="documentIdMaxLength"
                                 :error="dniError.state ? dniError.message : ''"
                             >
                                 <template #label>{{ $t('numeroDeDocumento') }}</template>
@@ -399,7 +399,16 @@ import { useAuthStore } from '../../stores/auth';
 import { useAdminStore } from '../../stores/admin';
 import { useProfileStore } from '../../stores/profile';
 import { Thread } from '../../classes/Threads.js';
-import { inputIsNumber, formatId, cleanId } from '../../services/utility';
+import { inputIsNumber } from '../../services/utility';
+import {
+    cleanDocumentIdForStorageFromConfig,
+    formatDocumentIdFromConfig,
+    formatDocumentIdInput,
+    getDocumentIdPlaceholderFromConfig,
+    getMaxDocumentIdInputLengthFromConfig,
+    isValidDocumentIdForConfig,
+    resolveProfileIdFormats
+} from '../../utils/documentId';
 import { normalizeFacebookProfileUrl } from '../../utils/facebookProfileUrl.js';
 import dialogs from '../../services/dialogs.js';
 import AdminLayout from '../layouts/AdminLayout.vue';
@@ -468,6 +477,12 @@ export default {
         ...mapState(useAuthStore, {
             settings: 'appConfig'
         }),
+        documentIdMaxLength() {
+            return getMaxDocumentIdInputLengthFromConfig(this.settings);
+        },
+        documentIdPlaceholder() {
+            return getDocumentIdPlaceholderFromConfig(this.settings);
+        },
         confirmModalTitle() {
             if (this.pendingAction === 'delete') return this.$t('confirmarEliminarUsuario');
             if (this.pendingAction === 'anonymize') return this.$t('confirmarAnonimizarUsuario');
@@ -554,9 +569,7 @@ export default {
             this.currentUser = user;
             console.log('selectUser', user);
             // Ensure nro_doc is stored as raw value (no dots) when loaded from backend
-            const nroDocRaw = this.currentUser.nro_doc
-                ? cleanId(this.currentUser.nro_doc, this.settings.profile_id_format)
-                : '';
+            const nroDocRaw = this.currentUser.nro_doc || '';
             this.newInfo = {
                 name: this.currentUser.name,
                 email: this.currentUser.email,
@@ -581,22 +594,21 @@ export default {
             };
             // Format nro_doc for display after loading
             if (this.newInfo.nro_doc) {
-                this.newInfo.nro_doc = formatId(this.newInfo.nro_doc, this.settings.profile_id_format);
+                this.newInfo.nro_doc = formatDocumentIdFromConfig(
+                    nroDocRaw,
+                    this.settings
+                );
             }
         },
         isNumber(value) {
             inputIsNumber(value);
         },
 
-        // Handle DNI input - format using pattern
-        handleDniInput(event) {
-            const formatted = formatId(event.target.value, this.settings.profile_id_format);
-            event.target.value = formatted;
-            // Update the Vue data model with the formatted value
-            this.newInfo.nro_doc = formatted;
-        },
         onDniModelUpdate(value) {
-            this.newInfo.nro_doc = formatId(value, this.settings.profile_id_format);
+            this.newInfo.nro_doc = formatDocumentIdInput(
+                value,
+                resolveProfileIdFormats(this.settings)
+            );
         },
 
         resetUserState() {
@@ -738,6 +750,12 @@ export default {
                 globalError = true;
             } */
 
+            if (this.newInfo.nro_doc && !isValidDocumentIdForConfig(this.newInfo.nro_doc, this.settings)) {
+                this.dniError.state = true;
+                this.dniError.message = this.$t('dniNoValido');
+                globalError = true;
+            }
+
             // Validate patente if provided - allow all strings
             if (this.newInfo.patente && this.newInfo.patente.length > 0) {
                 // Basic validation: just check it's not empty and has reasonable length
@@ -760,7 +778,10 @@ export default {
             if (!this.validate()) {
                 // DNI: send raw value without dots (backend expects digits only)
                 const nroDocRaw = this.newInfo.nro_doc
-                    ? cleanId(this.newInfo.nro_doc, this.settings.profile_id_format)
+                    ? cleanDocumentIdForStorageFromConfig(
+                        this.newInfo.nro_doc,
+                        this.settings
+                    )
                     : this.newInfo.nro_doc;
 
                 // Patente: trim whitespace before sending

--- a/src/utils/documentId.config.test.js
+++ b/src/utils/documentId.config.test.js
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import {
+    cleanDocumentIdForStorageFromConfig,
+    formatDocumentIdFromConfig,
+    getDocumentIdPlaceholderFromConfig,
+    getMaxDocumentIdInputLengthFromConfig,
+    isValidDocumentIdForConfig
+} from './documentId';
+
+const APP_CONFIG = {
+    profile_id_format: '##.###.###',
+    profile_id_formats: [
+        { type: 'dni', pattern: '##.###.###' },
+        { type: 'passport', pattern: 'A########' }
+    ]
+};
+
+describe('document id config helpers', () => {
+    it('formats passport values from app config', () => {
+        expect(formatDocumentIdFromConfig('A33070219', APP_CONFIG)).toBe(
+            'A33070219'
+        );
+    });
+
+    it('normalizes DNI for storage from app config', () => {
+        expect(
+            cleanDocumentIdForStorageFromConfig('30.123.456', APP_CONFIG)
+        ).toBe('30123456');
+    });
+
+    it('rejects values outside allowed masks from app config', () => {
+        expect(isValidDocumentIdForConfig('ABC123', APP_CONFIG)).toBe(false);
+    });
+
+    it('uses the longest mask for input maxlength', () => {
+        expect(getMaxDocumentIdInputLengthFromConfig(APP_CONFIG)).toBe(10);
+    });
+
+    it('builds a placeholder from all allowed masks', () => {
+        expect(getDocumentIdPlaceholderFromConfig(APP_CONFIG)).toBe(
+            '##.###.### / A########'
+        );
+    });
+});

--- a/src/utils/documentId.config.test.js
+++ b/src/utils/documentId.config.test.js
@@ -8,11 +8,7 @@ import {
 } from './documentId';
 
 const APP_CONFIG = {
-    profile_id_format: '##.###.###',
-    profile_id_formats: [
-        { type: 'dni', pattern: '##.###.###' },
-        { type: 'passport', pattern: 'A########' }
-    ]
+    profile_id_format: '##.###.###,A########'
 };
 
 describe('document id config helpers', () => {

--- a/src/utils/documentId.js
+++ b/src/utils/documentId.js
@@ -45,7 +45,7 @@ function resolvePatterns(formats) {
     }
 
     if (typeof formats === 'string' && formats.length > 0) {
-        return [formats];
+        return parseProfileIdFormat(formats);
     }
 
     return [];
@@ -68,13 +68,20 @@ function findBestPatternMatch(cleaned, patterns, requireComplete = false) {
     return best;
 }
 
-export function resolveProfileIdFormats(config = {}) {
-    if (Array.isArray(config.profile_id_formats) && config.profile_id_formats.length) {
-        return config.profile_id_formats;
+export function parseProfileIdFormat(value) {
+    if (!value || typeof value !== 'string') {
+        return [];
     }
 
+    return value
+        .split(',')
+        .map((pattern) => pattern.trim())
+        .filter(Boolean);
+}
+
+export function resolveProfileIdFormats(config = {}) {
     if (config.profile_id_format) {
-        return [{ type: 'default', pattern: config.profile_id_format }];
+        return parseProfileIdFormat(config.profile_id_format);
     }
 
     return [];
@@ -159,9 +166,7 @@ export function getMaxDocumentIdInputLengthFromConfig(config) {
 }
 
 export function getDocumentIdPlaceholderFromConfig(config) {
-    return resolveProfileIdFormats(config)
-        .map((entry) => entry.pattern)
-        .join(' / ');
+    return resolveProfileIdFormats(config).join(' / ');
 }
 
 export function formatDocumentIdInput(value, formats) {

--- a/src/utils/documentId.js
+++ b/src/utils/documentId.js
@@ -82,7 +82,8 @@ export function resolveProfileIdFormats(config = {}) {
     return [];
 }
 
-export function formatDocumentId(value, formats) {
+export function formatDocumentId(value, formats, options = {}) {
+    const { allowPartial = false } = options;
     const cleaned = cleanDocumentIdValue(value);
     if (!cleaned) {
         return '';
@@ -92,6 +93,10 @@ export function formatDocumentId(value, formats) {
     const best = findBestPatternMatch(cleaned, patterns, true);
     if (best) {
         return best.match.formatted;
+    }
+
+    if (!allowPartial) {
+        return '';
     }
 
     const partialBest = findBestPatternMatch(cleaned, patterns, false);
@@ -155,4 +160,6 @@ export function getMaxDocumentIdInputLengthFromConfig(config) {
     return getMaxDocumentIdInputLength(resolveProfileIdFormats(config));
 }
 
-export { cleanDocumentIdValue, formatId };
+export function formatDocumentIdInput(value, formats) {
+    return formatDocumentId(value, formats, { allowPartial: true });
+}

--- a/src/utils/documentId.js
+++ b/src/utils/documentId.js
@@ -1,5 +1,3 @@
-import { formatId } from '../services/utility';
-
 function cleanDocumentIdValue(value) {
     return String(value || '')
         .replace(/[^a-zA-Z0-9]/g, '')

--- a/src/utils/documentId.js
+++ b/src/utils/documentId.js
@@ -160,6 +160,14 @@ export function getMaxDocumentIdInputLengthFromConfig(config) {
     return getMaxDocumentIdInputLength(resolveProfileIdFormats(config));
 }
 
+export function getDocumentIdPlaceholderFromConfig(config) {
+    return resolveProfileIdFormats(config)
+        .map((entry) => entry.pattern)
+        .join(' / ');
+}
+
 export function formatDocumentIdInput(value, formats) {
     return formatDocumentId(value, formats, { allowPartial: true });
 }
+
+export { cleanDocumentIdValue };

--- a/src/utils/documentId.js
+++ b/src/utils/documentId.js
@@ -1,0 +1,158 @@
+import { formatId } from '../services/utility';
+
+function cleanDocumentIdValue(value) {
+    return String(value || '')
+        .replace(/[^a-zA-Z0-9]/g, '')
+        .toUpperCase();
+}
+
+function matchDocumentIdPattern(cleaned, pattern) {
+    let formatted = '';
+    let cleanedIndex = 0;
+
+    for (let i = 0; i < pattern.length; i++) {
+        if (cleanedIndex >= cleaned.length) {
+            break;
+        }
+
+        if (pattern[i] === '#') {
+            if (!/[0-9]/.test(cleaned[cleanedIndex])) {
+                return { formatted, consumed: cleanedIndex, complete: false };
+            }
+            formatted += cleaned[cleanedIndex];
+            cleanedIndex++;
+        } else if (pattern[i] === 'A') {
+            if (!/[A-Z]/.test(cleaned[cleanedIndex])) {
+                return { formatted, consumed: cleanedIndex, complete: false };
+            }
+            formatted += cleaned[cleanedIndex];
+            cleanedIndex++;
+        } else {
+            formatted += pattern[i];
+        }
+    }
+
+    return {
+        formatted,
+        consumed: cleanedIndex,
+        complete: cleanedIndex === cleaned.length
+    };
+}
+
+function resolvePatterns(formats) {
+    if (Array.isArray(formats)) {
+        return formats.map((entry) =>
+            typeof entry === 'string' ? entry : entry.pattern
+        );
+    }
+
+    if (typeof formats === 'string' && formats.length > 0) {
+        return [formats];
+    }
+
+    return [];
+}
+
+function findBestPatternMatch(cleaned, patterns, requireComplete = false) {
+    let best = null;
+
+    patterns.forEach((pattern) => {
+        const match = matchDocumentIdPattern(cleaned, pattern);
+        if (requireComplete && !match.complete) {
+            return;
+        }
+
+        if (!best || match.consumed > best.match.consumed) {
+            best = { pattern, match };
+        }
+    });
+
+    return best;
+}
+
+export function resolveProfileIdFormats(config = {}) {
+    if (Array.isArray(config.profile_id_formats) && config.profile_id_formats.length) {
+        return config.profile_id_formats;
+    }
+
+    if (config.profile_id_format) {
+        return [{ type: 'default', pattern: config.profile_id_format }];
+    }
+
+    return [];
+}
+
+export function formatDocumentId(value, formats) {
+    const cleaned = cleanDocumentIdValue(value);
+    if (!cleaned) {
+        return '';
+    }
+
+    const patterns = resolvePatterns(formats);
+    const best = findBestPatternMatch(cleaned, patterns, true);
+    if (best) {
+        return best.match.formatted;
+    }
+
+    const partialBest = findBestPatternMatch(cleaned, patterns, false);
+    return partialBest ? partialBest.match.formatted : '';
+}
+
+export function cleanDocumentIdForStorage(value, formats) {
+    const cleaned = cleanDocumentIdValue(value);
+    if (!cleaned) {
+        return '';
+    }
+
+    const patterns = resolvePatterns(formats);
+    const best = findBestPatternMatch(cleaned, patterns, true);
+    if (!best) {
+        return '';
+    }
+
+    return cleaned;
+}
+
+export function isValidDocumentId(value, formats) {
+    const cleaned = cleanDocumentIdValue(value);
+    if (!cleaned) {
+        return false;
+    }
+
+    const patterns = resolvePatterns(formats);
+    return Boolean(findBestPatternMatch(cleaned, patterns, true));
+}
+
+export function getMaxDocumentIdInputLength(formats) {
+    const patterns = resolvePatterns(formats);
+    if (!patterns.length) {
+        return 0;
+    }
+
+    return patterns.reduce(
+        (maxLength, pattern) => Math.max(maxLength, pattern.length),
+        0
+    );
+}
+
+export function getProfileIdFormatsFromConfig(config) {
+    return resolveProfileIdFormats(config);
+}
+
+export function formatDocumentIdFromConfig(value, config) {
+    return formatDocumentId(value, resolveProfileIdFormats(config));
+}
+
+export function cleanDocumentIdForStorageFromConfig(value, config) {
+    return cleanDocumentIdForStorage(value, resolveProfileIdFormats(config));
+}
+
+export function isValidDocumentIdForConfig(value, config) {
+    return isValidDocumentId(value, resolveProfileIdFormats(config));
+}
+
+export function getMaxDocumentIdInputLengthFromConfig(config) {
+    return getMaxDocumentIdInputLength(resolveProfileIdFormats(config));
+}
+
+export { cleanDocumentIdValue, formatId };

--- a/src/utils/documentId.test.js
+++ b/src/utils/documentId.test.js
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import {
+    cleanDocumentIdForStorage,
+    formatDocumentId,
+    getMaxDocumentIdInputLength,
+    isValidDocumentId,
+    resolveProfileIdFormats
+} from './documentId';
+
+const PROFILE_ID_FORMATS = [
+    { type: 'dni', pattern: '##.###.###' },
+    { type: 'passport', pattern: 'A########' }
+];
+
+describe('resolveProfileIdFormats', () => {
+    it('returns configured profile_id_formats when present', () => {
+        expect(
+            resolveProfileIdFormats({
+                profile_id_formats: PROFILE_ID_FORMATS
+            })
+        ).toEqual(PROFILE_ID_FORMATS);
+    });
+
+    it('falls back to legacy profile_id_format string', () => {
+        expect(
+            resolveProfileIdFormats({ profile_id_format: '##.###.###' })
+        ).toEqual([{ type: 'default', pattern: '##.###.###' }]);
+    });
+});
+
+describe('formatDocumentId', () => {
+    it('formats DNI values with the DNI mask', () => {
+        expect(formatDocumentId('30123456', PROFILE_ID_FORMATS)).toBe(
+            '30.123.456'
+        );
+    });
+
+    it('formats passport values with the passport mask', () => {
+        expect(formatDocumentId('A33070219', PROFILE_ID_FORMATS)).toBe(
+            'A33070219'
+        );
+    });
+
+    it('formats stored values that still contain separators', () => {
+        expect(formatDocumentId('30.123.456', PROFILE_ID_FORMATS)).toBe(
+            '30.123.456'
+        );
+    });
+});
+
+describe('cleanDocumentIdForStorage', () => {
+    it('stores DNI without separators', () => {
+        expect(
+            cleanDocumentIdForStorage('30.123.456', PROFILE_ID_FORMATS)
+        ).toBe('30123456');
+    });
+
+    it('stores passport values as uppercase alphanumeric without separators', () => {
+        expect(
+            cleanDocumentIdForStorage('a33070219', PROFILE_ID_FORMATS)
+        ).toBe('A33070219');
+    });
+});
+
+describe('isValidDocumentId', () => {
+    it('accepts values that fully match an allowed mask', () => {
+        expect(isValidDocumentId('30123456', PROFILE_ID_FORMATS)).toBe(true);
+        expect(isValidDocumentId('A33070219', PROFILE_ID_FORMATS)).toBe(true);
+    });
+
+    it('rejects values that do not match any allowed mask', () => {
+        expect(isValidDocumentId('ABC123', PROFILE_ID_FORMATS)).toBe(false);
+        expect(isValidDocumentId('301234567', PROFILE_ID_FORMATS)).toBe(false);
+    });
+});
+
+describe('getMaxDocumentIdInputLength', () => {
+    it('returns the longest formatted mask length', () => {
+        expect(getMaxDocumentIdInputLength(PROFILE_ID_FORMATS)).toBe(10);
+    });
+});

--- a/src/utils/documentId.test.js
+++ b/src/utils/documentId.test.js
@@ -4,45 +4,54 @@ import {
     formatDocumentId,
     getMaxDocumentIdInputLength,
     isValidDocumentId,
+    parseProfileIdFormat,
     resolveProfileIdFormats
 } from './documentId';
 
-const PROFILE_ID_FORMATS = [
-    { type: 'dni', pattern: '##.###.###' },
-    { type: 'passport', pattern: 'A########' }
-];
+const PROFILE_ID_FORMAT = '##.###.###,A########';
+const PROFILE_ID_PATTERNS = ['##.###.###', 'A########'];
 
-describe('resolveProfileIdFormats', () => {
-    it('returns configured profile_id_formats when present', () => {
-        expect(
-            resolveProfileIdFormats({
-                profile_id_formats: PROFILE_ID_FORMATS
-            })
-        ).toEqual(PROFILE_ID_FORMATS);
+describe('parseProfileIdFormat', () => {
+    it('splits comma-separated masks', () => {
+        expect(parseProfileIdFormat(PROFILE_ID_FORMAT)).toEqual(
+            PROFILE_ID_PATTERNS
+        );
     });
 
-    it('falls back to legacy profile_id_format string', () => {
+    it('returns a single mask unchanged', () => {
+        expect(parseProfileIdFormat('##.###.###')).toEqual(['##.###.###']);
+    });
+
+    it('trims whitespace around masks', () => {
+        expect(parseProfileIdFormat(' ##.###.### , A######## ')).toEqual(
+            PROFILE_ID_PATTERNS
+        );
+    });
+});
+
+describe('resolveProfileIdFormats', () => {
+    it('reads masks from profile_id_format config', () => {
         expect(
-            resolveProfileIdFormats({ profile_id_format: '##.###.###' })
-        ).toEqual([{ type: 'default', pattern: '##.###.###' }]);
+            resolveProfileIdFormats({ profile_id_format: PROFILE_ID_FORMAT })
+        ).toEqual(PROFILE_ID_PATTERNS);
     });
 });
 
 describe('formatDocumentId', () => {
     it('formats DNI values with the DNI mask', () => {
-        expect(formatDocumentId('30123456', PROFILE_ID_FORMATS)).toBe(
+        expect(formatDocumentId('30123456', PROFILE_ID_PATTERNS)).toBe(
             '30.123.456'
         );
     });
 
     it('formats passport values with the passport mask', () => {
-        expect(formatDocumentId('A33070219', PROFILE_ID_FORMATS)).toBe(
+        expect(formatDocumentId('A33070219', PROFILE_ID_PATTERNS)).toBe(
             'A33070219'
         );
     });
 
     it('formats stored values that still contain separators', () => {
-        expect(formatDocumentId('30.123.456', PROFILE_ID_FORMATS)).toBe(
+        expect(formatDocumentId('30.123.456', PROFILE_ID_PATTERNS)).toBe(
             '30.123.456'
         );
     });
@@ -51,31 +60,31 @@ describe('formatDocumentId', () => {
 describe('cleanDocumentIdForStorage', () => {
     it('stores DNI without separators', () => {
         expect(
-            cleanDocumentIdForStorage('30.123.456', PROFILE_ID_FORMATS)
+            cleanDocumentIdForStorage('30.123.456', PROFILE_ID_PATTERNS)
         ).toBe('30123456');
     });
 
     it('stores passport values as uppercase alphanumeric without separators', () => {
         expect(
-            cleanDocumentIdForStorage('a33070219', PROFILE_ID_FORMATS)
+            cleanDocumentIdForStorage('a33070219', PROFILE_ID_PATTERNS)
         ).toBe('A33070219');
     });
 });
 
 describe('isValidDocumentId', () => {
     it('accepts values that fully match an allowed mask', () => {
-        expect(isValidDocumentId('30123456', PROFILE_ID_FORMATS)).toBe(true);
-        expect(isValidDocumentId('A33070219', PROFILE_ID_FORMATS)).toBe(true);
+        expect(isValidDocumentId('30123456', PROFILE_ID_PATTERNS)).toBe(true);
+        expect(isValidDocumentId('A33070219', PROFILE_ID_PATTERNS)).toBe(true);
     });
 
     it('rejects values that do not match any allowed mask', () => {
-        expect(isValidDocumentId('ABC123', PROFILE_ID_FORMATS)).toBe(false);
-        expect(isValidDocumentId('301234567', PROFILE_ID_FORMATS)).toBe(false);
+        expect(isValidDocumentId('ABC123', PROFILE_ID_PATTERNS)).toBe(false);
+        expect(isValidDocumentId('301234567', PROFILE_ID_PATTERNS)).toBe(false);
     });
 });
 
 describe('getMaxDocumentIdInputLength', () => {
     it('returns the longest formatted mask length', () => {
-        expect(getMaxDocumentIdInputLength(PROFILE_ID_FORMATS)).toBe(10);
+        expect(getMaxDocumentIdInputLength(PROFILE_ID_PATTERNS)).toBe(10);
     });
 });

--- a/src/utils/formatDisplayDni.js
+++ b/src/utils/formatDisplayDni.js
@@ -1,5 +1,6 @@
 import {
     formatDocumentId,
+    parseProfileIdFormat,
     resolveProfileIdFormats
 } from './documentId';
 
@@ -11,14 +12,13 @@ function resolveFormats(profileIdFormatOrConfig) {
     if (
         profileIdFormatOrConfig &&
         typeof profileIdFormatOrConfig === 'object' &&
-        (profileIdFormatOrConfig.profile_id_formats ||
-            profileIdFormatOrConfig.profile_id_format)
+        profileIdFormatOrConfig.profile_id_format
     ) {
         return resolveProfileIdFormats(profileIdFormatOrConfig);
     }
 
-    if (profileIdFormatOrConfig) {
-        return [{ type: 'default', pattern: profileIdFormatOrConfig }];
+    if (typeof profileIdFormatOrConfig === 'string') {
+        return parseProfileIdFormat(profileIdFormatOrConfig);
     }
 
     return [];

--- a/src/utils/formatDisplayDni.js
+++ b/src/utils/formatDisplayDni.js
@@ -1,18 +1,44 @@
-import { formatId } from '../services/utility';
+import {
+    formatDocumentId,
+    resolveProfileIdFormats
+} from './documentId';
 
-export function formatDisplayDni(value, profileIdFormat) {
+function resolveFormats(profileIdFormatOrConfig) {
+    if (Array.isArray(profileIdFormatOrConfig)) {
+        return profileIdFormatOrConfig;
+    }
+
+    if (
+        profileIdFormatOrConfig &&
+        typeof profileIdFormatOrConfig === 'object' &&
+        (profileIdFormatOrConfig.profile_id_formats ||
+            profileIdFormatOrConfig.profile_id_format)
+    ) {
+        return resolveProfileIdFormats(profileIdFormatOrConfig);
+    }
+
+    if (profileIdFormatOrConfig) {
+        return [{ type: 'default', pattern: profileIdFormatOrConfig }];
+    }
+
+    return [];
+}
+
+export function formatDisplayDni(value, profileIdFormatOrFormats) {
     if (value === null || value === undefined || String(value).trim() === '') {
         return null;
     }
 
-    if (!profileIdFormat) {
+    const formats = resolveFormats(profileIdFormatOrFormats);
+    if (!formats.length) {
         return String(value);
     }
 
-    return formatId(value, profileIdFormat);
+    const formatted = formatDocumentId(value, formats);
+    return formatted === '' ? null : formatted;
 }
 
-export function displayDniOrDash(value, profileIdFormat, dash = '—') {
-    const formatted = formatDisplayDni(value, profileIdFormat);
+export function displayDniOrDash(value, profileIdFormatOrFormats, dash = '—') {
+    const formatted = formatDisplayDni(value, profileIdFormatOrFormats);
     return formatted === null ? dash : formatted;
 }

--- a/src/utils/formatDisplayDni.test.js
+++ b/src/utils/formatDisplayDni.test.js
@@ -1,31 +1,27 @@
 import { describe, expect, it } from 'vitest';
 import { displayDniOrDash, formatDisplayDni } from './formatDisplayDni';
 
-const DNI_FORMAT = '##.###.###';
-const PROFILE_ID_FORMATS = [
-    { type: 'dni', pattern: '##.###.###' },
-    { type: 'passport', pattern: 'A########' }
-];
+const PROFILE_ID_FORMAT = '##.###.###,A########';
 
 describe('formatDisplayDni', () => {
     it('formats raw DNI using profile_id_format pattern', () => {
-        expect(formatDisplayDni('30123456', DNI_FORMAT)).toBe('30.123.456');
+        expect(formatDisplayDni('30123456', '##.###.###')).toBe('30.123.456');
     });
 
-    it('formats passport values using profile_id_formats', () => {
-        expect(formatDisplayDni('A33070219', PROFILE_ID_FORMATS)).toBe(
+    it('formats passport values using comma-separated profile_id_format', () => {
+        expect(formatDisplayDni('A33070219', PROFILE_ID_FORMAT)).toBe(
             'A33070219'
         );
     });
 
     it('returns null for empty values', () => {
-        expect(formatDisplayDni(null, DNI_FORMAT)).toBeNull();
-        expect(formatDisplayDni('', DNI_FORMAT)).toBeNull();
-        expect(formatDisplayDni('   ', DNI_FORMAT)).toBeNull();
+        expect(formatDisplayDni(null, '##.###.###')).toBeNull();
+        expect(formatDisplayDni('', '##.###.###')).toBeNull();
+        expect(formatDisplayDni('   ', '##.###.###')).toBeNull();
     });
 
     it('returns null when value does not match any allowed mask', () => {
-        expect(formatDisplayDni('ABC123', PROFILE_ID_FORMATS)).toBeNull();
+        expect(formatDisplayDni('ABC123', PROFILE_ID_FORMAT)).toBeNull();
     });
 
     it('returns value as string when pattern is missing', () => {
@@ -35,17 +31,17 @@ describe('formatDisplayDni', () => {
 
 describe('displayDniOrDash', () => {
     it('returns formatted DNI for display', () => {
-        expect(displayDniOrDash('30123456', DNI_FORMAT)).toBe('30.123.456');
+        expect(displayDniOrDash('30123456', '##.###.###')).toBe('30.123.456');
     });
 
     it('returns formatted passport for display', () => {
-        expect(displayDniOrDash('A33070219', PROFILE_ID_FORMATS)).toBe(
+        expect(displayDniOrDash('A33070219', PROFILE_ID_FORMAT)).toBe(
             'A33070219'
         );
     });
 
     it('returns em dash for empty values', () => {
-        expect(displayDniOrDash(null, DNI_FORMAT)).toBe('—');
-        expect(displayDniOrDash('', DNI_FORMAT)).toBe('—');
+        expect(displayDniOrDash(null, '##.###.###')).toBe('—');
+        expect(displayDniOrDash('', '##.###.###')).toBe('—');
     });
 });

--- a/src/utils/formatDisplayDni.test.js
+++ b/src/utils/formatDisplayDni.test.js
@@ -2,16 +2,30 @@ import { describe, expect, it } from 'vitest';
 import { displayDniOrDash, formatDisplayDni } from './formatDisplayDni';
 
 const DNI_FORMAT = '##.###.###';
+const PROFILE_ID_FORMATS = [
+    { type: 'dni', pattern: '##.###.###' },
+    { type: 'passport', pattern: 'A########' }
+];
 
 describe('formatDisplayDni', () => {
     it('formats raw DNI using profile_id_format pattern', () => {
         expect(formatDisplayDni('30123456', DNI_FORMAT)).toBe('30.123.456');
     });
 
+    it('formats passport values using profile_id_formats', () => {
+        expect(formatDisplayDni('A33070219', PROFILE_ID_FORMATS)).toBe(
+            'A33070219'
+        );
+    });
+
     it('returns null for empty values', () => {
         expect(formatDisplayDni(null, DNI_FORMAT)).toBeNull();
         expect(formatDisplayDni('', DNI_FORMAT)).toBeNull();
         expect(formatDisplayDni('   ', DNI_FORMAT)).toBeNull();
+    });
+
+    it('returns null when value does not match any allowed mask', () => {
+        expect(formatDisplayDni('ABC123', PROFILE_ID_FORMATS)).toBeNull();
     });
 
     it('returns value as string when pattern is missing', () => {
@@ -22,6 +36,12 @@ describe('formatDisplayDni', () => {
 describe('displayDniOrDash', () => {
     it('returns formatted DNI for display', () => {
         expect(displayDniOrDash('30123456', DNI_FORMAT)).toBe('30.123.456');
+    });
+
+    it('returns formatted passport for display', () => {
+        expect(displayDniOrDash('A33070219', PROFILE_ID_FORMATS)).toBe(
+            'A33070219'
+        );
     });
 
     it('returns em dash for empty values', () => {

--- a/src/utils/userMigrationFields.test.js
+++ b/src/utils/userMigrationFields.test.js
@@ -33,12 +33,30 @@ describe('userMigrationFields', () => {
 });
 
 describe('formatMigrationFieldValue', () => {
-    it('formats nro_doc using profile_id_format for display', () => {
+    it('formats nro_doc using allowed document masks for display', () => {
         expect(
             formatMigrationFieldValue('nro_doc', { nro_doc: '30123456' }, {
-                profileIdFormat: '##.###.###'
+                profileIdFormat: {
+                    profile_id_formats: [
+                        { type: 'dni', pattern: '##.###.###' },
+                        { type: 'passport', pattern: 'A########' }
+                    ]
+                }
             })
         ).toBe('30.123.456');
+    });
+
+    it('formats passport nro_doc for display', () => {
+        expect(
+            formatMigrationFieldValue('nro_doc', { nro_doc: 'A33070219' }, {
+                profileIdFormat: {
+                    profile_id_formats: [
+                        { type: 'dni', pattern: '##.###.###' },
+                        { type: 'passport', pattern: 'A########' }
+                    ]
+                }
+            })
+        ).toBe('A33070219');
     });
 
     it('returns em dash when user or value is missing', () => {

--- a/src/utils/userMigrationFields.test.js
+++ b/src/utils/userMigrationFields.test.js
@@ -33,15 +33,10 @@ describe('userMigrationFields', () => {
 });
 
 describe('formatMigrationFieldValue', () => {
-    it('formats nro_doc using allowed document masks for display', () => {
+    it('formats nro_doc using profile_id_format for display', () => {
         expect(
             formatMigrationFieldValue('nro_doc', { nro_doc: '30123456' }, {
-                profileIdFormat: {
-                    profile_id_formats: [
-                        { type: 'dni', pattern: '##.###.###' },
-                        { type: 'passport', pattern: 'A########' }
-                    ]
-                }
+                profileIdFormat: '##.###.###'
             })
         ).toBe('30.123.456');
     });
@@ -49,12 +44,7 @@ describe('formatMigrationFieldValue', () => {
     it('formats passport nro_doc for display', () => {
         expect(
             formatMigrationFieldValue('nro_doc', { nro_doc: 'A33070219' }, {
-                profileIdFormat: {
-                    profile_id_formats: [
-                        { type: 'dni', pattern: '##.###.###' },
-                        { type: 'passport', pattern: 'A########' }
-                    ]
-                }
+                profileIdFormat: '##.###.###,A########'
             })
         ).toBe('A33070219');
     });


### PR DESCRIPTION
## Summary
- Add best-match document ID formatting/validation using comma-separated masks from `profile_id_format` config.
- Support DNI (`##.###.###`) and passport (`A########`) values such as `A33070219` in profile, admin, and display flows.
- Show allowed masks in document input placeholder and description; store/send raw values without separators.

## Config
Set in backend `.env` (authoritative via `/api/config`):

```env
PROFILE_ID_FORMAT="##.###.###,A########"
```

`config/conf.json` remains a local bootstrap/fallback until remote config loads.

## Test plan
- [ ] Set `PROFILE_ID_FORMAT="##.###.###,A########"` in backend `.env` and restart API
- [ ] Confirm admin user with passport `A33070219` displays in user detail/list/edit
- [ ] Confirm DNI still formats as `30.123.456` while saving `30123456`
- [ ] Confirm invalid values (e.g. `ABC123`) are rejected on profile save
- [ ] Run `npm run check` (lint + unit tests)