### PR TITLE
Add manual MP disconnect instructions on verification success

### DIFF
--- a/src/components/IdentityValidationPromptModal.view.test.js
+++ b/src/components/IdentityValidationPromptModal.view.test.js
@@ -35,5 +35,10 @@ describe('MP disconnect copy', () => {
         expect(messages.arg.identityVerificationSuccessMpDisconnectTail).toBe(
             ' si así lo deseás.'
         );
+        expect(
+            messages.arg.identityVerificationSuccessMpDisconnectManualInstructions
+        ).toBe(
+            'Si el link no funciona, podés hacerlo manualmente desde la app de Mercado Pago yendo a Menú-> Configuración -> Cuenta -> Seguridad -> Aplicaciones conectadas -> Carpoolear-SelladoVIaje -> Quitar permisos'
+        );
     });
 });

--- a/src/components/sections/IdentityValidation.view.test.js
+++ b/src/components/sections/IdentityValidation.view.test.js
@@ -147,6 +147,9 @@ describe('IdentityValidation Mercado Pago ownership warning', () => {
         expect(viewSource).toContain(
             "$t('identityVerificationSuccessMpDisconnectManualInstructions')"
         );
+        expect(viewSource).toContain(
+            'identity-verification-success-banner__mp-disconnect-manual'
+        );
         const disconnectTailIndex = viewSource.indexOf(
             "$t('identityVerificationSuccessMpDisconnectTail')"
         );
@@ -154,6 +157,22 @@ describe('IdentityValidation Mercado Pago ownership warning', () => {
             "$t('identityVerificationSuccessMpDisconnectManualInstructions')"
         );
         expect(manualInstructionsIndex).toBeGreaterThan(disconnectTailIndex);
+    });
+
+    it('groups MP disconnect copy under a single visibility guard', () => {
+        const templateStart = viewSource.indexOf(
+            '<template v-if="showMpIntegrationDisconnectHint">'
+        );
+        const manualInstructionsIndex = viewSource.indexOf(
+            "$t('identityVerificationSuccessMpDisconnectManualInstructions')"
+        );
+        const templateEnd = viewSource.indexOf(
+            '</template>',
+            templateStart
+        );
+        expect(templateStart).toBeGreaterThan(-1);
+        expect(manualInstructionsIndex).toBeGreaterThan(templateStart);
+        expect(manualInstructionsIndex).toBeLessThan(templateEnd);
     });
 
     it('shows ownership warning with profile edit link on MP verification card', () => {

--- a/src/components/sections/IdentityValidation.view.test.js
+++ b/src/components/sections/IdentityValidation.view.test.js
@@ -143,6 +143,19 @@ describe('IdentityValidation Mercado Pago ownership warning', () => {
         expect(viewSource).toContain(':href="mercadoPagoMyAppsUrl"');
     });
 
+    it('shows manual MP disconnect instructions when disconnect hint is visible', () => {
+        expect(viewSource).toContain(
+            "$t('identityVerificationSuccessMpDisconnectManualInstructions')"
+        );
+        const disconnectTailIndex = viewSource.indexOf(
+            "$t('identityVerificationSuccessMpDisconnectTail')"
+        );
+        const manualInstructionsIndex = viewSource.indexOf(
+            "$t('identityVerificationSuccessMpDisconnectManualInstructions')"
+        );
+        expect(manualInstructionsIndex).toBeGreaterThan(disconnectTailIndex);
+    });
+
     it('shows ownership warning with profile edit link on MP verification card', () => {
         expect(viewSource).toContain('identity-validation-mp-warning');
         expect(viewSource).toContain(

--- a/src/components/sections/IdentityValidation.vue
+++ b/src/components/sections/IdentityValidation.vue
@@ -21,24 +21,22 @@
                 <p class="identity-verification-success-banner__emphasis">
                     {{ $t('identityVerificationSuccessEmphasis') }}
                 </p>
-                <p
-                    v-if="showMpIntegrationDisconnectHint"
-                    class="identity-verification-success-banner__text"
-                >
-                    {{ $t('identityVerificationSuccessMpDisconnectLead') }}
-                    <a
-                        :href="mercadoPagoMyAppsUrl"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="identity-verification-success-banner__link identity-verification-success-banner__link--inline"
-                    >{{ $t('identityVerificationSuccessMpDisconnectLink') }}</a>{{ $t('identityVerificationSuccessMpDisconnectTail') }}
-                </p>
-                <p
-                    v-if="showMpIntegrationDisconnectHint"
-                    class="identity-verification-success-banner__text"
-                >
-                    {{ $t('identityVerificationSuccessMpDisconnectManualInstructions') }}
-                </p>
+                <template v-if="showMpIntegrationDisconnectHint">
+                    <p class="identity-verification-success-banner__text">
+                        {{ $t('identityVerificationSuccessMpDisconnectLead') }}
+                        <a
+                            :href="mercadoPagoMyAppsUrl"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="identity-verification-success-banner__link identity-verification-success-banner__link--inline"
+                        >{{ $t('identityVerificationSuccessMpDisconnectLink') }}</a>{{ $t('identityVerificationSuccessMpDisconnectTail') }}
+                    </p>
+                    <p
+                        class="identity-verification-success-banner__text identity-verification-success-banner__mp-disconnect-manual"
+                    >
+                        {{ $t('identityVerificationSuccessMpDisconnectManualInstructions') }}
+                    </p>
+                </template>
                 <IdentityValidationAdminReviewNote
                     :note="displayableManualApprovalReviewNote"
                     :label-key="manualApprovalReviewNoteLabelKey"

--- a/src/components/sections/IdentityValidation.vue
+++ b/src/components/sections/IdentityValidation.vue
@@ -33,6 +33,12 @@
                         class="identity-verification-success-banner__link identity-verification-success-banner__link--inline"
                     >{{ $t('identityVerificationSuccessMpDisconnectLink') }}</a>{{ $t('identityVerificationSuccessMpDisconnectTail') }}
                 </p>
+                <p
+                    v-if="showMpIntegrationDisconnectHint"
+                    class="identity-verification-success-banner__text"
+                >
+                    {{ $t('identityVerificationSuccessMpDisconnectManualInstructions') }}
+                </p>
                 <IdentityValidationAdminReviewNote
                     :note="displayableManualApprovalReviewNote"
                     :label-key="manualApprovalReviewNoteLabelKey"

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -855,6 +855,8 @@ const messages = {
         identityVerificationSuccessMpDisconnectLink:
             'eliminar la integración con Mercado Pago',
         identityVerificationSuccessMpDisconnectTail: ' si así lo deseás.',
+        identityVerificationSuccessMpDisconnectManualInstructions:
+            'Si el link no funciona, podés hacerlo manualmente desde la app de Mercado Pago yendo a Menú-> Configuración -> Cuenta -> Seguridad -> Aplicaciones conectadas -> Carpoolear-SelladoVIaje -> Quitar permisos',
         resultError: 'Ocurrió un error. Intentá de nuevo.',
         resultDniMismatch:
             'El DNI no coincide con el de tu perfil. Verificá que tu DNI esté cargado correctamente.',
@@ -2609,6 +2611,8 @@ const messages = {
         identityVerificationSuccessMpDisconnectLink:
             'eliminar la integración con Mercado Pago',
         identityVerificationSuccessMpDisconnectTail: ' si así lo deseás.',
+        identityVerificationSuccessMpDisconnectManualInstructions:
+            'Si el link no funciona, podés hacerlo manualmente desde la app de Mercado Pago yendo a Menú-> Configuración -> Cuenta -> Seguridad -> Aplicaciones conectadas -> Carpoolear-SelladoVIaje -> Quitar permisos',
         resultError: 'Ocurrió un error. Intentá de nuevo.',
         resultDniMismatch:
             'El DNI no coincide con el de tu perfil. Verificá que tu DNI esté cargado correctamente.',
@@ -4247,6 +4251,8 @@ const messages = {
         identityVerificationSuccessMpDisconnectLink:
             'remove the Mercado Pago integration',
         identityVerificationSuccessMpDisconnectTail: ' if you want.',
+        identityVerificationSuccessMpDisconnectManualInstructions:
+            "If the link doesn't work, you can do it manually from the Mercado Pago app by going to Menu -> Settings -> Account -> Security -> Connected apps -> Carpoolear-SelladoVIaje -> Remove permissions",
         resultError: 'An error occurred. Please try again.',
         resultDniMismatch:
             "The DNI doesn't match the one on your profile. Please make sure your DNI is correct.",


### PR DESCRIPTION
## Summary
- Adds i18n copy with step-by-step instructions to remove Mercado Pago permissions manually from the MP app when the disconnect link does not work.
- Shows the new text on the MP account verification success banner, alongside the existing disconnect link.
- Groups MP disconnect success copy under a single visibility guard in `IdentityValidation.vue`.

## Test plan
- [x] Unit/view tests pass (`IdentityValidation.view.test.js`, `IdentityValidationPromptModal.view.test.js`)
- [x] Frontend lint passes
- [x] Frontend production build passes
- [x] Backend tests pass (no backend changes)
- [x] Complete MP verification flow and confirm the manual instructions appear below the disconnect link on the success screen
- [x] Confirm copy renders correctly in Spanish (`arg`/`chl`) and English (`en`)