### PR TITLE
Fix trip creation outside Argentina validation feedback

### DIFF
--- a/src/components/views/NewTrip.foreignEndpoints.view.test.js
+++ b/src/components/views/NewTrip.foreignEndpoints.view.test.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const newTripViewPath = path.resolve(__dirname, 'NewTrip.vue');
+const newTripViewSource = fs.readFileSync(newTripViewPath, 'utf8');
+
+describe('NewTrip foreign endpoint validation', () => {
+    it('allows one foreign endpoint when the other is in the home country', () => {
+        expect(newTripViewSource).toContain('hasTooManyForeignTripEndpoints');
+        expect(newTripViewSource).not.toMatch(
+            /foreignPoints\s*\+=\s*p\.json\.country === this\.config\.osm_country \? 0 : 1/
+        );
+    });
+});

--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -126,8 +126,16 @@ import { TRIP_INFO_STATUS } from '../../utils/tripCreationTripInfo.js';
 import { buildTripDateForApi } from '../../utils/tripDateForApi.js';
 import NewTripCreationWizard from './NewTripCreationWizard.vue';
 import TripCreationSuccess from './TripCreationSuccess.vue';
+import TripFormValidationSummary from '../elements/TripFormValidationSummary.vue';
 import { handleTripCreateApiError } from '../../utils/tripCreateErrors.js';
 import { hasTooManyForeignTripEndpoints } from '../../utils/tripForeignEndpointsValidation.js';
+import {
+    collectActiveValidationMessages,
+    findFirstTripFormErrorElement,
+    formatTripValidationDialogMessage,
+    shouldShowTripFormValidationSummary
+} from '../../utils/tripFormValidationFeedback.js';
+import { getTripValidationErrorFields } from '../../utils/tripFormValidationFields.js';
 import { isEnabledAsync } from '../../services/debug';
 
 let tripApi = new TripApi();
@@ -159,7 +167,8 @@ export default {
         CompleteCarModal,
         TripCarsModal,
         NewTripCreationWizard,
-        TripCreationSuccess
+        TripCreationSuccess,
+        TripFormValidationSummary
     },
     provide() {
         return {
@@ -323,6 +332,7 @@ export default {
             creationSnapshot: null,
             parentTripId: null,
             tripInfoStatus: TRIP_INFO_STATUS.IDLE,
+            formValidationAttempted: false,
             tripCreationWizardKey: 0
         };
     },
@@ -493,14 +503,35 @@ export default {
                 return this.$t('contribucionRecomendadaCardDescripcionConSellado');
             }
             return this.$t('contribucionRecomendadaCardDescripcionSinSellado');
+        },
+        activeFormValidationMessages() {
+            return collectActiveValidationMessages(
+                getTripValidationErrorFields(this)
+            );
+        },
+        showTripValidationSummary() {
+            return shouldShowTripFormValidationSummary(
+                this.formValidationAttempted,
+                this.activeFormValidationMessages
+            );
+        },
+        tripFormValidationSummaryBindings() {
+            return {
+                attempted: this.formValidationAttempted,
+                messages: this.activeFormValidationMessages,
+                title: this.$t('algunosDatosNoValidos')
+            };
         }
     },
     watch: {
         cars() {
             this.preselectDriverCar();
         },
-        no_lucrar: function () {
+        no_lucrar() {
             this.lucrarError.state = false;
+        },
+        'trip.description': function () {
+            this.commentError.state = false;
         },
         'trip.rear_max_two_passengers': function() {
             if (this.trip.distance > 0) {
@@ -744,10 +775,17 @@ export default {
             this.dateAnswer = date;
         },
         jumpToError() {
+            const root = this.$refs.tripCreationWizard?.$el || this.$el;
+            const element = findFirstTripFormErrorElement(root);
+            if (element) {
+                this.$scrollToElement(element);
+                return;
+            }
+
             let hasError = document.getElementsByClassName('has-error');
             if (hasError.length) {
-                let element = hasError[0];
-                this.$scrollToElement(element);
+                let fallbackElement = hasError[0];
+                this.$scrollToElement(fallbackElement);
             }
         },
     restoreData(trip) {
@@ -1046,10 +1084,6 @@ export default {
                         estado: 'error'
                     }
                 );
-            } else if (globalError) {
-                dialogs.message(this.$t('algunosDatosNoValidos'), {
-                    estado: 'error'
-                });
             } else if (
                 !this.no_lucrar &&
                 this.trip.is_passenger.toString() !== '1'
@@ -1389,6 +1423,7 @@ export default {
                     return;
                 }
             }
+            this.formValidationAttempted = true;
             const validationResult = this.validate();
             if (validationResult) {
                 // Jump To Error
@@ -1397,6 +1432,7 @@ export default {
                 });
                 return;
             }
+            this.formValidationAttempted = false;
             /* eslint-disable no-unreachable */
             this.saving = true;
             if (!this.updatingTrip) {

--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -788,6 +788,12 @@ export default {
                 this.$scrollToElement(fallbackElement);
             }
         },
+        getTripValidationDialogMessage() {
+            return formatTripValidationDialogMessage(
+                this.$t('algunosDatosNoValidos'),
+                this.activeFormValidationMessages
+            );
+        },
     restoreData(trip) {
         this.no_lucrar = true;
         this.points = [];
@@ -1571,6 +1577,7 @@ export default {
                 defaultReturnTime: dayjs().add(2, 'hours').format('HH:00'),
                 ...options
             });
+            this.formValidationAttempted = false;
             this.tripCreationWizardKey += 1;
             this.preselectDriverCar();
             this.$nextTick(() => {
@@ -1584,6 +1591,7 @@ export default {
             this.$refs.tripCreationWizard?.cancelDraftSave?.();
             this.createdTrip = trip;
             this.showWizardSuccess = true;
+            this.formValidationAttempted = false;
             if (this.user?.id != null) {
                 clearTripCreationDraft(this.user.id);
             }

--- a/src/components/views/NewTrip.vue
+++ b/src/components/views/NewTrip.vue
@@ -127,6 +127,7 @@ import { buildTripDateForApi } from '../../utils/tripDateForApi.js';
 import NewTripCreationWizard from './NewTripCreationWizard.vue';
 import TripCreationSuccess from './TripCreationSuccess.vue';
 import { handleTripCreateApiError } from '../../utils/tripCreateErrors.js';
+import { hasTooManyForeignTripEndpoints } from '../../utils/tripForeignEndpointsValidation.js';
 import { isEnabledAsync } from '../../services/debug';
 
 let tripApi = new TripApi();
@@ -902,7 +903,6 @@ export default {
 
         validate() {
             let globalError = false;
-            let foreignPoints = 0;
             let validTime = false;
             let validDate = false;
             let validOtherTripTime = false;
@@ -921,35 +921,46 @@ export default {
                     p.error.state = true;
                     p.error.message = this.$t('localidadValida');
                     globalError = true;
-                } else {
-                    foreignPoints +=
-                        p.json.country === this.config.osm_country ? 0 : 1;
                 }
             });
-            if (foreignPoints > 1) {
+            if (
+                hasTooManyForeignTripEndpoints(
+                    this.points,
+                    this.config.osm_country
+                )
+            ) {
                 globalError = true;
                 this.points[0].error.state = true;
                 this.points[0].error.message = this.$t(
                     'origenDestinoArgentina'
                 );
+                last(this.points).error.state = true;
+                last(this.points).error.message = this.$t(
+                    'origenDestinoArgentina'
+                );
             }
 
             if (this.showReturnTrip) {
-                foreignPoints = 0;
                 this.otherTrip.points.forEach((p) => {
                     if (!p.json) {
                         p.error.state = true;
                         p.error.message = this.$t('seleccioneLocalidadValida');
                         globalError = true;
-                    } else {
-                        foreignPoints +=
-                            p.json.country === this.config.osm_country ? 0 : 1;
                     }
                 });
-                if (foreignPoints > 1) {
+                if (
+                    hasTooManyForeignTripEndpoints(
+                        this.otherTrip.points,
+                        this.config.osm_country
+                    )
+                ) {
                     globalError = true;
                     this.otherTrip.points[0].error.state = true;
                     this.otherTrip.points[0].error.message = this.$t(
+                        'origenDestinoArgentina'
+                    );
+                    last(this.otherTrip.points).error.state = true;
+                    last(this.otherTrip.points).error.message = this.$t(
                         'origenDestinoArgentina'
                     );
                 }

--- a/src/components/views/NewTripCreationWizard.view.test.js
+++ b/src/components/views/NewTripCreationWizard.view.test.js
@@ -215,6 +215,14 @@ describe('NewTripCreationWizard.vue redesign styling', () => {
         expect(wizardSource).not.toContain("$t('tripCreationTitlePassenger')");
     });
 
+    it('shows validation summary above submit actions', () => {
+        expect(wizardSource).toContain('TripFormValidationSummary');
+        expect(wizardSource).toContain('form.tripFormValidationSummaryBindings');
+        expect(wizardSource).toMatch(
+            /TripFormValidationSummary[\s\S]*new-trip-wizard__nav/
+        );
+    });
+
     it('shows Creando... on the submit button while the trip is saving', () => {
         expect(wizardSource).toMatch(
             /submitLabel\(\)\s*\{[\s\S]*?form\.saving[\s\S]*?\$t\('creando'\)/

--- a/src/components/views/NewTripCreationWizard.vue
+++ b/src/components/views/NewTripCreationWizard.vue
@@ -497,6 +497,10 @@
             </template>
         </modal>
 
+        <TripFormValidationSummary
+            v-bind="form.tripFormValidationSummaryBindings"
+        />
+
         <div class="new-trip-wizard__nav">
             <button
                 v-if="previousStep"
@@ -544,6 +548,7 @@ import TripSeatMapPanel from '../elements/TripSeatMapPanel.vue';
 import TripContributionStepPanel from '../elements/TripContributionStepPanel.vue';
 import TripPreferencesStepPanel from '../elements/TripPreferencesStepPanel.vue';
 import TripReviewStepPanel from '../elements/TripReviewStepPanel.vue';
+import TripFormValidationSummary from '../elements/TripFormValidationSummary.vue';
 import TripPointDetailFields from '../elements/TripPointDetailFields';
 import DatePicker from '../DatePicker';
 import autocomplete from '../Autocomplete';
@@ -597,6 +602,7 @@ export default {
         TripContributionStepPanel,
         TripPreferencesStepPanel,
         TripReviewStepPanel,
+        TripFormValidationSummary,
         TripPointDetailFields,
         DatePicker,
         autocomplete,

--- a/src/components/views/NewTripCreationWizard.vue
+++ b/src/components/views/NewTripCreationWizard.vue
@@ -1018,7 +1018,9 @@ export default {
                 ),
                 price: this.form.price,
                 maximumSeatPriceCents: this.form.maximum_seat_price_cents,
-                maximumTripPriceCents: this.form.maximum_trip_price_cents
+                maximumTripPriceCents: this.form.maximum_trip_price_cents,
+                osmCountry: this.form.config?.osm_country,
+                allowForeignPoints: this.form.allowForeignPoints
             };
         },
         syncPuntoDetailErrors(errors = {}) {

--- a/src/utils/tripCreationSteps.js
+++ b/src/utils/tripCreationSteps.js
@@ -7,6 +7,7 @@ import {
     parseSeatPriceInput
 } from './tripSeatPrice.js';
 import { exceedsMaximumSeatPrice } from './tripMaxPriceValidation.js';
+import { hasTooManyForeignTripEndpoints } from './tripForeignEndpointsValidation.js';
 
 export const STEP = {
     ROLE: 1,
@@ -185,7 +186,12 @@ function validateOrigin({ points = [], puntoPartida = '' }) {
     return { valid: true, errors: {} };
 }
 
-function validateDestination({ points = [], puntoLlegada = '' }) {
+function validateDestination({
+    points = [],
+    puntoLlegada = '',
+    osmCountry = 'ARG',
+    allowForeignPoints = false
+}) {
     const destination = lastPoint(points);
     if (!destination || !destination.json) {
         return { valid: false, errors: { destination: 'localidadValida' } };
@@ -194,6 +200,16 @@ function validateDestination({ points = [], puntoLlegada = '' }) {
     const origin = points[0];
     if (origin && origin.json && origin.name === destination.name) {
         return { valid: false, errors: { destination: 'origenDestinoDistintos' } };
+    }
+
+    if (
+        allowForeignPoints &&
+        hasTooManyForeignTripEndpoints(points, osmCountry)
+    ) {
+        return {
+            valid: false,
+            errors: { destination: 'origenDestinoArgentina' }
+        };
     }
 
     if (isTripPointDetailEmpty(puntoLlegada)) {

--- a/src/utils/tripCreationSteps.test.js
+++ b/src/utils/tripCreationSteps.test.js
@@ -335,4 +335,33 @@ describe('tripCreationSteps validateStep', () => {
             }).valid
         ).toBe(true);
     });
+
+    it('allows one foreign endpoint when the other is in the home country', () => {
+        expect(
+            validateStep(STEP.DESTINATION, {
+                points: [
+                    { json: { country: 'ARG' }, name: 'Santa Fe' },
+                    { json: { country: 'URY' }, name: 'Punta del Este' }
+                ],
+                osmCountry: 'ARG',
+                allowForeignPoints: true,
+                puntoLlegada: 'Terminal'
+            }).valid
+        ).toBe(true);
+    });
+
+    it('rejects trips with both endpoints outside the home country', () => {
+        const result = validateStep(STEP.DESTINATION, {
+            points: [
+                { json: { country: 'URY' }, name: 'Montevideo' },
+                { json: { country: 'URY' }, name: 'Punta del Este' }
+            ],
+            osmCountry: 'ARG',
+            allowForeignPoints: true,
+            puntoLlegada: 'Terminal'
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors.destination).toBe('origenDestinoArgentina');
+    });
 });

--- a/src/utils/tripFormValidationFields.js
+++ b/src/utils/tripFormValidationFields.js
@@ -1,0 +1,49 @@
+export function getTripValidationErrorFields(form = {}) {
+    const fields = [];
+
+    (form.points || []).forEach((point) => {
+        if (point?.error) {
+            fields.push(point.error);
+        }
+    });
+
+    [
+        form.dateError,
+        form.timeError,
+        form.priceError,
+        form.returnPriceError,
+        form.commentError,
+        form.seatsError,
+        form.lucrarError,
+        form.puntoPartidaError,
+        form.puntoLlegadaError,
+        form.carSelectionError
+    ].forEach((field) => {
+        if (field) {
+            fields.push(field);
+        }
+    });
+
+    if (form.showReturnTrip && form.otherTrip) {
+        (form.otherTrip.points || []).forEach((point) => {
+            if (point?.error) {
+                fields.push(point.error);
+            }
+        });
+
+        [
+            form.otherTrip.dateError,
+            form.otherTrip.timeError,
+            form.otherTrip.commentError,
+            form.otherTrip.seatsError,
+            form.otherTrip.puntoPartidaError,
+            form.otherTrip.puntoLlegadaError
+        ].forEach((field) => {
+            if (field) {
+                fields.push(field);
+            }
+        });
+    }
+
+    return fields;
+}

--- a/src/utils/tripFormValidationFields.test.js
+++ b/src/utils/tripFormValidationFields.test.js
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { getTripValidationErrorFields } from './tripFormValidationFields.js';
+
+function field(state, message = '') {
+    return { state, message };
+}
+
+function pointError(state, message = '') {
+    return { error: field(state, message) };
+}
+
+describe('tripFormValidationFields', () => {
+    it('returns outbound trip validation error field objects', () => {
+        const originError = field(true, 'Origen inválido');
+        const ignoredPointError = field(false, 'Ignorado');
+        const dateError = field(true, 'Falta fecha');
+        const form = {
+            points: [{ error: originError }, { error: ignoredPointError }],
+            dateError,
+            timeError: field(false),
+            priceError: field(true, 'Contribución requerida'),
+            returnPriceError: field(false),
+            commentError: field(true, 'Falta descripción'),
+            seatsError: field(false),
+            lucrarError: field(true, 'Compromiso requerido'),
+            puntoPartidaError: field(true, 'Punto partida requerido'),
+            puntoLlegadaError: field(false),
+            carSelectionError: field(false),
+            showReturnTrip: false
+        };
+
+        expect(getTripValidationErrorFields(form)).toEqual([
+            originError,
+            ignoredPointError,
+            dateError,
+            form.timeError,
+            form.priceError,
+            form.returnPriceError,
+            form.commentError,
+            form.seatsError,
+            form.lucrarError,
+            form.puntoPartidaError,
+            form.puntoLlegadaError,
+            form.carSelectionError
+        ]);
+    });
+
+    it('includes return trip validation fields when enabled', () => {
+        const returnPointError = field(true, 'Origen regreso inválido');
+        const returnDateError = field(true, 'Falta fecha regreso');
+        const form = {
+            points: [pointError(false), pointError(false)],
+            dateError: field(false),
+            timeError: field(false),
+            priceError: field(false),
+            returnPriceError: field(true, 'Contribución regreso requerida'),
+            commentError: field(false),
+            seatsError: field(false),
+            lucrarError: field(false),
+            puntoPartidaError: field(false),
+            puntoLlegadaError: field(false),
+            carSelectionError: field(false),
+            showReturnTrip: true,
+            otherTrip: {
+                points: [{ error: returnPointError }],
+                dateError: returnDateError,
+                timeError: field(false),
+                commentError: field(false),
+                seatsError: field(false),
+                puntoPartidaError: field(false),
+                puntoLlegadaError: field(false)
+            }
+        };
+
+        expect(getTripValidationErrorFields(form)).toContain(form.returnPriceError);
+        expect(getTripValidationErrorFields(form)).toContain(returnPointError);
+        expect(getTripValidationErrorFields(form)).toContain(returnDateError);
+    });
+});


### PR DESCRIPTION
## Summary
- Fix foreign trip validation to only reject trips where both origin and destination are outside Argentina, instead of counting every foreign point along the route.
- Show a persistent red validation summary above "Publicar viaje" listing active field errors; each item disappears as the user fixes it.
- Align wizard destination-step validation with the same endpoint-based foreign trip rules.

## Test plan
- [x] Check "Origen o destino fuera de Argentina", set origin to an Argentine city (e.g. Santa Fe) and destination to a foreign city (e.g. Punta del Este), complete the wizard, and confirm the trip can be published.
- [x] Try publishing with missing required fields on the last step and confirm the red summary lists each error above the submit button.
- [x] Fix one listed error and confirm it disappears from the summary while others remain.
- [x] Try both endpoints outside Argentina and confirm the `origenDestinoArgentina` error appears in the summary.
- [x] Run related unit tests: `npm run test:unit -- --run src/utils/tripFormValidationFields.test.js src/utils/tripForeignEndpointsValidation.test.js src/components/views/NewTrip.validationFeedback.view.test.js src/components/views/NewTrip.foreignEndpoints.view.test.js`