### PR TITLE
Show MP and QR payment options on unpaid manual verification panel

### DIFF
--- a/src/components/sections/IdentityValidation.view.test.js
+++ b/src/components/sections/IdentityValidation.view.test.js
@@ -223,6 +223,25 @@ describe('IdentityValidation learn more link', () => {
     });
 });
 
+describe('IdentityValidation unpaid manual verification payment', () => {
+    const pendingPaymentBlockStart = viewSource.indexOf(
+        'manualStatus.has_submission && manualStatus.paid === false'
+    );
+
+    it('shows Mercado Pago and QR payment buttons instead of pagar ahora', () => {
+        expect(pendingPaymentBlockStart).toBeGreaterThan(-1);
+        const pendingPaymentBlock = viewSource.slice(
+            pendingPaymentBlockStart,
+            pendingPaymentBlockStart + 2500
+        );
+
+        expect(pendingPaymentBlock).toContain("$t('manualValidationPagarMercadoPago')");
+        expect(pendingPaymentBlock).toContain("$t('pagarConQR')");
+        expect(pendingPaymentBlock).toContain('identityValidationManualQrEnabled');
+        expect(pendingPaymentBlock).not.toContain("$t('pagarAhora')");
+    });
+});
+
 describe('IdentityValidation manual admin review note', () => {
     it('shows admin review note in success banner and rejection notice when present', () => {
         expect(viewSource).toContain('IdentityValidationAdminReviewNote');

--- a/src/components/sections/IdentityValidation.view.test.js
+++ b/src/components/sections/IdentityValidation.view.test.js
@@ -256,6 +256,18 @@ describe('IdentityValidation unpaid manual verification payment', () => {
         expect(pendingPaymentBlock).toContain('manualValidationUploadWarningKey');
         expect(pendingPaymentBlock).toContain("$t('manualValidationPayClosing')");
     });
+
+    it('shows QR payment panel and polling flow for unpaid manual verification', () => {
+        expect(viewSource).toContain('createManualIdentityValidationQrOrder');
+        expect(viewSource).toContain("import QRCode from 'qrcode'");
+        expect(viewSource).toContain('showQrPanel');
+        expect(viewSource).toContain("$t('escaneáConAppMercadoPago')");
+        expect(viewSource).toContain("$t('qrExpiraEn')");
+        expect(viewSource).toContain('closeManualValidationQrPanel');
+        expect(viewSource).toContain('startManualValidationQrPolling');
+        expect(viewSource).toContain('stopManualValidationQrPolling');
+        expect(viewSource).toContain('beforeUnmount');
+    });
 });
 
 describe('IdentityValidation manual admin review note', () => {

--- a/src/components/sections/IdentityValidation.view.test.js
+++ b/src/components/sections/IdentityValidation.view.test.js
@@ -227,42 +227,42 @@ describe('IdentityValidation unpaid manual verification payment', () => {
     const pendingPaymentBlockStart = viewSource.indexOf(
         'manualStatus.has_submission && manualStatus.paid === false'
     );
+    const payOptionsPath = path.resolve(__dirname, 'ManualIdentityValidationPayOptions.vue');
+    const payOptionsSource = fs.readFileSync(payOptionsPath, 'utf8');
 
-    it('shows Mercado Pago and QR payment buttons instead of pagar ahora', () => {
+    it('uses shared manual payment options with MP and QR handlers', () => {
         expect(pendingPaymentBlockStart).toBeGreaterThan(-1);
         const pendingPaymentBlock = viewSource.slice(
             pendingPaymentBlockStart,
-            pendingPaymentBlockStart + 2500
+            pendingPaymentBlockStart + 1200
         );
 
-        expect(pendingPaymentBlock).toContain("$t('manualValidationPagarMercadoPago')");
-        expect(pendingPaymentBlock).toContain("$t('pagarConQR')");
-        expect(pendingPaymentBlock).toContain('identityValidationManualQrEnabled');
+        expect(pendingPaymentBlock).toContain('ManualIdentityValidationPayOptions');
+        expect(pendingPaymentBlock).toContain(':qr-enabled="identityValidationManualQrEnabled"');
+        expect(pendingPaymentBlock).toContain('@pay-mp="payManualValidation"');
+        expect(pendingPaymentBlock).toContain('@pay-qr="createManualValidationQrOrderAndShow"');
         expect(pendingPaymentBlock).not.toContain("$t('pagarAhora')");
     });
 
     it('shows the same manual payment instructions as the dedicated manual page', () => {
-        const pendingPaymentBlock = viewSource.slice(
-            pendingPaymentBlockStart,
-            pendingPaymentBlockStart + 3500
+        expect(payOptionsSource).toContain(
+            "$t('manualValidationPayIntro1', { cost: costDisplay })"
         );
-
-        expect(pendingPaymentBlock).toContain(
-            "$t('manualValidationPayIntro1', { cost: formattedManualCost })"
-        );
-        expect(pendingPaymentBlock).toContain("$t('manualValidationPayIntro2')");
-        expect(pendingPaymentBlock).toContain("$t('manualValidationPayListLead')");
-        expect(pendingPaymentBlock).toContain("$t('manualValidationPayBulletDni')");
-        expect(pendingPaymentBlock).toContain('manualValidationUploadWarningKey');
-        expect(pendingPaymentBlock).toContain("$t('manualValidationPayClosing')");
+        expect(payOptionsSource).toContain("$t('manualValidationPayIntro2')");
+        expect(payOptionsSource).toContain("$t('manualValidationPayListLead')");
+        expect(payOptionsSource).toContain("$t('manualValidationPayBulletDni')");
+        expect(payOptionsSource).toContain('manualValidationUploadWarningKey');
+        expect(payOptionsSource).toContain("$t('manualValidationPayClosing')");
+        expect(payOptionsSource).toContain("$t('manualValidationPagarMercadoPago')");
+        expect(payOptionsSource).toContain("$t('pagarConQR')");
     });
 
     it('shows QR payment panel and polling flow for unpaid manual verification', () => {
         expect(viewSource).toContain('createManualIdentityValidationQrOrder');
         expect(viewSource).toContain("import QRCode from 'qrcode'");
         expect(viewSource).toContain('showQrPanel');
-        expect(viewSource).toContain("$t('escaneáConAppMercadoPago')");
-        expect(viewSource).toContain("$t('qrExpiraEn')");
+        expect(payOptionsSource).toContain("$t('escaneáConAppMercadoPago')");
+        expect(payOptionsSource).toContain("$t('qrExpiraEn')");
         expect(viewSource).toContain('closeManualValidationQrPanel');
         expect(viewSource).toContain('startManualValidationQrPolling');
         expect(viewSource).toContain('stopManualValidationQrPolling');

--- a/src/components/sections/IdentityValidation.view.test.js
+++ b/src/components/sections/IdentityValidation.view.test.js
@@ -240,6 +240,22 @@ describe('IdentityValidation unpaid manual verification payment', () => {
         expect(pendingPaymentBlock).toContain('identityValidationManualQrEnabled');
         expect(pendingPaymentBlock).not.toContain("$t('pagarAhora')");
     });
+
+    it('shows the same manual payment instructions as the dedicated manual page', () => {
+        const pendingPaymentBlock = viewSource.slice(
+            pendingPaymentBlockStart,
+            pendingPaymentBlockStart + 3500
+        );
+
+        expect(pendingPaymentBlock).toContain(
+            "$t('manualValidationPayIntro1', { cost: formattedManualCost })"
+        );
+        expect(pendingPaymentBlock).toContain("$t('manualValidationPayIntro2')");
+        expect(pendingPaymentBlock).toContain("$t('manualValidationPayListLead')");
+        expect(pendingPaymentBlock).toContain("$t('manualValidationPayBulletDni')");
+        expect(pendingPaymentBlock).toContain('manualValidationUploadWarningKey');
+        expect(pendingPaymentBlock).toContain("$t('manualValidationPayClosing')");
+    });
 });
 
 describe('IdentityValidation manual admin review note', () => {

--- a/src/components/sections/IdentityValidation.vue
+++ b/src/components/sections/IdentityValidation.vue
@@ -105,68 +105,17 @@
                 <div class="panel-heading">{{ $t('esperandoPagoValidacionManual') }}</div>
                 <div class="panel-body">
                     <p>{{ $t('debesPagarParaContinuar') }}</p>
-                    <p class="manual-validation-text">
-                        {{ $t('manualValidationPayIntro1', { cost: formattedManualCost }) }}
-                    </p>
-                    <p class="manual-validation-text">{{ $t('manualValidationPayIntro2') }}</p>
-                    <p class="manual-validation-text manual-validation-list-lead">
-                        {{ $t('manualValidationPayListLead') }}
-                    </p>
-                    <ul class="manual-validation-bullets">
-                        <li>{{ $t('manualValidationPayBulletDni') }}</li>
-                    </ul>
-                    <p class="manual-validation-upload-warning">
-                        <i class="fa fa-info-circle" aria-hidden="true"></i>
-                        {{ $t(manualValidationUploadWarningKey) }}
-                    </p>
-                    <p class="manual-validation-text manual-validation-closing">
-                        {{ $t('manualValidationPayClosing') }}
-                    </p>
-                    <div class="manual-validation-pay-buttons">
-                        <AppButton
-                            variant="primary"
-                            size="lg"
-                            block
-                            class="manual-validation-pay-cta"
-                            :disabled="loadingPreference || loadingQr"
-                            :loading="loadingPreference"
-                            @click="payManualValidation"
-                        >
-                            {{ $t('manualValidationPagarMercadoPago') }}
-                        </AppButton>
-                        <AppButton
-                            v-if="identityValidationManualQrEnabled"
-                            variant="secondary"
-                            size="lg"
-                            block
-                            class="manual-validation-pay-cta"
-                            :disabled="loadingPreference || loadingQr"
-                            :loading="loadingQr"
-                            @click="createManualValidationQrOrderAndShow"
-                        >
-                            {{ $t('pagarConQR') }}
-                        </AppButton>
-                    </div>
-
-                    <div v-if="showQrPanel" class="qr-payment-panel panel panel-default">
-                        <div class="panel-body text-center">
-                            <p class="qr-instruction">{{ $t('escaneáConAppMercadoPago') }}</p>
-                            <div v-if="qrImageUrl" class="qr-image-wrap">
-                                <img :src="qrImageUrl" alt="QR" class="qr-image" />
-                            </div>
-                            <p v-else class="manual-validation-text">{{ $t('cargando') }}...</p>
-                            <p class="qr-expiry small">{{ $t('qrExpiraEn') }}</p>
-                            <AppButton
-                                variant="tertiary"
-                                size="sm"
-                                class="manual-validation-qr-close"
-                                @click="closeManualValidationQrPanel"
-                            >
-                                {{ $t('cerrar') }}
-                            </AppButton>
-                        </div>
-                    </div>
-
+                    <ManualIdentityValidationPayOptions
+                        :cost-display="formattedManualCost"
+                        :qr-enabled="identityValidationManualQrEnabled"
+                        :loading-preference="loadingPreference"
+                        :loading-qr="loadingQr"
+                        :show-qr-panel="showQrPanel"
+                        :qr-image-url="qrImageUrl"
+                        @pay-mp="payManualValidation"
+                        @pay-qr="createManualValidationQrOrderAndShow"
+                        @close-qr="closeManualValidationQrPanel"
+                    />
                     <template v-if="showPendingManualSwitchLink">
                         <hr class="manual-status-switch-separator" />
                         <p class="manual-status-switch-link">
@@ -546,11 +495,8 @@ import {
     shouldShowMercadoPagoIntegrationDisconnectHint
 } from '../../utils/mercadoPagoIntegrationDisconnectHint';
 import { isManualRejectedWithChoiceCards, canManualResubmitWithoutPayment, getManualValidationResubmitRoute, getManualValidationRestartRoute } from '../../utils/manualIdentityValidationStatus';
-import {
-    getManualValidationUploadWarningKey,
-    MANUAL_VALIDATION_UPLOAD_WARNING_STYLE
-} from '../../utils/manualValidationUploadWarning';
 import IdentityValidationAdminReviewNote from '../IdentityValidationAdminReviewNote.vue';
+import ManualIdentityValidationPayOptions from './ManualIdentityValidationPayOptions.vue';
 import AppButton from '../ui/AppButton.vue';
 
 const EMPTY_WARNING_PARTS = { layout: null, leadKey: null, tailKey: null };
@@ -559,6 +505,7 @@ export default {
     name: 'IdentityValidation',
     components: {
         IdentityValidationAdminReviewNote,
+        ManualIdentityValidationPayOptions,
         AppButton
     },
     data() {
@@ -730,12 +677,6 @@ export default {
         },
         showPendingManualSwitchLink() {
             return shouldShowPendingManualSwitchLink(this.config, this.manualStatus);
-        },
-        manualValidationUploadWarningKey() {
-            return getManualValidationUploadWarningKey();
-        },
-        manualValidationUploadWarningStyle() {
-            return MANUAL_VALIDATION_UPLOAD_WARNING_STYLE;
         }
     },
     methods: {
@@ -1170,84 +1111,6 @@ export default {
 
 .manual-status-panel {
     margin-bottom: 1.5em;
-}
-
-.manual-validation-pay-buttons {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    margin-top: 0.25rem;
-}
-
-.manual-validation-text {
-    margin: 0 0 0.75rem;
-    line-height: 1.5;
-    color: #333;
-}
-
-.manual-validation-list-lead {
-    margin-bottom: 0.35rem;
-}
-
-.manual-validation-closing {
-    margin-bottom: 1.25rem;
-}
-
-.manual-validation-upload-warning {
-    margin: 0 0 1rem;
-    padding: 0.75rem 0.9rem;
-    border: v-bind('manualValidationUploadWarningStyle.border');
-    border-radius: 4px;
-    background: v-bind('manualValidationUploadWarningStyle.background');
-    color: v-bind('manualValidationUploadWarningStyle.color');
-    line-height: 1.4;
-}
-
-.manual-validation-upload-warning .fa {
-    margin-right: 0.5rem;
-}
-
-.identity-validation-component .manual-validation-bullets {
-    list-style-type: disc;
-    list-style-position: outside;
-    padding-left: 1.5rem;
-    margin: 0 0 1rem;
-    margin-left: 0;
-    font-size: 0.9rem;
-    line-height: 1.5;
-    color: #333;
-}
-
-.identity-validation-component .manual-validation-bullets li {
-    display: list-item;
-    margin-bottom: 0.35rem;
-}
-
-.manual-validation-pay-cta {
-    text-transform: uppercase;
-    letter-spacing: 0.02em;
-}
-
-.qr-payment-panel {
-    margin-top: 1.25rem;
-}
-
-.qr-image-wrap {
-    margin: 1em 0;
-}
-
-.qr-image {
-    max-width: 256px;
-    height: auto;
-}
-
-.qr-instruction {
-    font-weight: bold;
-    color: #333;
-}
-
-.qr-expiry {
-    color: #666;
 }
 
 .manual-status-switch-separator {

--- a/src/components/sections/IdentityValidation.vue
+++ b/src/components/sections/IdentityValidation.vue
@@ -147,6 +147,26 @@
                             {{ $t('pagarConQR') }}
                         </AppButton>
                     </div>
+
+                    <div v-if="showQrPanel" class="qr-payment-panel panel panel-default">
+                        <div class="panel-body text-center">
+                            <p class="qr-instruction">{{ $t('escaneáConAppMercadoPago') }}</p>
+                            <div v-if="qrImageUrl" class="qr-image-wrap">
+                                <img :src="qrImageUrl" alt="QR" class="qr-image" />
+                            </div>
+                            <p v-else class="manual-validation-text">{{ $t('cargando') }}...</p>
+                            <p class="qr-expiry small">{{ $t('qrExpiraEn') }}</p>
+                            <AppButton
+                                variant="tertiary"
+                                size="sm"
+                                class="manual-validation-qr-close"
+                                @click="closeManualValidationQrPanel"
+                            >
+                                {{ $t('cerrar') }}
+                            </AppButton>
+                        </div>
+                    </div>
+
                     <template v-if="showPendingManualSwitchLink">
                         <hr class="manual-status-switch-separator" />
                         <p class="manual-status-switch-link">
@@ -497,6 +517,7 @@
 import { mapState } from 'pinia';
 import { useAuthStore } from '../../stores/auth';
 import { UserApi } from '../../services/api';
+import QRCode from 'qrcode';
 import {
     isIdentityValidationActionBlockedByMissingDni,
     PROFILE_EDIT_ROUTE,
@@ -556,7 +577,11 @@ export default {
             },
             loadingOAuth: false,
             loadingPreference: false,
-            loadingQr: false
+            loadingQr: false,
+            showQrPanel: false,
+            qrImageUrl: null,
+            qrData: null,
+            pollIntervalId: null
         };
     },
     computed: {
@@ -771,7 +796,50 @@ export default {
                 });
         },
         createManualValidationQrOrderAndShow() {
-            this.loadingQr = false;
+            this.loadingQr = true;
+            const userApi = new UserApi();
+            userApi.createManualIdentityValidationQrOrder()
+                .then((res) => {
+                    const data = res.data || res;
+                    const qrData = data.qr_data;
+                    const requestId = data.request_id;
+                    if (qrData && requestId) {
+                        this.manualStatus.request_id = requestId;
+                        this.qrData = qrData;
+                        this.showQrPanel = true;
+                        this.qrImageUrl = null;
+                        QRCode.toDataURL(qrData, { width: 256, margin: 2 }, (err, url) => {
+                            if (!err) this.qrImageUrl = url;
+                        });
+                        this.startManualValidationQrPolling();
+                    }
+                    this.loadingQr = false;
+                })
+                .catch(() => {
+                    this.loadingQr = false;
+                });
+        },
+        closeManualValidationQrPanel() {
+            this.showQrPanel = false;
+            this.qrData = null;
+            this.qrImageUrl = null;
+            this.stopManualValidationQrPolling();
+        },
+        startManualValidationQrPolling() {
+            this.stopManualValidationQrPolling();
+            this.pollIntervalId = setInterval(() => {
+                this.fetchManualStatus().then(() => {
+                    if (this.manualStatus.paid === true) {
+                        this.closeManualValidationQrPanel();
+                    }
+                });
+            }, 3000);
+        },
+        stopManualValidationQrPolling() {
+            if (this.pollIntervalId) {
+                clearInterval(this.pollIntervalId);
+                this.pollIntervalId = null;
+            }
         },
         startMercadoPagoOAuth() {
             if (!this.user || this.loadingOAuth || this.isIdentityValidationBlockedByMissingDni) return;
@@ -809,6 +877,9 @@ export default {
     },
     mounted() {
         this.fetchManualStatus();
+    },
+    beforeUnmount() {
+        this.stopManualValidationQrPolling();
     }
 };
 </script>
@@ -1155,6 +1226,28 @@ export default {
 .manual-validation-pay-cta {
     text-transform: uppercase;
     letter-spacing: 0.02em;
+}
+
+.qr-payment-panel {
+    margin-top: 1.25rem;
+}
+
+.qr-image-wrap {
+    margin: 1em 0;
+}
+
+.qr-image {
+    max-width: 256px;
+    height: auto;
+}
+
+.qr-instruction {
+    font-weight: bold;
+    color: #333;
+}
+
+.qr-expiry {
+    color: #666;
 }
 
 .manual-status-switch-separator {

--- a/src/components/sections/IdentityValidation.vue
+++ b/src/components/sections/IdentityValidation.vue
@@ -105,14 +105,31 @@
                 <div class="panel-heading">{{ $t('esperandoPagoValidacionManual') }}</div>
                 <div class="panel-body">
                     <p>{{ $t('debesPagarParaContinuar') }}</p>
-                    <AppButton
-                        variant="primary"
-                        :disabled="loadingPreference"
-                        :loading="loadingPreference"
-                        @click="payManualValidation"
-                    >
-                        {{ $t('pagarAhora') }}
-                    </AppButton>
+                    <div class="manual-validation-pay-buttons">
+                        <AppButton
+                            variant="primary"
+                            size="lg"
+                            block
+                            class="manual-validation-pay-cta"
+                            :disabled="loadingPreference || loadingQr"
+                            :loading="loadingPreference"
+                            @click="payManualValidation"
+                        >
+                            {{ $t('manualValidationPagarMercadoPago') }}
+                        </AppButton>
+                        <AppButton
+                            v-if="identityValidationManualQrEnabled"
+                            variant="secondary"
+                            size="lg"
+                            block
+                            class="manual-validation-pay-cta"
+                            :disabled="loadingPreference || loadingQr"
+                            :loading="loadingQr"
+                            @click="createManualValidationQrOrderAndShow"
+                        >
+                            {{ $t('pagarConQR') }}
+                        </AppButton>
+                    </div>
                     <template v-if="showPendingManualSwitchLink">
                         <hr class="manual-status-switch-separator" />
                         <p class="manual-status-switch-link">
@@ -517,7 +534,8 @@ export default {
                 can_resubmit_without_payment: false
             },
             loadingOAuth: false,
-            loadingPreference: false
+            loadingPreference: false,
+            loadingQr: false
         };
     },
     computed: {
@@ -530,6 +548,9 @@ export default {
         },
         identityValidationManualEnabled() {
             return this.config && this.config.identity_validation_manual_enabled === true;
+        },
+        identityValidationManualQrEnabled() {
+            return this.config && this.config.identity_validation_manual_qr_enabled === true;
         },
         identityValidationEnabled() {
             return this.config && this.config.identity_validation_enabled === true;
@@ -721,6 +742,9 @@ export default {
                 .catch(() => {
                     this.loadingPreference = false;
                 });
+        },
+        createManualValidationQrOrderAndShow() {
+            this.loadingQr = false;
         },
         startMercadoPagoOAuth() {
             if (!this.user || this.loadingOAuth || this.isIdentityValidationBlockedByMissingDni) return;
@@ -1048,6 +1072,18 @@ export default {
 
 .manual-status-panel {
     margin-bottom: 1.5em;
+}
+
+.manual-validation-pay-buttons {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-top: 0.25rem;
+}
+
+.manual-validation-pay-cta {
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
 }
 
 .manual-status-switch-separator {

--- a/src/components/sections/IdentityValidation.vue
+++ b/src/components/sections/IdentityValidation.vue
@@ -105,6 +105,23 @@
                 <div class="panel-heading">{{ $t('esperandoPagoValidacionManual') }}</div>
                 <div class="panel-body">
                     <p>{{ $t('debesPagarParaContinuar') }}</p>
+                    <p class="manual-validation-text">
+                        {{ $t('manualValidationPayIntro1', { cost: formattedManualCost }) }}
+                    </p>
+                    <p class="manual-validation-text">{{ $t('manualValidationPayIntro2') }}</p>
+                    <p class="manual-validation-text manual-validation-list-lead">
+                        {{ $t('manualValidationPayListLead') }}
+                    </p>
+                    <ul class="manual-validation-bullets">
+                        <li>{{ $t('manualValidationPayBulletDni') }}</li>
+                    </ul>
+                    <p class="manual-validation-upload-warning">
+                        <i class="fa fa-info-circle" aria-hidden="true"></i>
+                        {{ $t(manualValidationUploadWarningKey) }}
+                    </p>
+                    <p class="manual-validation-text manual-validation-closing">
+                        {{ $t('manualValidationPayClosing') }}
+                    </p>
                     <div class="manual-validation-pay-buttons">
                         <AppButton
                             variant="primary"
@@ -508,6 +525,10 @@ import {
     shouldShowMercadoPagoIntegrationDisconnectHint
 } from '../../utils/mercadoPagoIntegrationDisconnectHint';
 import { isManualRejectedWithChoiceCards, canManualResubmitWithoutPayment, getManualValidationResubmitRoute, getManualValidationRestartRoute } from '../../utils/manualIdentityValidationStatus';
+import {
+    getManualValidationUploadWarningKey,
+    MANUAL_VALIDATION_UPLOAD_WARNING_STYLE
+} from '../../utils/manualValidationUploadWarning';
 import IdentityValidationAdminReviewNote from '../IdentityValidationAdminReviewNote.vue';
 import AppButton from '../ui/AppButton.vue';
 
@@ -684,6 +705,12 @@ export default {
         },
         showPendingManualSwitchLink() {
             return shouldShowPendingManualSwitchLink(this.config, this.manualStatus);
+        },
+        manualValidationUploadWarningKey() {
+            return getManualValidationUploadWarningKey();
+        },
+        manualValidationUploadWarningStyle() {
+            return MANUAL_VALIDATION_UPLOAD_WARNING_STYLE;
         }
     },
     methods: {
@@ -1079,6 +1106,50 @@ export default {
     flex-direction: column;
     gap: 0.75rem;
     margin-top: 0.25rem;
+}
+
+.manual-validation-text {
+    margin: 0 0 0.75rem;
+    line-height: 1.5;
+    color: #333;
+}
+
+.manual-validation-list-lead {
+    margin-bottom: 0.35rem;
+}
+
+.manual-validation-closing {
+    margin-bottom: 1.25rem;
+}
+
+.manual-validation-upload-warning {
+    margin: 0 0 1rem;
+    padding: 0.75rem 0.9rem;
+    border: v-bind('manualValidationUploadWarningStyle.border');
+    border-radius: 4px;
+    background: v-bind('manualValidationUploadWarningStyle.background');
+    color: v-bind('manualValidationUploadWarningStyle.color');
+    line-height: 1.4;
+}
+
+.manual-validation-upload-warning .fa {
+    margin-right: 0.5rem;
+}
+
+.identity-validation-component .manual-validation-bullets {
+    list-style-type: disc;
+    list-style-position: outside;
+    padding-left: 1.5rem;
+    margin: 0 0 1rem;
+    margin-left: 0;
+    font-size: 0.9rem;
+    line-height: 1.5;
+    color: #333;
+}
+
+.identity-validation-component .manual-validation-bullets li {
+    display: list-item;
+    margin-bottom: 0.35rem;
 }
 
 .manual-validation-pay-cta {

--- a/src/components/sections/ManualIdentityValidation.vue
+++ b/src/components/sections/ManualIdentityValidation.vue
@@ -40,81 +40,27 @@
                         <p>{{ $t('debesPagarParaContinuar') }}</p>
                     </div>
 
-                    <p class="manual-validation-text">
-                        {{ $t('manualValidationPayIntro1', { cost: formattedCostDisplay }) }}
-                    </p>
-                    <p class="manual-validation-text">{{ $t('manualValidationPayIntro2') }}</p>
-                    <p class="manual-validation-text manual-validation-list-lead">
-                        {{ $t('manualValidationPayListLead') }}
-                    </p>
-                    <ul class="manual-validation-bullets">
-                        <li>{{ $t('manualValidationPayBulletDni') }}</li>
-                    </ul>
-                    <p class="manual-validation-upload-warning">
-                        <i class="fa fa-info-circle" aria-hidden="true"></i>
-                        {{ $t(manualValidationUploadWarningKey) }}
-                    </p>
-                    <p class="manual-validation-text manual-validation-closing">
-                        {{ $t('manualValidationPayClosing') }}
-                    </p>
-
-                    <div class="manual-validation-pay-buttons">
-                        <AppButton
-                            variant="primary"
-                            size="lg"
-                            block
-                            class="manual-validation-pay-cta"
-                            :disabled="loadingPreference || loadingQr || costCents <= 0"
-                            :loading="loadingPreference"
-                            @click="createPreferenceAndRedirect"
-                        >
-                            {{ $t('manualValidationPagarMercadoPago') }}
-                        </AppButton>
-                        <AppButton
-                            v-if="identityValidationManualQrEnabled"
-                            variant="secondary"
-                            size="lg"
-                            block
-                            class="manual-validation-pay-cta"
-                            :disabled="loadingPreference || loadingQr || costCents <= 0"
-                            :loading="loadingQr"
-                            @click="createQrOrderAndShow"
-                        >
-                            {{ $t('pagarConQR') }}
-                        </AppButton>
-                    </div>
-
-                    <template v-if="showSwitchToMercadoPagoLink">
-                        <hr class="manual-validation-switch-mode-separator" />
-                        <p class="manual-validation-switch-mode-link">
-                            <router-link :to="switchToMercadoPagoRoute">
-                                {{ $t('manualValidationSwitchToMercadoPago') }}
-                            </router-link>
-                        </p>
-                    </template>
-
-                    <p v-if="costCents <= 0" class="manual-validation-text small manual-validation-cost-unavailable">
-                        {{ $t('validacionManualNoDisponible') }}
-                    </p>
-
-                    <div v-if="showQrPanel" class="qr-payment-panel panel panel-default">
-                        <div class="panel-body text-center">
-                            <p class="qr-instruction">{{ $t('escaneáConAppMercadoPago') }}</p>
-                            <div v-if="qrImageUrl" class="qr-image-wrap">
-                                <img :src="qrImageUrl" alt="QR" class="qr-image" />
-                            </div>
-                            <p v-else class="manual-validation-text">{{ $t('cargando') }}...</p>
-                            <p class="qr-expiry small">{{ $t('qrExpiraEn') }}</p>
-                            <AppButton
-                                variant="tertiary"
-                                size="sm"
-                                class="manual-validation-qr-close"
-                                @click="closeQrPanel"
-                            >
-                                {{ $t('cerrar') }}
-                            </AppButton>
-                        </div>
-                    </div>
+                    <ManualIdentityValidationPayOptions
+                        :cost-display="formattedCostDisplay"
+                        :qr-enabled="identityValidationManualQrEnabled"
+                        :loading-preference="loadingPreference"
+                        :loading-qr="loadingQr"
+                        :show-qr-panel="showQrPanel"
+                        :qr-image-url="qrImageUrl"
+                        :cost-unavailable="costCents <= 0"
+                        @pay-mp="createPreferenceAndRedirect"
+                        @pay-qr="createQrOrderAndShow"
+                        @close-qr="closeQrPanel"
+                    >
+                        <template v-if="showSwitchToMercadoPagoLink">
+                            <hr class="manual-validation-switch-mode-separator" />
+                            <p class="manual-validation-switch-mode-link">
+                                <router-link :to="switchToMercadoPagoRoute">
+                                    {{ $t('manualValidationSwitchToMercadoPago') }}
+                                </router-link>
+                            </p>
+                        </template>
+                    </ManualIdentityValidationPayOptions>
                 </div>
             </div>
 
@@ -241,10 +187,6 @@ import {
     SWITCH_TO_MERCADO_PAGO_ROUTE
 } from '../../utils/identityValidationModeSwitch';
 import {
-    getManualValidationUploadWarningKey,
-    MANUAL_VALIDATION_UPLOAD_WARNING_STYLE
-} from '../../utils/manualValidationUploadWarning';
-import {
     IMAGE_UPLOAD_ACCEPT,
     getImageUploadMaxMb
 } from '../../utils/imageUpload';
@@ -256,12 +198,14 @@ import {
 } from '../../utils/manualIdentityValidationStatus';
 import AppButton from '../ui/AppButton.vue';
 import AppField from '../ui/AppField.vue';
+import ManualIdentityValidationPayOptions from './ManualIdentityValidationPayOptions.vue';
 
 export default {
     name: 'ManualIdentityValidation',
     components: {
         AppButton,
-        AppField
+        AppField,
+        ManualIdentityValidationPayOptions
     },
     data() {
         return {
@@ -302,12 +246,6 @@ export default {
         },
         showSwitchToMercadoPagoLink() {
             return shouldShowSwitchToMercadoPago(this.config);
-        },
-        manualValidationUploadWarningKey() {
-            return getManualValidationUploadWarningKey();
-        },
-        manualValidationUploadWarningStyle() {
-            return MANUAL_VALIDATION_UPLOAD_WARNING_STYLE;
         },
         switchToMercadoPagoRoute() {
             return SWITCH_TO_MERCADO_PAGO_ROUTE;
@@ -712,20 +650,6 @@ export default {
     margin-bottom: 1.25rem;
 }
 
-.manual-validation-upload-warning {
-    margin: 0 0 1rem;
-    padding: 0.75rem 0.9rem;
-    border: v-bind('manualValidationUploadWarningStyle.border');
-    border-radius: 4px;
-    background: v-bind('manualValidationUploadWarningStyle.background');
-    color: v-bind('manualValidationUploadWarningStyle.color');
-    line-height: 1.4;
-}
-
-.manual-validation-upload-warning .fa {
-    margin-right: 0.5rem;
-}
-
 .manual-identity-validation-component .manual-validation-bullets {
     list-style-type: disc;
     list-style-position: outside;
@@ -740,49 +664,6 @@ export default {
 .manual-identity-validation-component .manual-validation-bullets li {
     display: list-item;
     margin-bottom: 0.35rem;
-}
-
-.manual-validation-pay-buttons {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    margin-top: 0.25rem;
-}
-
-.manual-validation-pay-cta {
-    text-transform: uppercase;
-    letter-spacing: 0.02em;
-}
-
-.manual-validation-cost-unavailable {
-    margin-top: 0.75rem;
-}
-
-.qr-payment-panel {
-    margin-top: 1.25rem;
-}
-
-.qr-image-wrap {
-    margin: 1em 0;
-}
-
-.qr-image {
-    max-width: 256px;
-    height: auto;
-}
-
-.qr-instruction {
-    font-weight: bold;
-    color: #333;
-}
-
-.qr-expiry {
-    margin-top: 0.5em;
-    color: #333;
-}
-
-.manual-validation-qr-close {
-    margin-top: 0.75rem;
 }
 
 .required {

--- a/src/components/sections/ManualIdentityValidationPayOptions.view.test.js
+++ b/src/components/sections/ManualIdentityValidationPayOptions.view.test.js
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const componentPath = path.resolve(__dirname, 'ManualIdentityValidationPayOptions.vue');
+const identityValidationPath = path.resolve(__dirname, 'IdentityValidation.vue');
+const manualValidationPath = path.resolve(__dirname, 'ManualIdentityValidation.vue');
+
+describe('ManualIdentityValidationPayOptions shared component', () => {
+    it('defines manual payment instructions, buttons, and QR panel markup', () => {
+        const source = fs.readFileSync(componentPath, 'utf8');
+
+        expect(source).toContain("$t('manualValidationPayIntro1', { cost: costDisplay })");
+        expect(source).toContain("$t('manualValidationPagarMercadoPago')");
+        expect(source).toContain("$t('pagarConQR')");
+        expect(source).toContain("$t('escaneáConAppMercadoPago')");
+        expect(source).toContain("emit('pay-mp')");
+        expect(source).toContain("emit('pay-qr')");
+        expect(source).toContain("emit('close-qr')");
+    });
+
+    it('is used by identity validation and manual validation payment flows', () => {
+        const identitySource = fs.readFileSync(identityValidationPath, 'utf8');
+        const manualSource = fs.readFileSync(manualValidationPath, 'utf8');
+
+        expect(identitySource).toContain('ManualIdentityValidationPayOptions');
+        expect(manualSource).toContain('ManualIdentityValidationPayOptions');
+    });
+});

--- a/src/components/sections/ManualIdentityValidationPayOptions.vue
+++ b/src/components/sections/ManualIdentityValidationPayOptions.vue
@@ -1,0 +1,213 @@
+<template>
+    <div class="manual-validation-pay-options">
+        <p class="manual-validation-text">
+            {{ $t('manualValidationPayIntro1', { cost: costDisplay }) }}
+        </p>
+        <p class="manual-validation-text">{{ $t('manualValidationPayIntro2') }}</p>
+        <p class="manual-validation-text manual-validation-list-lead">
+            {{ $t('manualValidationPayListLead') }}
+        </p>
+        <ul class="manual-validation-bullets">
+            <li>{{ $t('manualValidationPayBulletDni') }}</li>
+        </ul>
+        <p class="manual-validation-upload-warning">
+            <i class="fa fa-info-circle" aria-hidden="true"></i>
+            {{ $t(manualValidationUploadWarningKey) }}
+        </p>
+        <p class="manual-validation-text manual-validation-closing">
+            {{ $t('manualValidationPayClosing') }}
+        </p>
+
+        <div class="manual-validation-pay-buttons">
+            <AppButton
+                variant="primary"
+                size="lg"
+                block
+                class="manual-validation-pay-cta"
+                :disabled="loadingPreference || loadingQr || costUnavailable"
+                :loading="loadingPreference"
+                @click="$emit('pay-mp')"
+            >
+                {{ $t('manualValidationPagarMercadoPago') }}
+            </AppButton>
+            <AppButton
+                v-if="qrEnabled"
+                variant="secondary"
+                size="lg"
+                block
+                class="manual-validation-pay-cta"
+                :disabled="loadingPreference || loadingQr || costUnavailable"
+                :loading="loadingQr"
+                @click="$emit('pay-qr')"
+            >
+                {{ $t('pagarConQR') }}
+            </AppButton>
+        </div>
+
+        <slot />
+
+        <p
+            v-if="costUnavailable"
+            class="manual-validation-text small manual-validation-cost-unavailable"
+        >
+            {{ $t('validacionManualNoDisponible') }}
+        </p>
+
+        <div v-if="showQrPanel" class="qr-payment-panel panel panel-default">
+            <div class="panel-body text-center">
+                <p class="qr-instruction">{{ $t('escaneáConAppMercadoPago') }}</p>
+                <div v-if="qrImageUrl" class="qr-image-wrap">
+                    <img :src="qrImageUrl" alt="QR" class="qr-image" />
+                </div>
+                <p v-else class="manual-validation-text">{{ $t('cargando') }}...</p>
+                <p class="qr-expiry small">{{ $t('qrExpiraEn') }}</p>
+                <AppButton
+                    variant="tertiary"
+                    size="sm"
+                    class="manual-validation-qr-close"
+                    @click="$emit('close-qr')"
+                >
+                    {{ $t('cerrar') }}
+                </AppButton>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+import {
+    getManualValidationUploadWarningKey,
+    MANUAL_VALIDATION_UPLOAD_WARNING_STYLE
+} from '../../utils/manualValidationUploadWarning';
+import AppButton from '../ui/AppButton.vue';
+
+export default {
+    name: 'ManualIdentityValidationPayOptions',
+    components: {
+        AppButton
+    },
+    props: {
+        costDisplay: {
+            type: String,
+            required: true
+        },
+        qrEnabled: {
+            type: Boolean,
+            default: false
+        },
+        loadingPreference: {
+            type: Boolean,
+            default: false
+        },
+        loadingQr: {
+            type: Boolean,
+            default: false
+        },
+        showQrPanel: {
+            type: Boolean,
+            default: false
+        },
+        qrImageUrl: {
+            type: String,
+            default: null
+        },
+        costUnavailable: {
+            type: Boolean,
+            default: false
+        }
+    },
+    emits: ['pay-mp', 'pay-qr', 'close-qr'],
+    computed: {
+        manualValidationUploadWarningKey() {
+            return getManualValidationUploadWarningKey();
+        },
+        manualValidationUploadWarningStyle() {
+            return MANUAL_VALIDATION_UPLOAD_WARNING_STYLE;
+        }
+    }
+};
+</script>
+
+<style scoped>
+.manual-validation-text {
+    margin: 0 0 0.75rem;
+    line-height: 1.5;
+    color: #333;
+}
+
+.manual-validation-list-lead {
+    margin-bottom: 0.35rem;
+}
+
+.manual-validation-closing {
+    margin-bottom: 1.25rem;
+}
+
+.manual-validation-upload-warning {
+    margin: 0 0 1rem;
+    padding: 0.75rem 0.9rem;
+    border: v-bind('manualValidationUploadWarningStyle.border');
+    border-radius: 4px;
+    background: v-bind('manualValidationUploadWarningStyle.background');
+    color: v-bind('manualValidationUploadWarningStyle.color');
+    line-height: 1.4;
+}
+
+.manual-validation-upload-warning .fa {
+    margin-right: 0.5rem;
+}
+
+.manual-validation-pay-options .manual-validation-bullets {
+    list-style-type: disc;
+    list-style-position: outside;
+    padding-left: 1.5rem;
+    margin: 0 0 1rem;
+    margin-left: 0;
+    font-size: 0.9rem;
+    line-height: 1.5;
+    color: #333;
+}
+
+.manual-validation-pay-options .manual-validation-bullets li {
+    display: list-item;
+    margin-bottom: 0.35rem;
+}
+
+.manual-validation-pay-buttons {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-top: 0.25rem;
+}
+
+.manual-validation-pay-cta {
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+}
+
+.manual-validation-cost-unavailable {
+    margin-top: 0.75rem;
+}
+
+.qr-payment-panel {
+    margin-top: 1.25rem;
+}
+
+.qr-image-wrap {
+    margin: 1em 0;
+}
+
+.qr-image {
+    max-width: 256px;
+    height: auto;
+}
+
+.qr-instruction {
+    font-weight: bold;
+    color: #333;
+}
+
+.qr-expiry {
+    color: #666;
+}
+</style>


### PR DESCRIPTION
## Summary
- Replace the single “Pagar ahora” button on the main identity validation screen’s unpaid manual verification panel with the same payment UI used on the dedicated manual validation page: Mercado Pago checkout and optional QR.
- Add QR order creation, QR panel display, and status polling so users can complete payment without leaving the identity validation flow.
- Extract shared `ManualIdentityValidationPayOptions` component used by both `IdentityValidation.vue` and `ManualIdentityValidation.vue` to keep instructions and payment actions in sync.

## Test plan
- [x] Start manual verification, abandon Mercado Pago checkout, return to **Verificación de cuenta** — confirm **Pagar con Mercado Pago** and **Pagar con QR** (when QR is enabled in backend config) are shown with the same instructions as `/identity-validation/manual`.
- [x] Tap **Pagar con Mercado Pago** — redirects to Mercado Pago Checkout Pro and marks request paid after successful payment.
- [x] Tap **Pagar con QR** — QR panel appears with scan instructions; after paying in the Mercado Pago app, panel closes and flow advances once webhook marks payment paid.
- [x] With `identity_validation_manual_qr_enabled=false` in `/api/config`, confirm only the Mercado Pago button is shown.
- [x] Run `npm run test:unit -- --run src/components/sections/IdentityValidation.view.test.js src/components/sections/ManualIdentityValidationPayOptions.view.test.js`
- [x] Run `npm run build`