### PR TITLE
Show load-more button on messages list (desktop)

### DIFF
--- a/src/components/views/ConversationList.view.test.js
+++ b/src/components/views/ConversationList.view.test.js
@@ -86,4 +86,22 @@ describe('ConversationList.vue messages redesign', () => {
     it('wraps list and chat in a messages-page__shell', () => {
         expect(viewSource).toContain('messages-page__shell');
     });
+
+    it('sizes the conversation list scroll area below the header so load-more stays reachable', () => {
+        const cssPath = path.resolve(
+            __dirname,
+            '../../styles/components/messages-page.css'
+        );
+        const css = fs.readFileSync(cssPath, 'utf8');
+        expect(css).toContain('.messages-page .conversation_list .list-group');
+        expect(css).toMatch(
+            /\.messages-page \.conversation_list \.list-group\s*\{[^}]*display:\s*flex/s
+        );
+        expect(css).toMatch(
+            /\.messages-page \.conversation_chat--chats\s*\{[^}]*flex:\s*1 1 auto/s
+        );
+        expect(css).toMatch(
+            /\.messages-page \.conversation_chat--chats\s*\{[^}]*height:\s*auto !important/s
+        );
+    });
 });

--- a/src/components/views/ConversationList.view.test.js
+++ b/src/components/views/ConversationList.view.test.js
@@ -104,4 +104,17 @@ describe('ConversationList.vue messages redesign', () => {
             /\.messages-page \.conversation_chat--chats\s*\{[^}]*height:\s*auto !important/s
         );
     });
+
+    it('styles the load-more row with dedicated spacing on desktop', () => {
+        expect(viewSource).toContain('messages-page__load-more');
+        const cssPath = path.resolve(
+            __dirname,
+            '../../styles/components/messages-page.css'
+        );
+        const css = fs.readFileSync(cssPath, 'utf8');
+        expect(css).toContain('.messages-page__load-more');
+        expect(css).toMatch(
+            /\.messages-page__load-more\s*\{[^}]*padding:/s
+        );
+    });
 });

--- a/src/components/views/ConversationList.vue
+++ b/src/components/views/ConversationList.vue
@@ -173,7 +173,7 @@
                                     </li>
                                     <li
                                         v-if="moreConversations"
-                                        class="list-group-item"
+                                        class="list-group-item messages-page__load-more"
                                     >
                                         <AppButton
                                             variant="primary"

--- a/src/styles/components/messages-page.css
+++ b/src/styles/components/messages-page.css
@@ -359,6 +359,24 @@
         border-right: 1px solid var(--messages-shell-border);
     }
 
+    .messages-page .conversation_list .list-group {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        min-height: 0;
+    }
+
+    .messages-page__list-header {
+        flex: 0 0 auto;
+    }
+
+    .messages-page .conversation_chat--chats {
+        flex: 1 1 auto;
+        min-height: 0;
+        height: auto !important;
+        overflow-y: auto;
+    }
+
     .messages-page .conversation_list .list-group-item {
         border-left-width: 0;
         border-right-width: 0;

--- a/src/styles/components/messages-page.css
+++ b/src/styles/components/messages-page.css
@@ -375,6 +375,13 @@
         min-height: 0;
         height: auto !important;
         overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    .messages-page__load-more {
+        flex-shrink: 0;
+        padding: 0.75rem 1rem 1rem;
+        border-top: 1px solid var(--messages-shell-border);
     }
 
     .messages-page .conversation_list .list-group-item {


### PR DESCRIPTION
## Summary
- Fixes the "Más resultados" button being clipped at the bottom of `/conversations` on desktop after the messages page redesign.
- Uses a flex column layout so the list header keeps its height and the conversation list scroll area fills the remaining space (replacing legacy `calc(100% - 32px)` offsets that no longer match the taller header).
- Adds dedicated spacing for the load-more row via `messages-page__load-more`.

## Test plan
- [x] `npm run test:unit -- --run src/components/views/ConversationList.view.test.js`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npx playwright test e2e-frontend/conversations.spec.js -g "Más resultados" --project=frontend`
- [x] Manual: open `/conversations` on desktop with many conversations and confirm "Más resultados" is fully visible at the bottom of the sidebar