### PR TITLE
Donation after-rating UI and platform checkout integration

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,5 +9,8 @@ if [[ ! -d node_modules ]]; then
   exit 1
 fi
 
+echo "pre-commit: eslint --fix..."
+npm run lint:fix
+
 echo "pre-commit: eslint..."
 npm run lint

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@300;400;500;600;700&family=Dela+Gothic+One&display=swap" rel="stylesheet">
     
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.3/dist/leaflet.css"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "build-capacitor-android-local": "npm run build:android && cp -r dist/default/production/www/* www/ && npx cap run android --target d59fb3c7",
     "cap:sync:android": "npx cap sync android && node scripts/fix-capacitor-cordova-gradle.js",
     "preview:mp-rejection-warning": "node scripts/print-mp-rejection-preview-url.mjs",
+    "preview:donation-after-rating": "node scripts/print-donation-after-rating-preview-url.mjs",
     "lint": "eslint --ext .js src",
     "lint:fix": "eslint --ext .js --fix src",
     "check": "npm run lint && npm run test:unit -- --run",

--- a/scripts/print-donation-after-rating-preview-url.mjs
+++ b/scripts/print-donation-after-rating-preview-url.mjs
@@ -1,0 +1,8 @@
+import { buildDonationAfterRatingPreviewUrl } from '../src/utils/donationAfterRatingPreview.js';
+
+const previewUrl = buildDonationAfterRatingPreviewUrl({
+    origin: 'http://localhost:8080'
+});
+
+console.log('Open while running npm run dev:');
+console.log(previewUrl);

--- a/src/components/elements/DonationAmountPicker.view.test.js
+++ b/src/components/elements/DonationAmountPicker.view.test.js
@@ -14,5 +14,7 @@ describe('DonationAmountPicker.vue', () => {
         expect(source).toContain(':value="String(tier.amount)"');
         expect(source).toContain('donationTierCafe');
         expect(source).toContain('donationUsageNote');
+        expect(source).toContain('usageNoteKey');
+        expect(source).toContain('radioGroupName');
     });
 });

--- a/src/components/elements/DonationAmountPicker.vue
+++ b/src/components/elements/DonationAmountPicker.vue
@@ -41,6 +41,7 @@
 
 <script>
 import { DONATION_TIERS } from '../../utils/donationOptions.js';
+import { fetchDonationTiers } from '../../utils/donationCheckout.js';
 
 /** i18n: donationTierCafe, donationTierBeer, donationTierFood */
 
@@ -73,9 +74,17 @@ export default {
         }
     },
     emits: ['update:modelValue'],
+    data() {
+        return {
+            loadedTiers: DONATION_TIERS
+        };
+    },
+    async mounted() {
+        this.loadedTiers = await fetchDonationTiers();
+    },
     computed: {
         tiers() {
-            return DONATION_TIERS;
+            return this.loadedTiers;
         }
     },
     methods: {

--- a/src/components/elements/DonationAmountPicker.vue
+++ b/src/components/elements/DonationAmountPicker.vue
@@ -1,8 +1,19 @@
 <template>
-    <div class="donation-amount-picker">
-        <p v-if="showUsageNote" class="donation-usage-note text-center">
-            {{ $t('donationUsageNote') }}
+    <div
+        class="donation-amount-picker"
+        :class="{ 'donation-amount-picker--body-text': bodyTextTone }"
+    >
+        <p
+            v-if="showUsageNote && !usageNoteHtml"
+            class="donation-usage-note text-center"
+        >
+            {{ $t(usageNoteKey) }}
         </p>
+        <p
+            v-if="showUsageNote && usageNoteHtml"
+            class="donation-usage-note text-center"
+            v-html="$t(usageNoteKey)"
+        ></p>
         <div class="radio">
             <label
                 v-for="tier in tiers"
@@ -11,8 +22,8 @@
             >
                 <input
                     type="radio"
-                    name="donationValor"
-                    :id="'donation-' + tier.amount"
+                    :name="radioGroupName"
+                    :id="radioGroupName + '-' + tier.amount"
                     :value="String(tier.amount)"
                     :checked="isSelected(tier.amount)"
                     @change="select(tier.amount)"
@@ -43,6 +54,22 @@ export default {
         showUsageNote: {
             type: Boolean,
             default: true
+        },
+        usageNoteKey: {
+            type: String,
+            default: 'donationUsageNote'
+        },
+        usageNoteHtml: {
+            type: Boolean,
+            default: false
+        },
+        bodyTextTone: {
+            type: Boolean,
+            default: false
+        },
+        radioGroupName: {
+            type: String,
+            default: 'donationValor'
         }
     },
     emits: ['update:modelValue'],
@@ -69,14 +96,31 @@ export default {
 .donation-tier-option {
     display: inline-flex;
     align-items: center;
-    gap: 6px;
+    gap: 8px;
     margin-right: 12px;
     margin-bottom: 8px;
+    position: static;
+    padding-left: 0;
+}
+
+.donation-tier-option input[type='radio'] {
+    position: static;
+    margin: 0;
+    flex-shrink: 0;
 }
 
 .donation-tier-option .fa {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
     font-size: 1.1em;
+    line-height: 1;
     opacity: 0.85;
+}
+
+.donation-tier-label {
+    line-height: 1.25;
 }
 
 .donation-usage-note {
@@ -87,9 +131,32 @@ export default {
     line-height: 1.45;
 }
 
+.donation-amount-picker--body-text .donation-usage-note {
+    color: var(--ds-text-primary);
+    font-size: 1.2rem;
+}
+
+.donation-amount-picker--body-text .donation-usage-note :deep(strong) {
+    font-weight: var(--ds-font-weight-bold, 700);
+}
+
+.donation-amount-picker--body-text .donation-tier-option,
+.donation-amount-picker--body-text .donation-tier-option .donation-tier-label,
+.donation-amount-picker--body-text .donation-tier-option .fa {
+    color: var(--ds-text-secondary);
+}
+
+.donation-amount-picker--body-text .donation-tier-option .fa {
+    opacity: 1;
+}
+
 @media (min-width: 768px) {
     .donation-usage-note {
         font-size: 1rem;
+    }
+
+    .donation-amount-picker--body-text .donation-usage-note {
+        font-size: 1.2rem;
     }
 }
 </style>

--- a/src/components/sections/DonationAfterRatingHeader.view.test.js
+++ b/src/components/sections/DonationAfterRatingHeader.view.test.js
@@ -6,19 +6,18 @@ const headerPath = path.resolve(__dirname, 'DonationAfterRatingHeader.vue');
 const headerSource = fs.readFileSync(headerPath, 'utf8');
 
 describe('DonationAfterRatingHeader', () => {
-    it('renders only a centered logo without navigation or donate actions', () => {
+    it('renders carpoolear and STS project branding in one line', () => {
         expect(headerSource).toContain('donation-after-rating-app-header');
-        expect(headerSource).toContain('donation-after-rating-app-header__logo');
-        expect(headerSource).toContain('header_logo');
-        expect(headerSource).toContain('justify-content: center');
+        expect(headerSource).toContain("$t('proyectoDe')");
+        expect(headerSource).toContain('logo_sts_nuevo_color.png');
+        expect(headerSource).toContain('flex-wrap: nowrap');
         expect(headerSource).toMatch(
-            /donation-after-rating-app-header__logo[\s\S]*height:\s*2\.75rem/
+            /donation-after-rating-app-header__project[\s\S]*color:\s*#fff/
+        );
+        expect(headerSource).toMatch(
+            /donation-after-rating-app-header__sts-logo[\s\S]*filter:\s*brightness\(0\)\s*invert\(1\)/
         );
         expect(headerSource).not.toContain('router-link');
         expect(headerSource).not.toContain('header-donate');
-        expect(headerSource).not.toContain('crearViaje');
-        expect(headerSource).not.toContain('HeaderMenuDropdown');
-        expect(headerSource).not.toContain('PendingRatingsBanner');
-        expect(headerSource).not.toContain('IdentityValidationCountdownBanner');
     });
 });

--- a/src/components/sections/DonationAfterRatingHeader.view.test.js
+++ b/src/components/sections/DonationAfterRatingHeader.view.test.js
@@ -10,6 +10,10 @@ describe('DonationAfterRatingHeader', () => {
         expect(headerSource).toContain('donation-after-rating-app-header');
         expect(headerSource).toContain('donation-after-rating-app-header__logo');
         expect(headerSource).toContain('header_logo');
+        expect(headerSource).toContain('justify-content: center');
+        expect(headerSource).toMatch(
+            /donation-after-rating-app-header__logo[\s\S]*height:\s*2\.75rem/
+        );
         expect(headerSource).not.toContain('router-link');
         expect(headerSource).not.toContain('header-donate');
         expect(headerSource).not.toContain('crearViaje');

--- a/src/components/sections/DonationAfterRatingHeader.view.test.js
+++ b/src/components/sections/DonationAfterRatingHeader.view.test.js
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const headerPath = path.resolve(__dirname, 'DonationAfterRatingHeader.vue');
+const headerSource = fs.readFileSync(headerPath, 'utf8');
+
+describe('DonationAfterRatingHeader', () => {
+    it('renders only a centered logo without navigation or donate actions', () => {
+        expect(headerSource).toContain('donation-after-rating-app-header');
+        expect(headerSource).toContain('donation-after-rating-app-header__logo');
+        expect(headerSource).toContain('header_logo');
+        expect(headerSource).not.toContain('router-link');
+        expect(headerSource).not.toContain('header-donate');
+        expect(headerSource).not.toContain('crearViaje');
+        expect(headerSource).not.toContain('HeaderMenuDropdown');
+        expect(headerSource).not.toContain('PendingRatingsBanner');
+        expect(headerSource).not.toContain('IdentityValidationCountdownBanner');
+    });
+});

--- a/src/components/sections/DonationAfterRatingHeader.vue
+++ b/src/components/sections/DonationAfterRatingHeader.vue
@@ -1,0 +1,52 @@
+<template>
+    <div class="donation-after-rating-app-header">
+        <img
+            :src="header_logo"
+            alt=""
+            class="donation-after-rating-app-header__logo"
+        />
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'DonationAfterRatingHeader',
+    data() {
+        return {
+            header_logo: process.env.ROUTE_BASE + 'img/logo2.svg'
+        };
+    }
+};
+</script>
+
+<style scoped>
+.donation-after-rating-app-header {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding-top: calc(
+        var(--ds-header-desktop-padding-y, 0.75rem) +
+            constant(safe-area-inset-top, 0px)
+    );
+    padding-top: calc(
+        var(--ds-header-desktop-padding-y, 0.75rem) +
+            env(safe-area-inset-top, 0px)
+    );
+    padding-bottom: var(--ds-header-desktop-padding-y, 0.75rem);
+    padding-left: 1rem;
+    padding-right: 1rem;
+}
+
+.donation-after-rating-app-header__logo {
+    display: block;
+    height: 2.75rem;
+    width: auto;
+    max-width: min(100%, 16rem);
+}
+
+@media (min-width: 768px) {
+    .donation-after-rating-app-header__logo {
+        height: 3.5rem;
+    }
+}
+</style>

--- a/src/components/sections/DonationAfterRatingHeader.vue
+++ b/src/components/sections/DonationAfterRatingHeader.vue
@@ -1,10 +1,22 @@
 <template>
     <div class="donation-after-rating-app-header">
-        <img
-            :src="header_logo"
-            alt=""
-            class="donation-after-rating-app-header__logo"
-        />
+        <div class="donation-after-rating-app-header__brand">
+            <img
+                :src="header_logo"
+                alt=""
+                class="donation-after-rating-app-header__logo"
+            />
+            <div class="donation-after-rating-app-header__project">
+                <span class="donation-after-rating-app-header__project-text">
+                    {{ $t('proyectoDe') }}
+                </span>
+                <img
+                    :src="$publicImg('logo_sts_nuevo_color.png')"
+                    alt="STS Rosario"
+                    class="donation-after-rating-app-header__sts-logo"
+                />
+            </div>
+        </div>
     </div>
 </template>
 
@@ -33,20 +45,71 @@ export default {
             env(safe-area-inset-top, 0px)
     );
     padding-bottom: var(--ds-header-desktop-padding-y, 0.75rem);
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+}
+
+.donation-after-rating-app-header__brand {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: nowrap;
+    gap: 0.5rem 0.65rem;
+    max-width: 100%;
 }
 
 .donation-after-rating-app-header__logo {
     display: block;
-    height: 2.75rem;
+    flex: 0 1 auto;
+    height: 1.85rem;
     width: auto;
-    max-width: min(100%, 16rem);
+    max-width: 9.5rem;
+}
+
+.donation-after-rating-app-header__project {
+    display: inline-flex;
+    align-items: center;
+    flex: 0 1 auto;
+    min-width: 0;
+    gap: 0.35rem;
+    color: #fff;
+    font-size: 0.7rem;
+    line-height: 1.1;
+}
+
+.donation-after-rating-app-header__project-text {
+    color: #fff;
+    white-space: nowrap;
+}
+
+.donation-after-rating-app-header__sts-logo {
+    display: block;
+    flex: 0 1 auto;
+    height: 1.15rem;
+    width: auto;
+    max-width: 5.5rem;
+    filter: brightness(0) invert(1);
 }
 
 @media (min-width: 768px) {
+    .donation-after-rating-app-header {
+        padding-left: 1rem;
+        padding-right: 1rem;
+    }
+
     .donation-after-rating-app-header__logo {
-        height: 3.5rem;
+        height: 2.35rem;
+        max-width: 12rem;
+    }
+
+    .donation-after-rating-app-header__project {
+        font-size: 0.85rem;
+        gap: 0.45rem;
+    }
+
+    .donation-after-rating-app-header__sts-logo {
+        height: 1.5rem;
+        max-width: 7rem;
     }
 }
 </style>

--- a/src/components/sections/DonationAfterRatingHero.view.test.js
+++ b/src/components/sections/DonationAfterRatingHero.view.test.js
@@ -39,4 +39,17 @@ describe('DonationAfterRatingHero', () => {
             /donation-after-rating-hero__media[\s\S]*width:\s*100%/
         );
     });
+
+    it('spans the full viewport width and keeps the title and image within bounds', () => {
+        expect(heroSource).toContain('donation-after-rating-hero--full-width');
+        expect(heroSource).toMatch(
+            /donation-after-rating-hero__title-line[\s\S]*max-width:\s*100%/
+        );
+        expect(heroSource).toMatch(
+            /donation-after-rating-hero__media[\s\S]*overflow:\s*hidden/
+        );
+        expect(heroSource).toMatch(
+            /@media \(min-width: 768px\)[\s\S]*align-items:\s*start/
+        );
+    });
 });

--- a/src/components/sections/DonationAfterRatingHero.view.test.js
+++ b/src/components/sections/DonationAfterRatingHero.view.test.js
@@ -21,11 +21,13 @@ describe('DonationAfterRatingHero', () => {
         expect(heroSource).toContain('donation-after-rating-hero__image-frame');
         expect(heroSource).toContain('donation-after-rating-hero__image-backdrop');
         expect(heroSource).toContain('donation-after-rating-hero__image');
-        expect(heroSource).toMatch(
-            /donation-after-rating-hero__image-backdrop[\s\S]*transform:\s*rotate/
+        const backdropRule = heroSource.match(
+            /\.donation-after-rating-hero__image-backdrop\s*\{[^}]+\}/
         );
+        expect(backdropRule).not.toBeNull();
+        expect(backdropRule[0]).not.toMatch(/transform:\s*rotate/);
         expect(heroSource).toMatch(
-            /donation-after-rating-hero__image[\s\S]*transform:\s*rotate/
+            /\.donation-after-rating-hero__image\s*\{[\s\S]*?transform:\s*rotate/
         );
     });
 

--- a/src/components/sections/DonationAfterRatingHero.view.test.js
+++ b/src/components/sections/DonationAfterRatingHero.view.test.js
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const heroPath = path.resolve(__dirname, 'DonationAfterRatingHero.vue');
+const heroSource = fs.readFileSync(heroPath, 'utf8');
+
+describe('DonationAfterRatingHero', () => {
+    it('renders the two-line hero title with Dela Gothic One styling', () => {
+        expect(heroSource).toContain('donation-after-rating-hero');
+        expect(heroSource).toContain('donation-after-rating-hero__title');
+        expect(heroSource).toContain('NECESITAMOS');
+        expect(heroSource).toContain('TU APORTE');
+        expect(heroSource).toContain("'Dela Gothic One'");
+        expect(heroSource).toContain('--ds-text-primary');
+        expect(heroSource).toContain('--ds-header-donate-bg');
+    });
+
+    it('shows the hero image from API_URL/img with a rotated green backdrop', () => {
+        expect(heroSource).toContain('getDonationAfterRatingHeroImageUrl');
+        expect(heroSource).toContain('donation-after-rating-hero__image-frame');
+        expect(heroSource).toContain('donation-after-rating-hero__image-backdrop');
+        expect(heroSource).toContain('donation-after-rating-hero__image');
+        expect(heroSource).toMatch(
+            /donation-after-rating-hero__image-backdrop[\s\S]*transform:\s*rotate/
+        );
+        expect(heroSource).toMatch(
+            /donation-after-rating-hero__image[\s\S]*transform:\s*rotate/
+        );
+    });
+
+    it('uses a side-by-side layout on desktop and stacks on mobile', () => {
+        expect(heroSource).toMatch(
+            /@media \(min-width: 768px\)[\s\S]*donation-after-rating-hero[\s\S]*grid-template-columns/
+        );
+        expect(heroSource).toMatch(
+            /donation-after-rating-hero__media[\s\S]*width:\s*100%/
+        );
+    });
+});

--- a/src/components/sections/DonationAfterRatingHero.view.test.js
+++ b/src/components/sections/DonationAfterRatingHero.view.test.js
@@ -9,10 +9,10 @@ describe('DonationAfterRatingHero', () => {
     it('renders the two-line hero title with Dela Gothic One styling', () => {
         expect(heroSource).toContain('donation-after-rating-hero');
         expect(heroSource).toContain('donation-after-rating-hero__title');
-        expect(heroSource).toContain('NECESITAMOS');
-        expect(heroSource).toContain('TU APORTE');
+        expect(heroSource).toContain("$t('donationAfterRatingHeroTitlePrimary')");
+        expect(heroSource).toContain("$t('donationAfterRatingHeroTitleAccent')");
         expect(heroSource).toContain("'Dela Gothic One'");
-        expect(heroSource).toContain('--ds-text-primary');
+        expect(heroSource).toContain('--ds-text-secondary');
         expect(heroSource).toContain('--ds-header-donate-bg');
     });
 
@@ -31,25 +31,29 @@ describe('DonationAfterRatingHero', () => {
         );
     });
 
-    it('uses a side-by-side layout on desktop and stacks on mobile', () => {
+    it('centers the mobile hero title and uses an 85vw image width', () => {
         expect(heroSource).toMatch(
-            /@media \(min-width: 768px\)[\s\S]*donation-after-rating-hero[\s\S]*grid-template-columns/
+            /donation-after-rating-hero__copy[\s\S]*text-align:\s*center/
         );
         expect(heroSource).toMatch(
-            /donation-after-rating-hero__media[\s\S]*width:\s*100%/
+            /donation-after-rating-hero__image-frame[\s\S]*width:\s*85vw/
         );
+        expect(heroSource).toContain('margin-top: 1.5rem');
     });
 
-    it('spans the full viewport width and keeps the title and image within bounds', () => {
-        expect(heroSource).toContain('donation-after-rating-hero--full-width');
+    it('shows the mission copy and vertically centers content on wide desktops', () => {
+        expect(heroSource).toContain("$t('donationAfterRatingMissionLead')");
+        expect(heroSource).toContain("$t('donationAfterRatingMissionOrg')");
+        expect(heroSource).toContain("$t('donationAfterRatingMissionBody')");
+        expect(heroSource).toContain('donation-after-rating-hero__mission-lead-emphasis');
         expect(heroSource).toMatch(
-            /donation-after-rating-hero__title-line[\s\S]*max-width:\s*100%/
+            /@media \(min-width: 992px\)[\s\S]*donation-after-rating-hero__mission[\s\S]*display:\s*block/
         );
         expect(heroSource).toMatch(
-            /donation-after-rating-hero__media[\s\S]*overflow:\s*hidden/
+            /@media \(min-width: 768px\)[\s\S]*align-items:\s*center/
         );
         expect(heroSource).toMatch(
-            /@media \(min-width: 768px\)[\s\S]*align-items:\s*start/
+            /@media \(min-width: 992px\)[\s\S]*donation-after-rating-hero__image-frame[\s\S]*width:\s*30vw/
         );
     });
 });

--- a/src/components/sections/DonationAfterRatingHero.vue
+++ b/src/components/sections/DonationAfterRatingHero.vue
@@ -81,6 +81,7 @@ export default {
     max-width: 34rem;
     margin: 0 auto;
     aspect-ratio: 4 / 3;
+    overflow: visible;
 }
 
 .donation-after-rating-hero__image-backdrop,
@@ -99,6 +100,7 @@ export default {
 .donation-after-rating-hero__image {
     object-fit: cover;
     transform: rotate(-4deg);
+    z-index: 1;
 }
 
 @media (min-width: 768px) {

--- a/src/components/sections/DonationAfterRatingHero.vue
+++ b/src/components/sections/DonationAfterRatingHero.vue
@@ -1,5 +1,5 @@
 <template>
-    <section class="donation-after-rating-hero">
+    <section class="donation-after-rating-hero donation-after-rating-hero--full-width">
         <div class="donation-after-rating-hero__copy">
             <h1 class="donation-after-rating-hero__title">
                 <span
@@ -44,14 +44,28 @@ export default {
 </script>
 
 <style scoped>
+.donation-after-rating-hero--full-width {
+    width: 100%;
+    max-width: 100vw;
+    box-sizing: border-box;
+}
+
 .donation-after-rating-hero {
     display: grid;
-    gap: 2rem;
+    gap: 1.5rem;
     margin-bottom: 2rem;
+}
+
+.donation-after-rating-hero__copy {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 0 1rem;
+    container-type: inline-size;
 }
 
 .donation-after-rating-hero__title {
     margin: 0;
+    width: 100%;
     font-family: 'Dela Gothic One', var(--ds-font-family);
     font-weight: 400;
     line-height: 0.95;
@@ -60,7 +74,9 @@ export default {
 
 .donation-after-rating-hero__title-line {
     display: block;
-    font-size: clamp(2.75rem, 12vw, 4.5rem);
+    width: 100%;
+    max-width: 100%;
+    font-size: clamp(1.75rem, 9.5cqw, 4.5rem);
 }
 
 .donation-after-rating-hero__title-line--primary {
@@ -73,15 +89,19 @@ export default {
 
 .donation-after-rating-hero__media {
     width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+    overflow: hidden;
 }
 
 .donation-after-rating-hero__image-frame {
     position: relative;
     width: 100%;
-    max-width: 34rem;
+    max-width: 100%;
+    min-width: 0;
     margin: 0 auto;
     aspect-ratio: 4 / 3;
-    overflow: visible;
 }
 
 .donation-after-rating-hero__image-backdrop,
@@ -106,22 +126,26 @@ export default {
 @media (min-width: 768px) {
     .donation-after-rating-hero {
         grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-        align-items: center;
-        gap: 2.5rem;
+        align-items: start;
+        gap: 4rem;
+        padding: 0 2.5rem;
+    }
+
+    .donation-after-rating-hero__copy {
+        padding: 0;
     }
 
     .donation-after-rating-hero__title-line {
-        font-size: clamp(3.5rem, 5vw, 5.5rem);
+        font-size: clamp(2.75rem, 4.2vw, 5.5rem);
     }
 
     .donation-after-rating-hero__media {
-        justify-self: end;
-        width: 100%;
+        justify-self: stretch;
+        padding: 1.5rem 0 1.5rem 1.5rem;
     }
 
     .donation-after-rating-hero__image-frame {
-        margin: 0 0 0 auto;
-        max-width: none;
+        margin: 0;
     }
 }
 </style>

--- a/src/components/sections/DonationAfterRatingHero.vue
+++ b/src/components/sections/DonationAfterRatingHero.vue
@@ -1,0 +1,125 @@
+<template>
+    <section class="donation-after-rating-hero">
+        <div class="donation-after-rating-hero__copy">
+            <h1 class="donation-after-rating-hero__title">
+                <span
+                    class="donation-after-rating-hero__title-line donation-after-rating-hero__title-line--primary"
+                >
+                    NECESITAMOS
+                </span>
+                <span
+                    class="donation-after-rating-hero__title-line donation-after-rating-hero__title-line--accent"
+                >
+                    TU APORTE
+                </span>
+            </h1>
+        </div>
+        <div class="donation-after-rating-hero__media">
+            <div class="donation-after-rating-hero__image-frame">
+                <div
+                    class="donation-after-rating-hero__image-backdrop"
+                    aria-hidden="true"
+                ></div>
+                <img
+                    class="donation-after-rating-hero__image"
+                    :src="heroImageUrl"
+                    alt=""
+                />
+            </div>
+        </div>
+    </section>
+</template>
+
+<script>
+import { getDonationAfterRatingHeroImageUrl } from '../../utils/donationAfterRatingHero.js';
+
+export default {
+    name: 'DonationAfterRatingHero',
+    computed: {
+        heroImageUrl() {
+            return getDonationAfterRatingHeroImageUrl();
+        }
+    }
+};
+</script>
+
+<style scoped>
+.donation-after-rating-hero {
+    display: grid;
+    gap: 2rem;
+    margin-bottom: 2rem;
+}
+
+.donation-after-rating-hero__title {
+    margin: 0;
+    font-family: 'Dela Gothic One', var(--ds-font-family);
+    font-weight: 400;
+    line-height: 0.95;
+    letter-spacing: -0.02em;
+}
+
+.donation-after-rating-hero__title-line {
+    display: block;
+    font-size: clamp(2.75rem, 12vw, 4.5rem);
+}
+
+.donation-after-rating-hero__title-line--primary {
+    color: var(--ds-text-primary);
+}
+
+.donation-after-rating-hero__title-line--accent {
+    color: var(--ds-header-donate-bg);
+}
+
+.donation-after-rating-hero__media {
+    width: 100%;
+}
+
+.donation-after-rating-hero__image-frame {
+    position: relative;
+    width: 100%;
+    max-width: 34rem;
+    margin: 0 auto;
+    aspect-ratio: 4 / 3;
+}
+
+.donation-after-rating-hero__image-backdrop,
+.donation-after-rating-hero__image {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: 1.25rem;
+}
+
+.donation-after-rating-hero__image-backdrop {
+    background: var(--ds-header-donate-bg);
+}
+
+.donation-after-rating-hero__image {
+    object-fit: cover;
+    transform: rotate(-4deg);
+}
+
+@media (min-width: 768px) {
+    .donation-after-rating-hero {
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+        align-items: center;
+        gap: 2.5rem;
+    }
+
+    .donation-after-rating-hero__title-line {
+        font-size: clamp(3.5rem, 5vw, 5.5rem);
+    }
+
+    .donation-after-rating-hero__media {
+        justify-self: end;
+        width: 100%;
+    }
+
+    .donation-after-rating-hero__image-frame {
+        margin: 0 0 0 auto;
+        max-width: none;
+    }
+}
+</style>

--- a/src/components/sections/DonationAfterRatingHero.vue
+++ b/src/components/sections/DonationAfterRatingHero.vue
@@ -5,14 +5,29 @@
                 <span
                     class="donation-after-rating-hero__title-line donation-after-rating-hero__title-line--primary"
                 >
-                    NECESITAMOS
+                    {{ $t('donationAfterRatingHeroTitlePrimary') }}
                 </span>
                 <span
                     class="donation-after-rating-hero__title-line donation-after-rating-hero__title-line--accent"
                 >
-                    TU APORTE
+                    {{ $t('donationAfterRatingHeroTitleAccent') }}
                 </span>
             </h1>
+            <div class="donation-after-rating-hero__mission">
+                <p class="donation-after-rating-hero__mission-lead">
+                    <span
+                        class="donation-after-rating-hero__mission-org"
+                        v-html="$t('donationAfterRatingMissionOrg')"
+                    ></span>
+                    <span class="donation-after-rating-hero__mission-lead-emphasis">
+                        {{ $t('donationAfterRatingMissionLead') }}
+                    </span>
+                </p>
+                <p
+                    class="donation-after-rating-hero__mission-body"
+                    v-html="$t('donationAfterRatingMissionBody')"
+                ></p>
+            </div>
         </div>
         <div class="donation-after-rating-hero__media">
             <div class="donation-after-rating-hero__image-frame">
@@ -53,6 +68,7 @@ export default {
 .donation-after-rating-hero {
     display: grid;
     gap: 1.5rem;
+    margin-top: 1.5rem;
     margin-bottom: 2rem;
 }
 
@@ -61,6 +77,7 @@ export default {
     box-sizing: border-box;
     padding: 0 1rem;
     container-type: inline-size;
+    text-align: center;
 }
 
 .donation-after-rating-hero__title {
@@ -77,14 +94,48 @@ export default {
     width: 100%;
     max-width: 100%;
     font-size: clamp(1.75rem, 9.5cqw, 4.5rem);
+    text-transform: uppercase;
 }
 
 .donation-after-rating-hero__title-line--primary {
-    color: var(--ds-text-primary);
+    color: var(--ds-text-secondary);
 }
 
 .donation-after-rating-hero__title-line--accent {
     color: var(--ds-header-donate-bg);
+}
+
+.donation-after-rating-hero__mission {
+    display: none;
+    margin: 1.25rem 0 0;
+    color: var(--ds-text-secondary);
+    font-family: var(--ds-font-family);
+    font-size: 1.4rem;
+    line-height: 1.45;
+    text-align: left;
+}
+
+.donation-after-rating-hero__mission-lead {
+    margin: 0;
+    font-size: inherit;
+    line-height: inherit;
+    font-weight: var(--ds-font-weight-normal, 400);
+}
+
+.donation-after-rating-hero__mission-lead-emphasis,
+.donation-after-rating-hero__mission-lead :deep(strong) {
+    font-weight: var(--ds-font-weight-bold, 700);
+}
+
+.donation-after-rating-hero__mission-body {
+    margin: 0.75rem 0 0;
+    font-size: inherit;
+    line-height: inherit;
+    font-weight: var(--ds-font-weight-normal, 400);
+}
+
+.donation-after-rating-hero__mission-body :deep(strong) {
+    font-weight: var(--ds-font-weight-bold, 700);
 }
 
 .donation-after-rating-hero__media {
@@ -97,8 +148,8 @@ export default {
 
 .donation-after-rating-hero__image-frame {
     position: relative;
-    width: 100%;
-    max-width: 100%;
+    width: 85vw;
+    max-width: 85vw;
     min-width: 0;
     margin: 0 auto;
     aspect-ratio: 4 / 3;
@@ -126,13 +177,15 @@ export default {
 @media (min-width: 768px) {
     .donation-after-rating-hero {
         grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-        align-items: start;
+        align-items: center;
         gap: 4rem;
         padding: 0 2.5rem;
+        margin-top: 2rem;
     }
 
     .donation-after-rating-hero__copy {
         padding: 0;
+        text-align: left;
     }
 
     .donation-after-rating-hero__title-line {
@@ -145,7 +198,21 @@ export default {
     }
 
     .donation-after-rating-hero__image-frame {
-        margin: 0;
+        width: 100%;
+        max-width: 100%;
+    }
+}
+
+@media (min-width: 992px) {
+    .donation-after-rating-hero__mission {
+        display: block;
+    }
+
+    .donation-after-rating-hero__image-frame {
+        width: 30vw;
+        max-width: 30vw;
+        margin-left: auto;
+        margin-right: 0;
     }
 }
 </style>

--- a/src/components/sections/HeaderApp.donationAfterRatingHeader.test.js
+++ b/src/components/sections/HeaderApp.donationAfterRatingHeader.test.js
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const headerPath = path.resolve(__dirname, 'HeaderApp.vue');
+const headerSource = fs.readFileSync(headerPath, 'utf8');
+
+describe('HeaderApp donation after rating header', () => {
+    it('shows the minimal donation header instead of the full app chrome', () => {
+        expect(headerSource).toContain('usesDonationAfterRatingHeader');
+        expect(headerSource).toContain('DonationAfterRatingHeader');
+        expect(headerSource).toMatch(
+            /v-if="usesDonationAfterRatingHeader"[\s\S]*DonationAfterRatingHeader/
+        );
+        expect(headerSource).toMatch(
+            /v-else[\s\S]*IdentityValidationCountdownBanner/
+        );
+        expect(headerSource).not.toMatch(
+            /usesDonationAfterRatingHeader[\s\S]*IdentityValidationCountdownBanner/
+        );
+    });
+});

--- a/src/components/sections/HeaderApp.donationAfterRatingHeader.test.js
+++ b/src/components/sections/HeaderApp.donationAfterRatingHeader.test.js
@@ -7,16 +7,19 @@ const headerSource = fs.readFileSync(headerPath, 'utf8');
 
 describe('HeaderApp donation after rating header', () => {
     it('shows the minimal donation header instead of the full app chrome', () => {
+        const template = headerSource.match(/<template>([\s\S]*)<\/template>/)[1];
+
         expect(headerSource).toContain('usesDonationAfterRatingHeader');
         expect(headerSource).toContain('DonationAfterRatingHeader');
-        expect(headerSource).toMatch(
-            /v-if="usesDonationAfterRatingHeader"[\s\S]*DonationAfterRatingHeader/
+        expect(template).toContain(
+            '<DonationAfterRatingHeader v-if="usesDonationAfterRatingHeader" />'
         );
-        expect(headerSource).toMatch(
+        expect(template).toContain('<template v-else>');
+        expect(template.indexOf('DonationAfterRatingHeader')).toBeLessThan(
+            template.indexOf('<template v-else>')
+        );
+        expect(template).toMatch(
             /v-else[\s\S]*IdentityValidationCountdownBanner/
-        );
-        expect(headerSource).not.toMatch(
-            /usesDonationAfterRatingHeader[\s\S]*IdentityValidationCountdownBanner/
         );
     });
 });

--- a/src/components/sections/HeaderApp.vue
+++ b/src/components/sections/HeaderApp.vue
@@ -1,5 +1,7 @@
 <template>
     <header class="header header-component">
+        <DonationAfterRatingHeader v-if="usesDonationAfterRatingHeader" />
+        <template v-else>
         <IdentityValidationCountdownBanner />
         <PendingRatingsBanner />
         <div
@@ -316,6 +318,7 @@
                 <header-menu-dropdown v-if="logged" />
             </div>
         </div>
+        </template>
     </header>
 </template>
 
@@ -334,6 +337,7 @@ import IdentityValidationCountdownBanner from '../IdentityValidationCountdownBan
 import UserRatingsCounts from '../elements/UserRatingsCounts.vue';
 import PendingRatingsBanner from '../PendingRatingsBanner.vue';
 import HeaderMenuDropdown from './HeaderMenuDropdown.vue';
+import DonationAfterRatingHeader from './DonationAfterRatingHeader.vue';
 import svgItem from '../SvgItem';
 import AppButton from '../ui/AppButton.vue';
 import { shouldHideDonationOnIOSCapacitor } from '../../services/capacitor.js';
@@ -343,6 +347,7 @@ import {
     syncLocaleToBackend,
 } from '../../utils/userLocale.js';
 import { installAppHeaderOffsetObserver } from '../../utils/appHeaderOffset.js';
+import { usesDonationAfterRatingHeader as isDonationAfterRatingHeaderRoute } from '../../utils/donationAfterRatingHeader.js';
 
 const userApi = new UserApi();
 
@@ -407,6 +412,9 @@ export default {
         }),
         showChangelogNav() {
             return this.logged && this.hasAnyChangelog;
+        },
+        usesDonationAfterRatingHeader() {
+            return isDonationAfterRatingHeaderRoute(this.$route.name);
         },
 
         showLogo() {
@@ -507,6 +515,7 @@ export default {
         UserRatingsCounts,
         PendingRatingsBanner,
         HeaderMenuDropdown,
+        DonationAfterRatingHeader,
         svgItem,
         AppButton
     }

--- a/src/components/views/DonationAfterRating.view.test.js
+++ b/src/components/views/DonationAfterRating.view.test.js
@@ -7,6 +7,15 @@ const viewPath = path.resolve(__dirname, 'DonationAfterRating.vue');
 const viewSource = fs.readFileSync(viewPath, 'utf8');
 
 describe('DonationAfterRating page content', () => {
+    it('renders the hero outside the constrained page container', () => {
+        expect(viewSource).toMatch(
+            /<DonationAfterRatingHero \/>[\s\S]*donation-after-rating__content container/
+        );
+        expect(viewSource).not.toMatch(
+            /class="donation-after-rating container"[\s\S]*<DonationAfterRatingHero/
+        );
+    });
+
     it('shows the hero section above the donation prompt content', () => {
         expect(viewSource).toContain('DonationAfterRatingHero');
         expect(viewSource.indexOf('DonationAfterRatingHero')).toBeLessThan(

--- a/src/components/views/DonationAfterRating.view.test.js
+++ b/src/components/views/DonationAfterRating.view.test.js
@@ -7,6 +7,13 @@ const viewPath = path.resolve(__dirname, 'DonationAfterRating.vue');
 const viewSource = fs.readFileSync(viewPath, 'utf8');
 
 describe('DonationAfterRating page content', () => {
+    it('shows the hero section above the donation prompt content', () => {
+        expect(viewSource).toContain('DonationAfterRatingHero');
+        expect(viewSource.indexOf('DonationAfterRatingHero')).toBeLessThan(
+            viewSource.indexOf('donation-after-rating__header')
+        );
+    });
+
     it('shows the donation prompt content from the post-rating modal', () => {
         expect(viewSource).toContain("$t('donaACarpoolear')");
         expect(viewSource).toContain("$t('proyectoDe')");

--- a/src/components/views/DonationAfterRating.view.test.js
+++ b/src/components/views/DonationAfterRating.view.test.js
@@ -7,51 +7,108 @@ const viewPath = path.resolve(__dirname, 'DonationAfterRating.vue');
 const viewSource = fs.readFileSync(viewPath, 'utf8');
 
 describe('DonationAfterRating page content', () => {
-    it('renders the hero outside the constrained page container', () => {
+    it('wraps all page content in an 80vw container on big desktop', () => {
+        expect(viewSource).toContain('donation-after-rating__page');
         expect(viewSource).toMatch(
-            /<DonationAfterRatingHero \/>[\s\S]*donation-after-rating__content container/
+            /<div class="donation-after-rating__page">[\s\S]*<DonationAfterRatingHero \/>/
         );
-        expect(viewSource).not.toMatch(
-            /class="donation-after-rating container"[\s\S]*<DonationAfterRatingHero/
+        expect(viewSource).toMatch(
+            /@media \(min-width: 992px\)[\s\S]*donation-after-rating__page[\s\S]*width:\s*80vw/
         );
     });
 
-    it('shows the hero section above the donation prompt content', () => {
-        expect(viewSource).toContain('DonationAfterRatingHero');
+    it('shows the community CTA between the hero and donation form', () => {
+        expect(viewSource).toContain('donation-after-rating__cta');
+        expect(viewSource).toContain("$t('donationAfterRatingJoinPrefix')");
+        expect(viewSource).toContain("$t('donationAfterRatingJoinAccent')");
+        expect(viewSource).toContain('text-transform: uppercase');
+        expect(viewSource).toContain(
+            "$t('donationAfterRatingMonthlyBenefitsIntro')"
+        );
+        expect(viewSource).toContain('donation-after-rating__benefits');
+        expect(viewSource).toContain('padding-inline-start: 2rem');
+        expect(viewSource).toContain('list-style-position: inside');
+        expect(viewSource).toContain('DONATION_AFTER_RATING_BENEFIT_KEYS');
         expect(viewSource.indexOf('DonationAfterRatingHero')).toBeLessThan(
-            viewSource.indexOf('donation-after-rating__header')
+            viewSource.indexOf('donation-after-rating__cta')
+        );
+        expect(viewSource.indexOf('donation-after-rating__cta')).toBeLessThan(
+            viewSource.indexOf('DonationAmountPicker')
         );
     });
 
-    it('shows the donation prompt content from the post-rating modal', () => {
-        expect(viewSource).toContain("$t('donaACarpoolear')");
-        expect(viewSource).toContain("$t('proyectoDe')");
-        expect(viewSource).toContain("$t('buenisimoCompartirViaje')");
-        expect(viewSource).toContain("$t('ayudanosPlataforma')");
-        expect(viewSource).toContain('DonationAmountPicker');
+    it('shows the redesigned monthly and one-time donation actions', () => {
+        expect(viewSource).toContain('donationAfterRatingMonthlyAmountIntro');
+        expect(viewSource).toContain(':body-text-tone="true"');
+        expect(viewSource).toContain('variant="header-donate"');
+        expect(viewSource).toContain('width: fit-content');
+        expect(viewSource).toContain('margin-top: 9rem');
+        expect(viewSource).toContain('radio-group-name="donationAfterRatingMonthly"');
+        expect(viewSource).toContain('radio-group-name="donationAfterRatingOnce"');
+        expect(viewSource).toContain(
+            "$t('donationAfterRatingJoinCommunityMonthly')"
+        );
+        expect(viewSource).toContain(
+            "$t('donationAfterRatingJoinCommunityMonthlyHint')"
+        );
+        expect(viewSource).toContain("$t('donationAfterRatingOnceIntro')");
+        expect(viewSource).toContain("$t('donationAfterRatingOnceCta')");
+        expect(viewSource).toContain('donation-after-rating__btn-once');
+        expect(viewSource).not.toContain("$t('MENSUAL')");
+        expect(viewSource).not.toContain("$t('unicaVez')");
+        expect(viewSource).not.toContain("$t('donationUsageNote')");
+        expect(viewSource).not.toContain("$t('conoceMasDonar')");
+        expect(viewSource).not.toContain("$t('continuarSinDonar')");
+        expect(viewSource).toContain('volunteerParagraphHtml');
+        expect(viewSource).toContain('instagramParagraphHtml');
+        expect(viewSource).toContain(
+            "$t('donationAfterRatingCannotContributeLink')"
+        );
+        expect(viewSource).toContain(
+            "$t('donationAfterRatingCannotContributeSuffix')"
+        );
         expect(viewSource).toContain('getDonationOnceUrl');
         expect(viewSource).toContain('getDonationMonthlyUrl');
-        expect(viewSource).not.toContain('value="2000"');
-        expect(viewSource).not.toContain('value="10000"');
-        expect(viewSource).toContain("$t('unicaVez')");
-        expect(viewSource).toContain("$t('MENSUAL')");
-        expect(viewSource).toContain("$t('cancelaCuando')");
-        expect(viewSource).toMatch(
-            /donation-actions[\s\S]*?variant="primary"[\s\S]*?onDonateMonthly[\s\S]*?variant="secondary"[\s\S]*?onDonateOnceTime/s
-        );
-        expect(viewSource).toContain("$t('conoceMasDonar')");
         expect(viewSource).toContain('onDonateOnceTime');
         expect(viewSource).toContain('onDonateMonthly');
-        expect(viewSource).toContain('openDonationLink');
+        expect(viewSource).toContain('onContinueWithoutDonating');
+        expect(viewSource).toContain('CARPOOLEAR_COLLABORATE_URL');
+        expect(viewSource).toContain('CARPOOLEAR_INSTAGRAM_URL');
     });
 
-    it('offers a skip button that returns to the trips list', () => {
-        expect(viewSource).toContain("$t('continuarSinDonar')");
+    it('offers a skip link that returns to the trips list', () => {
+        expect(viewSource).toContain('href="/trips"');
         expect(viewSource).toContain('onContinueWithoutDonating');
         expect(viewSource).toMatch(/name:\s*'trips'/);
     });
 
-    it.each(['arg', 'en'])('defines continuarSinDonar in %s locale', (locale) => {
-        expect(messages[locale].continuarSinDonar).toBeTruthy();
-    });
+    it.each(['arg', 'en'])(
+        'defines donation after rating copy in %s locale',
+        (locale) => {
+            expect(messages[locale].donationAfterRatingHeroTitlePrimary).toBeTruthy();
+            expect(messages[locale].donationAfterRatingMissionLead).toBeTruthy();
+            expect(messages[locale].donationAfterRatingMissionOrg).toBeTruthy();
+            expect(messages[locale].donationAfterRatingMissionBody).toBeTruthy();
+            expect(messages[locale].donationAfterRatingJoinAccent).toBeTruthy();
+            expect(
+                messages[locale].donationAfterRatingMonthlyBenefitsIntro
+            ).toBeTruthy();
+            expect(
+                messages[locale].donationAfterRatingMonthlyAmountIntro
+            ).toMatch(/<strong>.*<\/strong>/);
+            expect(
+                messages[locale].donationAfterRatingJoinCommunityMonthly
+            ).toBeTruthy();
+            expect(messages[locale].donationAfterRatingOnceCta).toBeTruthy();
+            expect(
+                messages[locale].donationAfterRatingVolunteerParagraph
+            ).toContain('{link}');
+            for (const key of [
+                'donationAfterRatingBenefitVisibility',
+                'donationAfterRatingBenefitBadge'
+            ]) {
+                expect(messages[locale][key]).toBeTruthy();
+            }
+        }
+    );
 });

--- a/src/components/views/DonationAfterRating.vue
+++ b/src/components/views/DonationAfterRating.vue
@@ -1,6 +1,7 @@
 <template>
     <div class="donation-after-rating container">
         <div class="col-xs-24">
+            <DonationAfterRatingHero />
             <h3 class="donation-after-rating__header">
                 <span>{{ $t('donaACarpoolear') }}</span>
                 <br class="hidden-sm hidden-md hidden-lg" />
@@ -69,6 +70,7 @@ import { useAuthStore } from '../../stores/auth';
 import { useProfileStore } from '../../stores/profile';
 import dialogs from '../../services/dialogs.js';
 import DonationAmountPicker from '../elements/DonationAmountPicker.vue';
+import DonationAfterRatingHero from '../sections/DonationAfterRatingHero.vue';
 import AppButton from '../ui/AppButton.vue';
 import {
     appendDonationTrackingUserId,
@@ -82,12 +84,17 @@ export default {
     name: 'donation-after-rating',
     components: {
         DonationAmountPicker,
+        DonationAfterRatingHero,
         AppButton
     },
     props: {
         tripId: {
             type: [String, Number],
             required: true
+        },
+        preview: {
+            type: Boolean,
+            default: false
         }
     },
     data() {
@@ -123,7 +130,17 @@ export default {
             }
             await this.openExternalBrowser(url);
         },
+        notifyPreviewMode() {
+            dialogs.message('Preview mode: donation actions are disabled.', {
+                duration: 4,
+                estado: 'info'
+            });
+        },
         async onDonateOnceTime() {
+            if (this.preview) {
+                this.notifyPreviewMode();
+                return;
+            }
             if (this.donateValue > 0) {
                 let url = getDonationOnceUrl(this.donateValue);
                 url = appendDonationTrackingUserId(url, this.user && this.user.id);
@@ -143,6 +160,10 @@ export default {
             }
         },
         async onDonateMonthly() {
+            if (this.preview) {
+                this.notifyPreviewMode();
+                return;
+            }
             if (this.donateValue > 0) {
                 let url = getDonationMonthlyUrl(this.donateValue);
                 url = appendDonationTrackingUserId(url, this.user && this.user.id);
@@ -162,6 +183,10 @@ export default {
             }
         },
         async onContinueWithoutDonating() {
+            if (this.preview) {
+                this.notifyPreviewMode();
+                return;
+            }
             await this.registerDonation({
                 has_donated: 0,
                 has_denied: 1,

--- a/src/components/views/DonationAfterRating.vue
+++ b/src/components/views/DonationAfterRating.vue
@@ -1,66 +1,92 @@
 <template>
     <div class="donation-after-rating">
-        <DonationAfterRatingHero />
+        <div class="donation-after-rating__page">
+            <DonationAfterRatingHero />
+            <section class="donation-after-rating__cta">
+            <h2 class="donation-after-rating__cta-title">
+                <span>{{ $t('donationAfterRatingJoinPrefix') }}</span>
+                <span class="donation-after-rating__cta-title-accent">
+                    {{ $t('donationAfterRatingJoinAccent') }}
+                </span>
+            </h2>
+            <p
+                class="donation-after-rating__cta-intro"
+                v-html="$t('donationAfterRatingMonthlyBenefitsIntro')"
+            ></p>
+            <ul class="donation-after-rating__benefits">
+                <li
+                    v-for="benefitKey in benefitKeys"
+                    :key="benefitKey"
+                    class="donation-after-rating__benefits-item"
+                    v-html="$t(benefitKey)"
+                ></li>
+            </ul>
+        </section>
         <div class="donation-after-rating__content container">
             <div class="col-xs-24">
-            <h3 class="donation-after-rating__header">
-                <span>{{ $t('donaACarpoolear') }}</span>
-                <br class="hidden-sm hidden-md hidden-lg" />
-                <small>{{ $t('proyectoDe') }}</small>
-                <img
-                    width="90"
-                    alt="STS Rosario"
-                    :src="$publicImg('logo_sts_nuevo_color.png')"
-                />
-            </h3>
-            <div class="donation">
-                <div class="text-center donation-text">
-                    <p>
-                        {{ $t('buenisimoCompartirViaje') }}
-                    </p>
-                    {{ $t('ayudanosPlataforma') }}
-                </div>
-                <DonationAmountPicker v-model="donateValue" />
-                <div class="donation-actions">
+                <div class="donation donation-after-rating__donation">
+                    <DonationAmountPicker
+                        v-model="donateValue"
+                        usage-note-key="donationAfterRatingMonthlyAmountIntro"
+                        :usage-note-html="true"
+                        :body-text-tone="true"
+                        radio-group-name="donationAfterRatingMonthly"
+                    />
                     <AppButton
-                        class="donation-actions__btn"
-                        variant="primary"
+                        class="donation-after-rating__btn-monthly"
+                        variant="header-donate"
                         @click="onDonateMonthly"
                     >
-                        <span class="donation-actions__label">
-                            {{ $t('MENSUAL') }}
+                        <span class="donation-after-rating__btn-label">
+                            {{ $t('donationAfterRatingJoinCommunityMonthly') }}
                         </span>
-                        <span class="donation-actions__hint">
-                            ({{ $t('cancelaCuando') }})
+                        <span class="donation-after-rating__btn-hint">
+                            ({{ $t('donationAfterRatingJoinCommunityMonthlyHint') }})
                         </span>
                     </AppButton>
-                    <AppButton
-                        class="donation-actions__btn"
-                        variant="secondary"
-                        @click="onDonateOnceTime"
-                    >
-                        {{ $t('unicaVez') }}
-                    </AppButton>
-                </div>
-                <div class="text-center">
-                    <br />
-                    <a
-                        href="/aportar"
-                        target="_blank"
-                        v-on:click.prevent="openDonationLink()"
-                    >
-                        {{ $t('conoceMasDonar') }}
-                    </a>
-                </div>
-                <div class="text-center donation-after-rating__skip">
-                    <button
-                        class="btn btn-default"
-                        @click="onContinueWithoutDonating"
-                    >
-                        {{ $t('continuarSinDonar') }}
-                    </button>
+
+                    <section class="donation-after-rating__once">
+                        <p
+                            class="donation-after-rating__once-intro"
+                            v-html="$t('donationAfterRatingOnceIntro')"
+                        ></p>
+                        <DonationAmountPicker
+                            v-model="donateValue"
+                            :show-usage-note="false"
+                            :body-text-tone="true"
+                            radio-group-name="donationAfterRatingOnce"
+                        />
+                        <AppButton
+                            class="donation-after-rating__btn-once"
+                            variant="secondary"
+                            @click="onDonateOnceTime"
+                        >
+                            {{ $t('donationAfterRatingOnceCta') }}
+                        </AppButton>
+                    </section>
+
+                    <section class="donation-after-rating__alternatives">
+                        <p
+                            class="donation-after-rating__alt-copy"
+                            v-html="volunteerParagraphHtml"
+                        ></p>
+                        <p
+                            class="donation-after-rating__alt-copy"
+                            v-html="instagramParagraphHtml"
+                        ></p>
+                        <p class="donation-after-rating__alt-copy">
+                            <a
+                                href="/trips"
+                                class="donation-after-rating__skip-link"
+                                @click.prevent="onContinueWithoutDonating"
+                            >
+                                {{ $t('donationAfterRatingCannotContributeLink') }}
+                            </a>{{ $t('donationAfterRatingCannotContributeSuffix') }}
+                        </p>
+                    </section>
                 </div>
             </div>
+        </div>
         </div>
     </div>
 </template>
@@ -78,6 +104,11 @@ import {
     getDonationMonthlyUrl,
     getDonationOnceUrl
 } from '../../utils/donationOptions.js';
+import { DONATION_AFTER_RATING_BENEFIT_KEYS } from '../../utils/donationAfterRatingBenefits.js';
+import {
+    CARPOOLEAR_COLLABORATE_URL,
+    CARPOOLEAR_INSTAGRAM_URL
+} from '../../utils/carpoolearSocialUrls.js';
 import { App } from '@capacitor/app';
 import { Capacitor } from '@capacitor/core';
 
@@ -100,13 +131,22 @@ export default {
     },
     data() {
         return {
-            donateValue: 0
+            donateValue: 0,
+            benefitKeys: DONATION_AFTER_RATING_BENEFIT_KEYS
         };
     },
     computed: {
         ...mapState(useAuthStore, {
             user: 'user'
-        })
+        }),
+        volunteerParagraphHtml() {
+            const link = `<a href="${CARPOOLEAR_COLLABORATE_URL}" target="_blank" rel="noopener noreferrer">${this.$t('donationAfterRatingVolunteerLink')}</a>`;
+            return this.$t('donationAfterRatingVolunteerParagraph', { link });
+        },
+        instagramParagraphHtml() {
+            const link = `<a href="${CARPOOLEAR_INSTAGRAM_URL}" target="_blank" rel="noopener noreferrer">${this.$t('donationAfterRatingInstagramLink')}</a>`;
+            return this.$t('donationAfterRatingInstagramParagraph', { link });
+        }
     },
     methods: {
         ...mapActions(useProfileStore, {
@@ -123,13 +163,6 @@ export default {
             } else {
                 window.open(url, '_blank');
             }
-        },
-        async openDonationLink() {
-            let url = 'https://carpoolear.com.ar/aportar';
-            if (this.user && this.user.id) {
-                url = `${url}?u=${this.user.id}`;
-            }
-            await this.openExternalBrowser(url);
         },
         notifyPreviewMode() {
             dialogs.message('Preview mode: donation actions are disabled.', {
@@ -201,77 +234,209 @@ export default {
 </script>
 
 <style scoped>
-.donation-after-rating__header {
+.donation-after-rating__page {
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+}
+
+.donation-after-rating__cta {
+    width: 100%;
+    max-width: 100vw;
+    box-sizing: border-box;
+    padding: 0 1rem 2rem;
     text-align: center;
-    margin-bottom: 1.5rem;
 }
 
-.donation-text {
-    margin-bottom: 1.5rem;
+.donation-after-rating__cta-title {
+    margin: 0 0 1rem;
+    font-family: 'Dela Gothic One', var(--ds-font-family);
+    font-size: clamp(1.75rem, 8vw, 3rem);
+    font-weight: 400;
+    line-height: 1.05;
+    letter-spacing: -0.02em;
+    color: var(--ds-text-secondary);
+    text-transform: uppercase;
 }
 
-.donation-text p {
-    margin-top: 0;
-    font-size: 1.1rem;
-    margin-bottom: 0.5rem;
+.donation-after-rating__cta-title-accent {
+    display: block;
+    color: var(--ds-header-donate-bg);
 }
 
-.donation-actions {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
+.donation-after-rating__cta-intro {
+    margin: 0 auto;
+    color: var(--ds-text-primary);
+    font-size: 1.2rem;
+    line-height: 1.45;
+}
+
+.donation-after-rating__cta-intro :deep(strong) {
+    font-weight: var(--ds-font-weight-bold, 700);
+}
+
+.donation-after-rating__benefits {
+    margin: 1.25rem auto 0;
+    padding: 0;
+    padding-inline-start: 2rem;
+    max-width: 42rem;
+    list-style: disc;
+    list-style-position: outside;
+    text-align: left;
+}
+
+.donation-after-rating__benefits-item {
+    margin: 0 0 0.75rem;
+    padding-left: 0.5rem;
+    color: var(--ds-text-primary);
+    font-size: 1.05rem;
+    line-height: 1.45;
+}
+
+.donation-after-rating__benefits-item:last-child {
+    margin-bottom: 0;
+}
+
+.donation-after-rating__benefits-item :deep(strong) {
+    font-weight: var(--ds-font-weight-bold, 700);
+}
+
+@media (max-width: 767px) {
+    .donation-after-rating__benefits {
+        margin-left: 0;
+        margin-right: 0;
+        padding-inline-start: 1.75rem;
+        padding-inline-end: 0.25rem;
+        list-style-position: inside;
+    }
+
+    .donation-after-rating__benefits-item {
+        padding-left: 0;
+    }
+}
+
+.donation-after-rating__donation {
+    max-width: 42rem;
+    margin: 0 auto;
+    padding: 0 1rem 2rem;
+    text-align: center;
+}
+
+.donation-after-rating__btn-monthly,
+.donation-after-rating__btn-once {
+    width: fit-content;
+    max-width: 100%;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.donation-after-rating__btn-monthly {
     margin-top: 1rem;
 }
 
-.donation-actions__btn {
-    width: 100%;
-    min-height: 4.5rem;
-    flex-direction: column;
-    gap: 0.25rem;
-    white-space: normal;
-    text-align: center;
-}
-
-.donation-actions__btn.app-button--secondary {
-    min-height: 0;
-    padding-top: 0.75rem;
-    padding-bottom: 0.75rem;
-}
-
-.donation-actions__btn :deep(.app-button__label) {
+.donation-after-rating__btn-monthly :deep(.app-button__label) {
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 0.15rem;
     line-height: 1.25;
+    white-space: normal;
 }
 
-.donation-actions__label {
+.donation-after-rating__btn-label {
     display: block;
 }
 
-.donation-actions__hint {
+.donation-after-rating__btn-hint {
     display: block;
     font-size: 0.85em;
     font-weight: var(--ds-font-weight-normal, 400);
     line-height: 1.2;
 }
 
+.donation-after-rating__once {
+    margin-top: 9rem;
+    text-align: center;
+}
+
+.donation-after-rating__once-intro {
+    margin: 0 0 1rem;
+    color: var(--ds-text-primary);
+    font-size: 1.05rem;
+    line-height: 1.45;
+}
+
+.donation-after-rating__once :deep(.donation-amount-picker) {
+    margin-bottom: 1rem;
+}
+
+.donation-after-rating__btn-once {
+    margin-top: 0;
+}
+
+.donation-after-rating__btn-once.app-button--secondary {
+    background: transparent;
+    border: 2px solid var(--ds-header-donate-bg);
+    color: var(--ds-text-primary);
+}
+
+.donation-after-rating__btn-once.app-button--secondary:hover:not(:disabled):not([aria-disabled='true']) {
+    background: rgba(92, 184, 92, 0.08);
+    border-color: var(--ds-header-donate-border);
+    color: var(--ds-text-primary);
+}
+
+.donation-after-rating__alternatives {
+    display: flex;
+    flex-direction: column;
+    gap: 2.5rem;
+    margin-top: 9rem;
+    margin-bottom: calc(52px + constant(safe-area-inset-bottom, 0px));
+    margin-bottom: calc(52px + env(safe-area-inset-bottom, 0px));
+    text-align: left;
+}
+
+.donation-after-rating__alt-copy {
+    margin: 0;
+    color: var(--ds-text-primary);
+    font-size: 1.05rem;
+    line-height: 1.45;
+}
+
+.donation-after-rating__alt-copy:last-child {
+    margin-bottom: 0;
+}
+
+.donation-after-rating__alt-copy :deep(a) {
+    color: var(--ds-text-primary);
+    font-weight: var(--ds-font-weight-bold, 700);
+    text-decoration: underline;
+}
+
+.donation-after-rating__skip-link {
+    color: var(--ds-text-primary);
+    font-weight: var(--ds-font-weight-normal, 400);
+    text-decoration: underline;
+}
+
 @media (min-width: 768px) {
-    .donation-actions {
-        flex-direction: row;
+    .donation-after-rating__cta {
+        padding-left: 2.5rem;
+        padding-right: 2.5rem;
     }
 
-    .donation-actions__btn {
-        flex: 1 1 0;
-        width: auto;
+    .donation-after-rating__donation {
+        padding-left: 0;
+        padding-right: 0;
     }
 }
 
-/* Clear fixed .actionbar-bottom (52px + safe area) on mobile */
-.donation-after-rating__skip {
-    margin-top: 1.5rem;
-    margin-bottom: calc(52px + constant(safe-area-inset-bottom, 0px));
-    margin-bottom: calc(52px + env(safe-area-inset-bottom, 0px));
+@media (min-width: 992px) {
+    .donation-after-rating__page {
+        width: 80vw;
+        max-width: 80vw;
+        margin-left: auto;
+        margin-right: auto;
+    }
 }
 </style>

--- a/src/components/views/DonationAfterRating.vue
+++ b/src/components/views/DonationAfterRating.vue
@@ -99,11 +99,7 @@ import dialogs from '../../services/dialogs.js';
 import DonationAmountPicker from '../elements/DonationAmountPicker.vue';
 import DonationAfterRatingHero from '../sections/DonationAfterRatingHero.vue';
 import AppButton from '../ui/AppButton.vue';
-import {
-    appendDonationTrackingUserId,
-    getDonationMonthlyUrl,
-    getDonationOnceUrl
-} from '../../utils/donationOptions.js';
+import { startDonationCheckout } from '../../utils/donationCheckout.js';
 import { DONATION_AFTER_RATING_BENEFIT_KEYS } from '../../utils/donationAfterRatingBenefits.js';
 import {
     CARPOOLEAR_COLLABORATE_URL,
@@ -137,7 +133,8 @@ export default {
     },
     computed: {
         ...mapState(useAuthStore, {
-            user: 'user'
+            user: 'user',
+            appConfig: 'appConfig'
         }),
         volunteerParagraphHtml() {
             const link = `<a href="${CARPOOLEAR_COLLABORATE_URL}" target="_blank" rel="noopener noreferrer">${this.$t('donationAfterRatingVolunteerLink')}</a>`;
@@ -176,15 +173,24 @@ export default {
                 return;
             }
             if (this.donateValue > 0) {
-                let url = getDonationOnceUrl(this.donateValue);
-                url = appendDonationTrackingUserId(url, this.user && this.user.id);
-                await this.openExternalBrowser(url);
-                await this.registerDonation({
-                    has_donated: 1,
-                    has_denied: 0,
-                    ammount: parseFloat(this.donateValue),
-                    trip_id: this.tripId
-                });
+                try {
+                    const url = await startDonationCheckout({
+                        type: 'once',
+                        amount: this.donateValue,
+                        source: 'after_rating',
+                        tripId: this.tripId,
+                        userId: this.user && this.user.id,
+                        appConfig: this.appConfig
+                    });
+                    await this.openExternalBrowser(url);
+                } catch (error) {
+                    console.error('Donation checkout failed:', error);
+                    dialogs.message(this.$t('tienesQueSeleccionarDonacion'), {
+                        duration: 10,
+                        estado: 'error'
+                    });
+                    return;
+                }
                 this.$router.push({ name: 'trips' });
             } else {
                 dialogs.message(this.$t('tienesQueSeleccionarDonacion'), {
@@ -199,15 +205,24 @@ export default {
                 return;
             }
             if (this.donateValue > 0) {
-                let url = getDonationMonthlyUrl(this.donateValue);
-                url = appendDonationTrackingUserId(url, this.user && this.user.id);
-                await this.openExternalBrowser(url);
-                await this.registerDonation({
-                    has_donated: 1,
-                    has_denied: 0,
-                    ammount: parseFloat(this.donateValue),
-                    trip_id: this.tripId
-                });
+                try {
+                    const url = await startDonationCheckout({
+                        type: 'monthly',
+                        amount: this.donateValue,
+                        source: 'after_rating',
+                        tripId: this.tripId,
+                        userId: this.user && this.user.id,
+                        appConfig: this.appConfig
+                    });
+                    await this.openExternalBrowser(url);
+                } catch (error) {
+                    console.error('Donation checkout failed:', error);
+                    dialogs.message(this.$t('tienesQueSeleccionarDonacion'), {
+                        duration: 10,
+                        estado: 'error'
+                    });
+                    return;
+                }
                 this.$router.push({ name: 'trips' });
             } else {
                 dialogs.message(this.$t('tienesQueSeleccionarDonacion'), {

--- a/src/components/views/DonationAfterRating.vue
+++ b/src/components/views/DonationAfterRating.vue
@@ -1,7 +1,8 @@
 <template>
-    <div class="donation-after-rating container">
-        <div class="col-xs-24">
-            <DonationAfterRatingHero />
+    <div class="donation-after-rating">
+        <DonationAfterRatingHero />
+        <div class="donation-after-rating__content container">
+            <div class="col-xs-24">
             <h3 class="donation-after-rating__header">
                 <span>{{ $t('donaACarpoolear') }}</span>
                 <br class="hidden-sm hidden-md hidden-lg" />

--- a/src/components/views/Trips.vue
+++ b/src/components/views/Trips.vue
@@ -559,11 +559,7 @@ import dialogs from '../../services/dialogs.js';
 import push from '../../cordova/push-capacitor.js';
 import modal from '../Modal';
 import DonationAmountPicker from '../elements/DonationAmountPicker.vue';
-import {
-    appendDonationTrackingUserId,
-    getDonationMonthlyUrl,
-    getDonationOnceUrl
-} from '../../utils/donationOptions.js';
+import { startDonationCheckout } from '../../utils/donationCheckout.js';
 import { App } from '@capacitor/app';
 import { Capacitor } from '@capacitor/core';
 import {
@@ -994,20 +990,24 @@ export default {
         },
         async onDonateOnceTime() {
             if (this.donateValue > 0) {
-                let url = getDonationOnceUrl(this.donateValue);
-                url = appendDonationTrackingUserId(
-                    url,
-                    this.user && this.user.id
-                );
-                // Open in external browser (required for iOS donations)
-                await this.openExternalBrowser(url);
+                try {
+                    const url = await startDonationCheckout({
+                        type: 'once',
+                        amount: this.donateValue,
+                        source: 'trips',
+                        userId: this.user && this.user.id,
+                        appConfig: this.appConfig
+                    });
+                    await this.openExternalBrowser(url);
+                } catch (error) {
+                    console.error('Donation checkout failed:', error);
+                    dialogs.message(this.$t('valorDonacion'), {
+                        duration: 10,
+                        estado: 'error'
+                    });
+                    return;
+                }
                 this.showModal = false;
-                let data = {
-                    has_donated: 1,
-                    has_denied: 0,
-                    ammount: parseFloat(this.donateValue)
-                };
-                this.registerDonation(data);
             } else {
                 dialogs.message(this.$t('valorDonacion'), {
                     duration: 10,
@@ -1017,20 +1017,24 @@ export default {
         },
         async onDonateMonthly() {
             if (this.donateValue >= 0) {
-                let url = getDonationMonthlyUrl(this.donateValue);
-                url = appendDonationTrackingUserId(
-                    url,
-                    this.user && this.user.id
-                );
-                // Open in external browser (required for iOS donations)
-                await this.openExternalBrowser(url);
+                try {
+                    const url = await startDonationCheckout({
+                        type: 'monthly',
+                        amount: this.donateValue,
+                        source: 'trips',
+                        userId: this.user && this.user.id,
+                        appConfig: this.appConfig
+                    });
+                    await this.openExternalBrowser(url);
+                } catch (error) {
+                    console.error('Donation checkout failed:', error);
+                    dialogs.message(this.$t('valorDonacion'), {
+                        duration: 10,
+                        estado: 'error'
+                    });
+                    return;
+                }
                 this.showModal = false;
-                let data = {
-                    has_donated: 1,
-                    has_denied: 0,
-                    ammount: parseFloat(this.donateValue)
-                };
-                this.registerDonation(data);
             } else {
                 dialogs.message(this.$t('valorDonacion'), {
                     duration: 10,

--- a/src/indexHtmlFonts.test.js
+++ b/src/indexHtmlFonts.test.js
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const indexPath = path.resolve(__dirname, '../index.html');
+const indexSource = fs.readFileSync(indexPath, 'utf8');
+
+describe('index.html fonts', () => {
+    it('loads Dela Gothic One for the donation hero title', () => {
+        expect(indexSource).toContain('family=Dela+Gothic+One');
+    });
+});

--- a/src/language/donationCopy.test.js
+++ b/src/language/donationCopy.test.js
@@ -19,6 +19,11 @@ describe('donation copy wording', () => {
         expect(messages.arg.tienesQueSeleccionarDonacion).toBe(
             'Tienes que seleccionar un valor de aporte'
         );
+        expect(messages.arg.donationAfterRatingHeroTitlePrimary).toBe('Necesitamos');
+        expect(messages.arg.donationAfterRatingHeroTitleAccent).toBe('Tu aporte');
+        expect(messages.arg.donationAfterRatingJoinAccent).toBe(
+            'Comunidad Carpoolear'
+        );
     });
 
     it('uses aportar/aporte wording in chl', () => {
@@ -59,8 +64,7 @@ describe('donation copy wording', () => {
 describe('aportar page links', () => {
     it.each([
         'sections/HeaderApp.vue',
-        'views/Trips.vue',
-        'views/DonationAfterRating.vue'
+        'views/Trips.vue'
     ])('points %s at /aportar instead of /donar', (relativePath) => {
         const source = fs.readFileSync(
             path.resolve(__dirname, `../components/${relativePath}`),

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -1208,6 +1208,45 @@ const messages = {
         elegiPropiaAventura: 'Elegí tu propia aventura',
         conoceMasDonar: 'Conocé más sobre aportes',
         continuarSinDonar: 'Continuar sin aportar',
+        donationAfterRatingHeroTitlePrimary: 'Necesitamos',
+        donationAfterRatingHeroTitleAccent: 'Tu aporte',
+        donationAfterRatingMissionLead:
+            ' Queremos ser la mejor comunidad de carpooling de Argentina.',
+        donationAfterRatingMissionOrg:
+            'Somos un proyecto de la <strong>ONG STS Rosario</strong>.',
+        donationAfterRatingMissionBody:
+            'Con más de <strong>500.000 usuarios</strong> tenemos gastos de <strong>servidores</strong>, gastos de <strong>programación</strong> y muchas horas semanales de consultas de <strong>Mesa de ayuda</strong> que <strong>queremos poder pagarlas</strong> (hoy es trabajo voluntario)',
+        donationAfterRatingJoinPrefix: 'Sumate a la',
+        donationAfterRatingJoinAccent: 'Comunidad Carpoolear',
+        donationAfterRatingMonthlyBenefitsIntro:
+            'Con tu <strong>aporte mensual</strong> podemos mejorar la plataforma para todos, y obtenés beneficios:',
+        donationAfterRatingBenefitVisibility:
+            '<strong>Mayor visibilidad:</strong> tus viajes se van a mostrar primero en el listado, ayudándote a compartirlos más fácilmente.',
+        donationAfterRatingBenefitPrioritySupport:
+            '<strong>Soporte prioritario:</strong> tus tickets de Mesa de Ayuda tendrán prioridad sobre el resto.',
+        donationAfterRatingBenefitEarlyAccess:
+            '<strong>Acceso anticipado:</strong> vas a poder probar algunas funcionalidades nuevas antes que el resto.',
+        donationAfterRatingBenefitSemiannualReport:
+            '<strong>Informe semestral:</strong> cada 6 meses te vamos a mandar un mail contándote todas las cosas que pudimos hacer gracias a tu aporte.',
+        donationAfterRatingBenefitBadge:
+            '<strong>Chapa:</strong> tu perfil tendrá una insignia mostrando cómo ayudas a mantener a Carpoolear vivo, y vas a aparecer en una lista de personas que forman parte de la Comunidad Carpoolear (si así lo querés).',
+        donationAfterRatingMonthlyAmountIntro:
+            'Puedo <strong>aportar cada mes</strong> con el equivalente a...',
+        donationAfterRatingJoinCommunityMonthly:
+            'Quiero formar parte de la Comunidad Carpoolear',
+        donationAfterRatingJoinCommunityMonthlyHint: 'cancelá cuando quieras',
+        donationAfterRatingOnceIntro:
+            '¿No podés comprometerte a aportar un poquito cada mes? Podés hacerlo por única vez:',
+        donationAfterRatingOnceCta: 'Quiero aportar por única vez',
+        donationAfterRatingVolunteerParagraph:
+            '¿No estás en condiciones de aportar económicamente? Podés aportar tu tiempo {link}, siempre necesitamos una mano.',
+        donationAfterRatingVolunteerLink: 'sumándote como voluntario',
+        donationAfterRatingInstagramParagraph:
+            '¿No tenés mucho tiempo? Podés seguirnos en {link} y ayudarnos a difundir la comunidad contándole a la gente que conozcas sobre Carpoolear.',
+        donationAfterRatingInstagramLink: 'Instagram',
+        donationAfterRatingCannotContributeLink: 'No puedo aportar',
+        donationAfterRatingCannotContributeSuffix:
+            ' ni siquiera difusión ahora :(',
         calificacionesPendientes: 'Calificaciones pendientes',
         noHayCalificacionesPendientes: 'No hay calificaciones pendientes',
         cargandoCalificaciones: 'Cargando calificaciones',
@@ -2330,6 +2369,45 @@ const messages = {
         elegiPropiaAventura: 'Elegí tu propia aventura',
         conoceMasDonar: 'Conocé más sobre aportes',
         continuarSinDonar: 'Continuar sin aportar',
+        donationAfterRatingHeroTitlePrimary: 'Necesitamos',
+        donationAfterRatingHeroTitleAccent: 'Tu aporte',
+        donationAfterRatingMissionLead:
+            ' Queremos ser la mejor comunidad de carpooling de Argentina.',
+        donationAfterRatingMissionOrg:
+            'Somos un proyecto de la <strong>ONG STS Rosario</strong>.',
+        donationAfterRatingMissionBody:
+            'Con más de <strong>500.000 usuarios</strong> tenemos gastos de <strong>servidores</strong>, gastos de <strong>programación</strong> y muchas horas semanales de consultas de <strong>Mesa de ayuda</strong> que <strong>queremos poder pagarlas</strong> (hoy es trabajo voluntario)',
+        donationAfterRatingJoinPrefix: 'Sumate a la',
+        donationAfterRatingJoinAccent: 'Comunidad Carpoolear',
+        donationAfterRatingMonthlyBenefitsIntro:
+            'Con tu <strong>aporte mensual</strong> podemos mejorar la plataforma para todos, y obtenés beneficios:',
+        donationAfterRatingBenefitVisibility:
+            '<strong>Mayor visibilidad:</strong> tus viajes se van a mostrar primero en el listado, ayudándote a compartirlos más fácilmente.',
+        donationAfterRatingBenefitPrioritySupport:
+            '<strong>Soporte prioritario:</strong> tus tickets de Mesa de Ayuda tendrán prioridad sobre el resto.',
+        donationAfterRatingBenefitEarlyAccess:
+            '<strong>Acceso anticipado:</strong> vas a poder probar algunas funcionalidades nuevas antes que el resto.',
+        donationAfterRatingBenefitSemiannualReport:
+            '<strong>Informe semestral:</strong> cada 6 meses te vamos a mandar un mail contándote todas las cosas que pudimos hacer gracias a tu aporte.',
+        donationAfterRatingBenefitBadge:
+            '<strong>Chapa:</strong> tu perfil tendrá una insignia mostrando cómo ayudas a mantener a Carpoolear vivo, y vas a aparecer en una lista de personas que forman parte de la Comunidad Carpoolear (si así lo querés).',
+        donationAfterRatingMonthlyAmountIntro:
+            'Puedo <strong>aportar cada mes</strong> con el equivalente a...',
+        donationAfterRatingJoinCommunityMonthly:
+            'Quiero formar parte de la Comunidad Carpoolear',
+        donationAfterRatingJoinCommunityMonthlyHint: 'cancelá cuando quieras',
+        donationAfterRatingOnceIntro:
+            '¿No podés comprometerte a aportar un poquito cada mes? Podés hacerlo por única vez:',
+        donationAfterRatingOnceCta: 'Quiero aportar por única vez',
+        donationAfterRatingVolunteerParagraph:
+            '¿No estás en condiciones de aportar económicamente? Podés aportar tu tiempo {link}, siempre necesitamos una mano.',
+        donationAfterRatingVolunteerLink: 'sumándote como voluntario',
+        donationAfterRatingInstagramParagraph:
+            '¿No tenés mucho tiempo? Podés seguirnos en {link} y ayudarnos a difundir la comunidad contándole a la gente que conozcas sobre Carpoolear.',
+        donationAfterRatingInstagramLink: 'Instagram',
+        donationAfterRatingCannotContributeLink: 'No puedo aportar',
+        donationAfterRatingCannotContributeSuffix:
+            ' ni siquiera difusión ahora :(',
         calificacionesPendientes: 'Calificaciones pendientes',
         noHayCalificacionesPendientes: 'No hay calificaciones pendientes',
         cargandoCalificaciones: 'Cargando calificaciones',
@@ -4681,6 +4759,45 @@ const messages = {
         elegiPropiaAventura: 'Choose your own adventure',
         conoceMasDonar: 'Learn more about contributions',
         continuarSinDonar: 'Continue without contributing',
+        donationAfterRatingHeroTitlePrimary: 'We need',
+        donationAfterRatingHeroTitleAccent: 'Your contribution',
+        donationAfterRatingMissionLead:
+            ' We want to be Argentina\'s best carpooling community.',
+        donationAfterRatingMissionOrg:
+            'We are a project of the <strong>NGO STS Rosario</strong>.',
+        donationAfterRatingMissionBody:
+            'With more than <strong>500,000 users</strong> we have <strong>server</strong> costs, <strong>development</strong> costs, and many weekly hours of <strong>help desk</strong> inquiries that we <strong>want to be able to pay for</strong> (today it is volunteer work).',
+        donationAfterRatingJoinPrefix: 'Join the',
+        donationAfterRatingJoinAccent: 'Carpoolear Community',
+        donationAfterRatingMonthlyBenefitsIntro:
+            'With your <strong>monthly contribution</strong> we can improve the platform for everyone, and you get benefits:',
+        donationAfterRatingBenefitVisibility:
+            '<strong>Greater visibility:</strong> your trips will be shown first in the listing, helping you share them more easily.',
+        donationAfterRatingBenefitPrioritySupport:
+            '<strong>Priority support:</strong> your Help Desk tickets will take priority over others.',
+        donationAfterRatingBenefitEarlyAccess:
+            '<strong>Early access:</strong> you\'ll be able to try some new features before everyone else.',
+        donationAfterRatingBenefitSemiannualReport:
+            '<strong>Semiannual report:</strong> every 6 months we\'ll send you an email about everything we were able to do thanks to your contribution.',
+        donationAfterRatingBenefitBadge:
+            '<strong>Badge:</strong> your profile will have a badge showing how you help keep Carpoolear alive, and you\'ll appear on a list of people who are part of the Carpoolear Community (if you want).',
+        donationAfterRatingMonthlyAmountIntro:
+            'I can <strong>contribute each month</strong> with the equivalent of...',
+        donationAfterRatingJoinCommunityMonthly:
+            'I want to be part of the Carpoolear Community',
+        donationAfterRatingJoinCommunityMonthlyHint: 'cancel anytime',
+        donationAfterRatingOnceIntro:
+            'Can\'t commit to contributing a little each month? You can do it once:',
+        donationAfterRatingOnceCta: 'I want to contribute once',
+        donationAfterRatingVolunteerParagraph:
+            'Not in a position to contribute financially? You can contribute your time by {link}; we always need a hand.',
+        donationAfterRatingVolunteerLink: 'joining as a volunteer',
+        donationAfterRatingInstagramParagraph:
+            'Don\'t have much time? Follow us on {link} and help spread the word about Carpoolear to people you know.',
+        donationAfterRatingInstagramLink: 'Instagram',
+        donationAfterRatingCannotContributeLink: 'I can\'t contribute',
+        donationAfterRatingCannotContributeSuffix:
+            ' or even help spread the word right now :(',
         calificacionesPendientes: 'Pending ratings',
         noHayCalificacionesPendientes: 'No pending ratings',
         cargandoCalificaciones: 'Loading ratings',

--- a/src/router/routes.donationAfterRating.test.js
+++ b/src/router/routes.donationAfterRating.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
+import { DONATION_AFTER_RATING_HEADER_ROUTE_NAMES } from '../utils/donationAfterRatingHeader.js';
 
 const routesPath = path.resolve(__dirname, 'routes.js');
 const routesSource = fs.readFileSync(routesPath, 'utf8');
@@ -8,7 +9,22 @@ const routesSource = fs.readFileSync(routesPath, 'utf8');
 describe('donation after positive rating route', () => {
     it('registers a full-page donation prompt after rating', () => {
         expect(routesSource).toContain("path: '/donate-after-rating/:tripId'");
-        expect(routesSource).toContain("name: 'donate-after-rating'");
+        expect(routesSource).toContain(
+            `name: '${DONATION_AFTER_RATING_HEADER_ROUTE_NAMES[0]}'`
+        );
         expect(routesSource).toContain('DonationAfterRating');
+    });
+
+    it('registers a dev-only preview route without auth guards', () => {
+        expect(routesSource).toContain(
+            "path: '/preview/donation-after-rating/:tripId?'"
+        );
+        expect(routesSource).toContain(
+            `name: '${DONATION_AFTER_RATING_HEADER_ROUTE_NAMES[1]}'`
+        );
+        expect(routesSource).toContain('preview: true');
+        expect(routesSource).not.toMatch(
+            /preview-donation-after-rating[\s\S]*?beforeEnter/
+        );
     });
 });

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -241,7 +241,6 @@ export default [
                     active_id: 'home'
                 },
                 header: {
-                    titleKey: 'donaACarpoolear',
                     buttons: []
                 }
             }
@@ -1393,6 +1392,30 @@ export default [
             }
         }
     },
+    ...(import.meta.env.DEV
+        ? [
+              {
+                  path: '/preview/donation-after-rating/:tripId?',
+                  name: 'preview-donation-after-rating',
+                  component: DonationAfterRating,
+                  props: (route) => ({
+                      tripId: route.params.tripId || '0',
+                      preview: true
+                  }),
+                  meta: {
+                      actionbar: {
+                          footer: {
+                              show: true,
+                              active_id: 'home'
+                          },
+                          header: {
+                              buttons: []
+                          }
+                      }
+                  }
+              }
+          ]
+        : []),
     {
         path: '/:pathMatch(.*)*',
         redirect: '/trips'

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -1394,27 +1394,27 @@ export default [
     },
     ...(import.meta.env.DEV
         ? [
-              {
-                  path: '/preview/donation-after-rating/:tripId?',
-                  name: 'preview-donation-after-rating',
-                  component: DonationAfterRating,
-                  props: (route) => ({
-                      tripId: route.params.tripId || '0',
-                      preview: true
-                  }),
-                  meta: {
-                      actionbar: {
-                          footer: {
-                              show: true,
-                              active_id: 'home'
-                          },
-                          header: {
-                              buttons: []
-                          }
-                      }
-                  }
-              }
-          ]
+            {
+                path: '/preview/donation-after-rating/:tripId?',
+                name: 'preview-donation-after-rating',
+                component: DonationAfterRating,
+                props: (route) => ({
+                    tripId: route.params.tripId || '0',
+                    preview: true
+                }),
+                meta: {
+                    actionbar: {
+                        footer: {
+                            show: true,
+                            active_id: 'home'
+                        },
+                        header: {
+                            buttons: []
+                        }
+                    }
+                }
+            }
+        ]
         : []),
     {
         path: '/:pathMatch(.*)*',

--- a/src/services/api/Donation.js
+++ b/src/services/api/Donation.js
@@ -1,0 +1,17 @@
+import TaggedApi from '../../classes/TaggedApi';
+
+class DonationApi extends TaggedApi {
+    getTiers() {
+        return this.get('/api/donation-tiers', {});
+    }
+
+    checkoutOnce(data) {
+        return this.post('/api/donations/checkout/once', data);
+    }
+
+    checkoutMonthly(data) {
+        return this.post('/api/donations/checkout/monthly', data);
+    }
+}
+
+export default new DonationApi();

--- a/src/utils/carpoolearSocialUrls.js
+++ b/src/utils/carpoolearSocialUrls.js
@@ -1,3 +1,5 @@
 export const CARPOOLEAR_FACEBOOK_URL = 'https://www.facebook.com/Carpoolear';
 export const CARPOOLEAR_INSTAGRAM_URL =
     'https://www.instagram.com/carpoolear/?hl=en';
+export const CARPOOLEAR_COLLABORATE_URL =
+    'https://carpoolear.com.ar/colabora-como-colaborar';

--- a/src/utils/donationAfterRatingBenefits.js
+++ b/src/utils/donationAfterRatingBenefits.js
@@ -1,0 +1,7 @@
+export const DONATION_AFTER_RATING_BENEFIT_KEYS = [
+    'donationAfterRatingBenefitVisibility',
+    'donationAfterRatingBenefitPrioritySupport',
+    'donationAfterRatingBenefitEarlyAccess',
+    'donationAfterRatingBenefitSemiannualReport',
+    'donationAfterRatingBenefitBadge'
+];

--- a/src/utils/donationAfterRatingBenefits.test.js
+++ b/src/utils/donationAfterRatingBenefits.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { DONATION_AFTER_RATING_BENEFIT_KEYS } from './donationAfterRatingBenefits.js';
+import messages from '../language/i18n';
+
+describe('donationAfterRatingBenefits', () => {
+    it('lists all monthly benefit translation keys', () => {
+        expect(DONATION_AFTER_RATING_BENEFIT_KEYS).toEqual([
+            'donationAfterRatingBenefitVisibility',
+            'donationAfterRatingBenefitPrioritySupport',
+            'donationAfterRatingBenefitEarlyAccess',
+            'donationAfterRatingBenefitSemiannualReport',
+            'donationAfterRatingBenefitBadge'
+        ]);
+    });
+
+    it.each(['arg', 'chl', 'en'])(
+        'defines monthly benefit copy in %s locale with bold labels',
+        (locale) => {
+            for (const key of DONATION_AFTER_RATING_BENEFIT_KEYS) {
+                expect(messages[locale][key]).toMatch(/^<strong>[^<]+:<\/strong> /);
+            }
+        }
+    );
+});

--- a/src/utils/donationAfterRatingHeader.js
+++ b/src/utils/donationAfterRatingHeader.js
@@ -1,0 +1,8 @@
+export const DONATION_AFTER_RATING_HEADER_ROUTE_NAMES = [
+    'donate-after-rating',
+    'preview-donation-after-rating'
+];
+
+export function usesDonationAfterRatingHeader(routeName) {
+    return DONATION_AFTER_RATING_HEADER_ROUTE_NAMES.includes(routeName);
+}

--- a/src/utils/donationAfterRatingHeader.test.js
+++ b/src/utils/donationAfterRatingHeader.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import {
+    DONATION_AFTER_RATING_HEADER_ROUTE_NAMES,
+    usesDonationAfterRatingHeader
+} from './donationAfterRatingHeader.js';
+
+describe('usesDonationAfterRatingHeader', () => {
+    it('lists the donation after rating route names', () => {
+        expect(DONATION_AFTER_RATING_HEADER_ROUTE_NAMES).toEqual([
+            'donate-after-rating',
+            'preview-donation-after-rating'
+        ]);
+    });
+
+    it('returns true for donation after rating routes', () => {
+        expect(usesDonationAfterRatingHeader('donate-after-rating')).toBe(true);
+        expect(
+            usesDonationAfterRatingHeader('preview-donation-after-rating')
+        ).toBe(true);
+    });
+
+    it('returns false for other routes', () => {
+        expect(usesDonationAfterRatingHeader('trips')).toBe(false);
+        expect(usesDonationAfterRatingHeader('my-trips')).toBe(false);
+        expect(usesDonationAfterRatingHeader(null)).toBe(false);
+    });
+});

--- a/src/utils/donationAfterRatingHero.js
+++ b/src/utils/donationAfterRatingHero.js
@@ -1,0 +1,7 @@
+export const DONATION_AFTER_RATING_HERO_IMAGE_FILE = 'carpoolear-grupal-1.jpg';
+
+export function getDonationAfterRatingHeroImageUrl(env = import.meta.env) {
+    const baseUrl = String(env.VITE_API_URL || '').replace(/\/$/, '');
+
+    return `${baseUrl}/img/${DONATION_AFTER_RATING_HERO_IMAGE_FILE}`;
+}

--- a/src/utils/donationAfterRatingHero.test.js
+++ b/src/utils/donationAfterRatingHero.test.js
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+    DONATION_AFTER_RATING_HERO_IMAGE_FILE,
+    getDonationAfterRatingHeroImageUrl
+} from './donationAfterRatingHero.js';
+
+describe('donationAfterRatingHero', () => {
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    it('exports the hero image filename', () => {
+        expect(DONATION_AFTER_RATING_HERO_IMAGE_FILE).toBe(
+            'carpoolear-grupal-1.jpg'
+        );
+    });
+
+    it('builds the hero image url from API_URL/img/', () => {
+        vi.stubEnv('VITE_API_URL', 'https://api.carpoolear.test');
+
+        expect(getDonationAfterRatingHeroImageUrl()).toBe(
+            'https://api.carpoolear.test/img/carpoolear-grupal-1.jpg'
+        );
+    });
+
+    it('normalizes a trailing slash on API_URL', () => {
+        vi.stubEnv('VITE_API_URL', 'https://api.carpoolear.test/');
+
+        expect(getDonationAfterRatingHeroImageUrl()).toBe(
+            'https://api.carpoolear.test/img/carpoolear-grupal-1.jpg'
+        );
+    });
+});

--- a/src/utils/donationAfterRatingPreview.js
+++ b/src/utils/donationAfterRatingPreview.js
@@ -1,0 +1,12 @@
+export const DONATION_AFTER_RATING_PREVIEW_TRIP_ID = '0';
+
+export function buildDonationAfterRatingPreviewUrl(options = {}) {
+    const tripId = options.tripId ?? DONATION_AFTER_RATING_PREVIEW_TRIP_ID;
+    const basePath = options.basePath ?? `/preview/donation-after-rating/${tripId}`;
+
+    if (options.origin) {
+        return `${options.origin}/#${basePath}`;
+    }
+
+    return basePath;
+}

--- a/src/utils/donationAfterRatingPreview.test.js
+++ b/src/utils/donationAfterRatingPreview.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import {
+    DONATION_AFTER_RATING_PREVIEW_TRIP_ID,
+    buildDonationAfterRatingPreviewUrl
+} from './donationAfterRatingPreview.js';
+
+describe('donationAfterRatingPreview', () => {
+    it('exports a default preview trip id', () => {
+        expect(DONATION_AFTER_RATING_PREVIEW_TRIP_ID).toBe('0');
+    });
+
+    it('builds the hash-router preview path', () => {
+        expect(buildDonationAfterRatingPreviewUrl()).toBe(
+            '/preview/donation-after-rating/0'
+        );
+    });
+
+    it('builds a full dev preview url when base origin is provided', () => {
+        expect(
+            buildDonationAfterRatingPreviewUrl({
+                origin: 'http://localhost:8080'
+            })
+        ).toBe('http://localhost:8080/#/preview/donation-after-rating/0');
+    });
+});

--- a/src/utils/donationCheckout.js
+++ b/src/utils/donationCheckout.js
@@ -1,0 +1,76 @@
+import donationApi from '../services/api/Donation.js';
+import {
+    appendDonationTrackingUserId,
+    DONATION_TIERS,
+    getDonationMonthlyUrl,
+    getDonationOnceUrl
+} from './donationOptions.js';
+
+let cachedTiers = null;
+
+export async function fetchDonationTiers() {
+    if (cachedTiers) {
+        return cachedTiers;
+    }
+
+    try {
+        const response = await donationApi.getTiers();
+        const tiers = Array.isArray(response) ? response : response?.data;
+        if (Array.isArray(tiers) && tiers.length > 0) {
+            cachedTiers = tiers.map(normalizeTier);
+            return cachedTiers;
+        }
+    } catch (error) {
+        console.warn('fetchDonationTiers: falling back to static tiers.', error);
+    }
+
+    return DONATION_TIERS;
+}
+
+function normalizeTier(tier) {
+    return {
+        id: tier.id,
+        amount: tier.amount ?? Math.round((tier.amount_cents || 0) / 100),
+        labelKey: tier.label_key ?? tier.labelKey,
+        icon: tier.icon,
+        onceUrl: tier.onceUrl,
+        monthlyUrl: tier.monthlyUrl
+    };
+}
+
+export function isPlatformDonationsApiEnabled(appConfig) {
+    return Boolean(appConfig?.platform_donations_api_enabled);
+}
+
+export async function startDonationCheckout({
+    type,
+    amount,
+    source,
+    tripId,
+    userId,
+    appConfig
+}) {
+    if (isPlatformDonationsApiEnabled(appConfig)) {
+        const payload = {
+            amount: parseInt(amount, 10),
+            source,
+            trip_id: tripId || undefined
+        };
+        const response =
+            type === 'monthly'
+                ? await donationApi.checkoutMonthly(payload)
+                : await donationApi.checkoutOnce(payload);
+
+        const initPoint = response?.init_point ?? response?.data?.init_point;
+        if (initPoint) {
+            return initPoint;
+        }
+    }
+
+    const staticUrl =
+        type === 'monthly'
+            ? getDonationMonthlyUrl(amount)
+            : getDonationOnceUrl(amount);
+
+    return appendDonationTrackingUserId(staticUrl, userId);
+}

--- a/src/utils/donationCheckout.js
+++ b/src/utils/donationCheckout.js
@@ -39,7 +39,7 @@ function normalizeTier(tier) {
 }
 
 export function isPlatformDonationsApiEnabled(appConfig) {
-    return Boolean(appConfig?.platform_donations_api_enabled);
+    return Boolean(appConfig?.['platform_donations_api_enabled']);
 }
 
 export async function startDonationCheckout({
@@ -61,7 +61,8 @@ export async function startDonationCheckout({
                 ? await donationApi.checkoutMonthly(payload)
                 : await donationApi.checkoutOnce(payload);
 
-        const initPoint = response?.init_point ?? response?.data?.init_point;
+        const initPoint =
+            response?.['init_point'] ?? response?.data?.['init_point'];
         if (initPoint) {
             return initPoint;
         }

--- a/src/utils/donationCheckout.test.js
+++ b/src/utils/donationCheckout.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    isPlatformDonationsApiEnabled,
+    startDonationCheckout
+} from './donationCheckout.js';
+
+vi.mock('../services/api/Donation.js', () => ({
+    default: {
+        checkoutOnce: vi.fn(async () => ({ init_point: 'https://mp.test/once' })),
+        checkoutMonthly: vi.fn(async () => ({ init_point: 'https://mp.test/monthly' })),
+        getTiers: vi.fn(async () => [])
+    }
+}));
+
+describe('donationCheckout', () => {
+    it('detects platform donations API flag from app config', () => {
+        expect(isPlatformDonationsApiEnabled({ platform_donations_api_enabled: true })).toBe(true);
+        expect(isPlatformDonationsApiEnabled({ platform_donations_api_enabled: false })).toBe(false);
+    });
+
+    it('uses checkout API when platform donations are enabled', async () => {
+        const url = await startDonationCheckout({
+            type: 'once',
+            amount: 5000,
+            source: 'after_rating',
+            tripId: 12,
+            userId: 7,
+            appConfig: { platform_donations_api_enabled: true }
+        });
+
+        expect(url).toBe('https://mp.test/once');
+    });
+
+    it('falls back to static donation URLs when API is disabled', async () => {
+        const url = await startDonationCheckout({
+            type: 'monthly',
+            amount: 5000,
+            userId: 7,
+            appConfig: { platform_donations_api_enabled: false }
+        });
+
+        expect(url).toContain('preapproval_plan_id');
+        expect(url).toContain('u=7');
+    });
+});


### PR DESCRIPTION
## Summary
- Add full-page donation-after-rating experience (hero, minimal header, benefits, monthly/once CTAs).
- Load donation tiers from `GET /api/donation-tiers` with static fallback.
- Start one-time and monthly donations via platform checkout API when `platform_donations_api_enabled` is on.
- Stop recording `has_donated` before payment confirmation; denial/skip flow unchanged.

## Test plan
- [ ] Open `/preview/donation-after-rating/:tripId` and verify layout/copy on mobile and desktop
- [ ] With API disabled, confirm static MP links still open from Trips donation modal
- [ ] With API enabled, confirm donate buttons call checkout endpoints and redirect to MP
- [ ] Run `npm run test:unit -- --run src/utils/donationCheckout.test.js`