### PR TITLE
Update verificación de cuenta payment UI copy and actions

### DIFF
--- a/src/components/sections/IdentityValidation.vue
+++ b/src/components/sections/IdentityValidation.vue
@@ -735,6 +735,7 @@ export default {
                         this.closeManualValidationQrPanel();
                         this.mpPaymentUrl = initPoint;
                         this.showMpPanel = true;
+                        this.startManualValidationQrPolling();
                     }
                     this.loadingPreference = false;
                 })
@@ -776,6 +777,7 @@ export default {
         closeManualValidationMpPanel() {
             this.showMpPanel = false;
             this.mpPaymentUrl = null;
+            this.stopManualValidationQrPolling();
         },
         startManualValidationQrPolling() {
             this.stopManualValidationQrPolling();
@@ -783,6 +785,7 @@ export default {
                 this.fetchManualStatus().then(() => {
                     if (this.manualStatus.paid === true) {
                         this.closeManualValidationQrPanel();
+                        this.closeManualValidationMpPanel();
                     }
                 });
             }, 3000);

--- a/src/components/sections/IdentityValidation.vue
+++ b/src/components/sections/IdentityValidation.vue
@@ -112,9 +112,12 @@
                         :loading-qr="loadingQr"
                         :show-qr-panel="showQrPanel"
                         :qr-image-url="qrImageUrl"
+                        :show-mp-panel="showMpPanel"
+                        :mp-payment-url="mpPaymentUrl"
                         @pay-mp="payManualValidation"
                         @pay-qr="createManualValidationQrOrderAndShow"
                         @close-qr="closeManualValidationQrPanel"
+                        @close-mp="closeManualValidationMpPanel"
                     />
                     <template v-if="showPendingManualSwitchLink">
                         <hr class="manual-status-switch-separator" />
@@ -526,6 +529,8 @@ export default {
             loadingPreference: false,
             loadingQr: false,
             showQrPanel: false,
+            showMpPanel: false,
+            mpPaymentUrl: null,
             qrImageUrl: null,
             qrData: null,
             pollIntervalId: null
@@ -727,10 +732,11 @@ export default {
                     const data = res.data || res;
                     const initPoint = data.init_point;
                     if (initPoint) {
-                        window.location.href = initPoint;
-                    } else {
-                        this.loadingPreference = false;
+                        this.closeManualValidationQrPanel();
+                        this.mpPaymentUrl = initPoint;
+                        this.showMpPanel = true;
                     }
+                    this.loadingPreference = false;
                 })
                 .catch(() => {
                     this.loadingPreference = false;
@@ -747,6 +753,7 @@ export default {
                     if (qrData && requestId) {
                         this.manualStatus.request_id = requestId;
                         this.qrData = qrData;
+                        this.closeManualValidationMpPanel();
                         this.showQrPanel = true;
                         this.qrImageUrl = null;
                         QRCode.toDataURL(qrData, { width: 256, margin: 2 }, (err, url) => {
@@ -765,6 +772,10 @@ export default {
             this.qrData = null;
             this.qrImageUrl = null;
             this.stopManualValidationQrPolling();
+        },
+        closeManualValidationMpPanel() {
+            this.showMpPanel = false;
+            this.mpPaymentUrl = null;
         },
         startManualValidationQrPolling() {
             this.stopManualValidationQrPolling();

--- a/src/components/sections/ManualIdentityValidation.vue
+++ b/src/components/sections/ManualIdentityValidation.vue
@@ -47,10 +47,13 @@
                         :loading-qr="loadingQr"
                         :show-qr-panel="showQrPanel"
                         :qr-image-url="qrImageUrl"
+                        :show-mp-panel="showMpPanel"
+                        :mp-payment-url="mpPaymentUrl"
                         :cost-unavailable="costCents <= 0"
                         @pay-mp="createPreferenceAndRedirect"
                         @pay-qr="createQrOrderAndShow"
                         @close-qr="closeQrPanel"
+                        @close-mp="closeMpPanel"
                     >
                         <template v-if="showSwitchToMercadoPagoLink">
                             <hr class="manual-validation-switch-mode-separator" />
@@ -222,6 +225,8 @@ export default {
             submitting: false,
             submitError: null,
             showQrPanel: false,
+            showMpPanel: false,
+            mpPaymentUrl: null,
             qrImageUrl: null,
             qrData: null,
             pollIntervalId: null,
@@ -366,10 +371,11 @@ export default {
                     const data = res.data || res;
                     const initPoint = data.init_point;
                     if (initPoint) {
-                        window.location.href = initPoint;
-                    } else {
-                        this.loadingPreference = false;
+                        this.closeQrPanel();
+                        this.mpPaymentUrl = initPoint;
+                        this.showMpPanel = true;
                     }
+                    this.loadingPreference = false;
                 })
                 .catch(() => {
                     this.loadingPreference = false;
@@ -387,6 +393,7 @@ export default {
                     if (qrData && requestId) {
                         this.requestId = requestId;
                         this.qrData = qrData;
+                        this.closeMpPanel();
                         this.showQrPanel = true;
                         this.qrImageUrl = null;
                         QRCode.toDataURL(qrData, { width: 256, margin: 2 }, (err, url) => {
@@ -405,6 +412,10 @@ export default {
             this.qrData = null;
             this.qrImageUrl = null;
             this.stopPollingStatus();
+        },
+        closeMpPanel() {
+            this.showMpPanel = false;
+            this.mpPaymentUrl = null;
         },
         startPollingStatus() {
             this.stopPollingStatus();

--- a/src/components/sections/ManualIdentityValidation.vue
+++ b/src/components/sections/ManualIdentityValidation.vue
@@ -374,6 +374,7 @@ export default {
                         this.closeQrPanel();
                         this.mpPaymentUrl = initPoint;
                         this.showMpPanel = true;
+                        this.startPollingStatus();
                     }
                     this.loadingPreference = false;
                 })
@@ -416,6 +417,7 @@ export default {
         closeMpPanel() {
             this.showMpPanel = false;
             this.mpPaymentUrl = null;
+            this.stopPollingStatus();
         },
         startPollingStatus() {
             this.stopPollingStatus();
@@ -423,6 +425,7 @@ export default {
                 this.fetchStatus().then(() => {
                     if (this.paymentSuccess) {
                         this.closeQrPanel();
+                        this.closeMpPanel();
                     }
                 });
             }, 3000);

--- a/src/components/sections/ManualIdentityValidationPayOptions.view.test.js
+++ b/src/components/sections/ManualIdentityValidationPayOptions.view.test.js
@@ -55,4 +55,43 @@ describe('ManualIdentityValidationPayOptions shared component', () => {
         const qrPanel = source.slice(source.indexOf('showQrPanel'));
         expect(qrPanel).toContain('ManualValidationQrPaymentHelp');
     });
+
+    it('shows copy and share payment link actions when Mercado Pago payment is selected', () => {
+        const source = fs.readFileSync(componentPath, 'utf8');
+        const identitySource = fs.readFileSync(identityValidationPath, 'utf8');
+        const manualSource = fs.readFileSync(manualValidationPath, 'utf8');
+
+        expect(source).toContain('showMpPanel');
+        expect(source).toContain('mpPaymentUrl');
+        expect(source).toContain("$t('copiarLinkDePago')");
+        expect(source).toContain("$t('enviarLinkDePago')");
+        expect(source).toContain("$t('manualValidationPagarMercadoPago')");
+        expect(source).toContain('copyTextToClipboard');
+        expect(source).toContain('shareContent');
+        expect(source).toContain('copyMpLink');
+        expect(source).toContain('shareMpLink');
+        expect(source).toContain('openMpCheckout');
+        expect(source).toContain("emit('close-mp')");
+
+        expect(identitySource).toContain(':show-mp-panel="showMpPanel"');
+        expect(identitySource).toContain(':mp-payment-url="mpPaymentUrl"');
+        expect(manualSource).toContain(':show-mp-panel="showMpPanel"');
+        expect(manualSource).toContain(':mp-payment-url="mpPaymentUrl"');
+
+        const identityPayMethod = identitySource.slice(
+            identitySource.indexOf('payManualValidation()'),
+            identitySource.indexOf('createManualValidationQrOrderAndShow')
+        );
+        expect(identityPayMethod).toContain('this.showMpPanel = true');
+        expect(identityPayMethod).toContain('this.mpPaymentUrl');
+        expect(identityPayMethod).not.toContain('window.location.href = initPoint');
+
+        const manualPayMethod = manualSource.slice(
+            manualSource.indexOf('createPreferenceAndRedirect()'),
+            manualSource.indexOf('createQrOrderAndShow')
+        );
+        expect(manualPayMethod).toContain('this.showMpPanel = true');
+        expect(manualPayMethod).toContain('this.mpPaymentUrl');
+        expect(manualPayMethod).not.toContain('window.location.href = initPoint');
+    });
 });

--- a/src/components/sections/ManualIdentityValidationPayOptions.view.test.js
+++ b/src/components/sections/ManualIdentityValidationPayOptions.view.test.js
@@ -79,16 +79,16 @@ describe('ManualIdentityValidationPayOptions shared component', () => {
         expect(manualSource).toContain(':mp-payment-url="mpPaymentUrl"');
 
         const identityPayMethod = identitySource.slice(
-            identitySource.indexOf('payManualValidation()'),
-            identitySource.indexOf('createManualValidationQrOrderAndShow')
+            identitySource.indexOf('payManualValidation() {'),
+            identitySource.indexOf('createManualValidationQrOrderAndShow() {')
         );
         expect(identityPayMethod).toContain('this.showMpPanel = true');
         expect(identityPayMethod).toContain('this.mpPaymentUrl');
         expect(identityPayMethod).not.toContain('window.location.href = initPoint');
 
         const manualPayMethod = manualSource.slice(
-            manualSource.indexOf('createPreferenceAndRedirect()'),
-            manualSource.indexOf('createQrOrderAndShow')
+            manualSource.indexOf('createPreferenceAndRedirect() {'),
+            manualSource.indexOf('createQrOrderAndShow() {')
         );
         expect(manualPayMethod).toContain('this.showMpPanel = true');
         expect(manualPayMethod).toContain('this.mpPaymentUrl');

--- a/src/components/sections/ManualIdentityValidationPayOptions.view.test.js
+++ b/src/components/sections/ManualIdentityValidationPayOptions.view.test.js
@@ -26,4 +26,33 @@ describe('ManualIdentityValidationPayOptions shared component', () => {
         expect(identitySource).toContain('ManualIdentityValidationPayOptions');
         expect(manualSource).toContain('ManualIdentityValidationPayOptions');
     });
+
+    it('shows QR payment how-to before selecting QR and after the QR panel is open', () => {
+        const source = fs.readFileSync(componentPath, 'utf8');
+        const helpComponentPath = path.resolve(
+            __dirname,
+            'ManualValidationQrPaymentHelp.vue'
+        );
+
+        expect(fs.existsSync(helpComponentPath)).toBe(true);
+        const helpSource = fs.readFileSync(helpComponentPath, 'utf8');
+
+        expect(helpSource).toContain("$t('comoPagarElQR')");
+        expect(helpSource).toContain("$t('comoHacerPagoQRTitulo')");
+        expect(helpSource).toContain("$t('comoHacerPagoQRCelular')");
+        expect(helpSource).toContain("$t('comoHacerPagoQRComputadoraPrefix')");
+        expect(helpSource).toContain("$t('comoHacerPagoQRComputadoraLink')");
+        expect(helpSource).toContain("$t('comoHacerPagoQRComputadoraSuffix')");
+        expect(helpSource).toContain('CARPOOLEAR_APP_URL');
+        expect(helpSource).toContain('target="_blank"');
+        expect(helpSource).toContain('rel="noopener noreferrer"');
+        expect(helpSource).toContain('helpOpen');
+
+        const beforeQrPanel = source.slice(0, source.indexOf('showQrPanel'));
+        expect(beforeQrPanel).toContain('v-if="qrEnabled"');
+        expect(beforeQrPanel).toContain('ManualValidationQrPaymentHelp');
+
+        const qrPanel = source.slice(source.indexOf('showQrPanel'));
+        expect(qrPanel).toContain('ManualValidationQrPaymentHelp');
+    });
 });

--- a/src/components/sections/ManualIdentityValidationPayOptions.view.test.js
+++ b/src/components/sections/ManualIdentityValidationPayOptions.view.test.js
@@ -94,4 +94,33 @@ describe('ManualIdentityValidationPayOptions shared component', () => {
         expect(manualPayMethod).toContain('this.mpPaymentUrl');
         expect(manualPayMethod).not.toContain('window.location.href = initPoint');
     });
+
+    it('polls for payment after creating a Mercado Pago checkout link', () => {
+        const identitySource = fs.readFileSync(identityValidationPath, 'utf8');
+        const manualSource = fs.readFileSync(manualValidationPath, 'utf8');
+
+        const identityPayMethod = identitySource.slice(
+            identitySource.indexOf('payManualValidation() {'),
+            identitySource.indexOf('createManualValidationQrOrderAndShow() {')
+        );
+        expect(identityPayMethod).toContain('this.startManualValidationQrPolling()');
+
+        const identityCloseMp = identitySource.slice(
+            identitySource.indexOf('closeManualValidationMpPanel() {'),
+            identitySource.indexOf('startManualValidationQrPolling() {')
+        );
+        expect(identityCloseMp).toContain('this.stopManualValidationQrPolling()');
+
+        const manualPayMethod = manualSource.slice(
+            manualSource.indexOf('createPreferenceAndRedirect() {'),
+            manualSource.indexOf('createQrOrderAndShow() {')
+        );
+        expect(manualPayMethod).toContain('this.startPollingStatus()');
+
+        const manualCloseMp = manualSource.slice(
+            manualSource.indexOf('closeMpPanel() {'),
+            manualSource.indexOf('startPollingStatus() {')
+        );
+        expect(manualCloseMp).toContain('this.stopPollingStatus()');
+    });
 });

--- a/src/components/sections/ManualIdentityValidationPayOptions.view.test.js
+++ b/src/components/sections/ManualIdentityValidationPayOptions.view.test.js
@@ -56,6 +56,24 @@ describe('ManualIdentityValidationPayOptions shared component', () => {
         expect(qrPanel).toContain('ManualValidationQrPaymentHelp');
     });
 
+    it('centers the QR payment how-to link', () => {
+        const helpSource = fs.readFileSync(
+            path.resolve(__dirname, 'ManualValidationQrPaymentHelp.vue'),
+            'utf8'
+        );
+        const helpBlock = helpSource.slice(
+            helpSource.indexOf('.qr-payment-help {'),
+            helpSource.indexOf('.qr-payment-help__toggle')
+        );
+        const contentBlock = helpSource.slice(
+            helpSource.indexOf('.qr-payment-help__content'),
+            helpSource.indexOf('.qr-payment-help__title')
+        );
+
+        expect(helpBlock).toContain('text-align: center');
+        expect(contentBlock).toContain('text-align: left');
+    });
+
     it('shows copy and share payment link actions when Mercado Pago payment is selected', () => {
         const source = fs.readFileSync(componentPath, 'utf8');
         const identitySource = fs.readFileSync(identityValidationPath, 'utf8');

--- a/src/components/sections/ManualIdentityValidationPayOptions.vue
+++ b/src/components/sections/ManualIdentityValidationPayOptions.vue
@@ -75,7 +75,7 @@
         </div>
 
         <div v-if="showMpPanel" class="mp-payment-panel panel panel-default">
-            <div class="panel-body text-center">
+            <div class="panel-body mp-payment-panel__actions">
                 <AppButton
                     variant="primary"
                     size="lg"
@@ -279,8 +279,11 @@ export default {
     margin-top: 1.25rem;
 }
 
-.mp-payment-panel .manual-validation-pay-cta {
-    margin-bottom: 0.75rem;
+.mp-payment-panel__actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: stretch;
 }
 
 .qr-image-wrap {

--- a/src/components/sections/ManualIdentityValidationPayOptions.vue
+++ b/src/components/sections/ManualIdentityValidationPayOptions.vue
@@ -42,8 +42,8 @@
             >
                 {{ $t('pagarConQR') }}
             </AppButton>
-            <ManualValidationQrPaymentHelp v-if="qrEnabled" />
         </div>
+        <ManualValidationQrPaymentHelp v-if="qrEnabled" />
 
         <slot />
 

--- a/src/components/sections/ManualIdentityValidationPayOptions.vue
+++ b/src/components/sections/ManualIdentityValidationPayOptions.vue
@@ -42,6 +42,7 @@
             >
                 {{ $t('pagarConQR') }}
             </AppButton>
+            <ManualValidationQrPaymentHelp v-if="qrEnabled" />
         </div>
 
         <slot />
@@ -61,6 +62,7 @@
                 </div>
                 <p v-else class="manual-validation-text">{{ $t('cargando') }}...</p>
                 <p class="qr-expiry small">{{ $t('qrExpiraEn') }}</p>
+                <ManualValidationQrPaymentHelp />
                 <AppButton
                     variant="tertiary"
                     size="sm"
@@ -80,11 +82,13 @@ import {
     MANUAL_VALIDATION_UPLOAD_WARNING_STYLE
 } from '../../utils/manualValidationUploadWarning';
 import AppButton from '../ui/AppButton.vue';
+import ManualValidationQrPaymentHelp from './ManualValidationQrPaymentHelp.vue';
 
 export default {
     name: 'ManualIdentityValidationPayOptions',
     components: {
-        AppButton
+        AppButton,
+        ManualValidationQrPaymentHelp
     },
     props: {
         costDisplay: {

--- a/src/components/sections/ManualIdentityValidationPayOptions.vue
+++ b/src/components/sections/ManualIdentityValidationPayOptions.vue
@@ -73,6 +73,49 @@
                 </AppButton>
             </div>
         </div>
+
+        <div v-if="showMpPanel" class="mp-payment-panel panel panel-default">
+            <div class="panel-body text-center">
+                <AppButton
+                    variant="primary"
+                    size="lg"
+                    block
+                    class="manual-validation-pay-cta"
+                    :disabled="!mpPaymentUrl"
+                    @click="openMpCheckout"
+                >
+                    {{ $t('manualValidationPagarMercadoPago') }}
+                </AppButton>
+                <AppButton
+                    variant="secondary"
+                    size="lg"
+                    block
+                    class="manual-validation-pay-cta"
+                    :disabled="!mpPaymentUrl"
+                    @click="copyMpLink"
+                >
+                    {{ $t('copiarLinkDePago') }}
+                </AppButton>
+                <AppButton
+                    variant="secondary"
+                    size="lg"
+                    block
+                    class="manual-validation-pay-cta"
+                    :disabled="!mpPaymentUrl"
+                    @click="shareMpLink"
+                >
+                    {{ $t('enviarLinkDePago') }}
+                </AppButton>
+                <AppButton
+                    variant="tertiary"
+                    size="sm"
+                    class="manual-validation-mp-close"
+                    @click="$emit('close-mp')"
+                >
+                    {{ $t('cerrar') }}
+                </AppButton>
+            </div>
+        </div>
     </div>
 </template>
 
@@ -83,6 +126,9 @@ import {
 } from '../../utils/manualValidationUploadWarning';
 import AppButton from '../ui/AppButton.vue';
 import ManualValidationQrPaymentHelp from './ManualValidationQrPaymentHelp.vue';
+import toast from '../../cordova/toast.js';
+import { copyTextToClipboard } from '../../utils/copyTextToClipboard';
+import { shareContent } from '../../utils/shareContent.js';
 
 export default {
     name: 'ManualIdentityValidationPayOptions',
@@ -115,18 +161,53 @@ export default {
             type: String,
             default: null
         },
+        showMpPanel: {
+            type: Boolean,
+            default: false
+        },
+        mpPaymentUrl: {
+            type: String,
+            default: null
+        },
         costUnavailable: {
             type: Boolean,
             default: false
         }
     },
-    emits: ['pay-mp', 'pay-qr', 'close-qr'],
+    emits: ['pay-mp', 'pay-qr', 'close-qr', 'close-mp'],
     computed: {
         manualValidationUploadWarningKey() {
             return getManualValidationUploadWarningKey();
         },
         manualValidationUploadWarningStyle() {
             return MANUAL_VALIDATION_UPLOAD_WARNING_STYLE;
+        }
+    },
+    methods: {
+        openMpCheckout() {
+            if (this.mpPaymentUrl) {
+                window.location.href = this.mpPaymentUrl;
+            }
+        },
+        async copyMpLink() {
+            const copied = await copyTextToClipboard(this.mpPaymentUrl);
+            if (copied) {
+                toast.toast(this.$t('linkDePagoCopiado'));
+            }
+        },
+        async shareMpLink() {
+            if (!this.mpPaymentUrl) {
+                return;
+            }
+            const title = this.$t('enviarLinkDePago');
+            const result = await shareContent({
+                title,
+                text: title,
+                url: this.mpPaymentUrl
+            });
+            if (!result.ok && !result.cancelled) {
+                await this.copyMpLink();
+            }
         }
     }
 };
@@ -193,8 +274,13 @@ export default {
     margin-top: 0.75rem;
 }
 
-.qr-payment-panel {
+.qr-payment-panel,
+.mp-payment-panel {
     margin-top: 1.25rem;
+}
+
+.mp-payment-panel .manual-validation-pay-cta {
+    margin-bottom: 0.75rem;
 }
 
 .qr-image-wrap {

--- a/src/components/sections/ManualValidationQrPaymentHelp.vue
+++ b/src/components/sections/ManualValidationQrPaymentHelp.vue
@@ -43,7 +43,7 @@ export default {
 <style scoped>
 .qr-payment-help {
     margin-top: 0.75rem;
-    text-align: left;
+    text-align: center;
 }
 
 .qr-payment-help__toggle {
@@ -58,6 +58,7 @@ export default {
 
 .qr-payment-help__content {
     margin-top: 0.75rem;
+    text-align: left;
 }
 
 .qr-payment-help__title {

--- a/src/components/sections/ManualValidationQrPaymentHelp.vue
+++ b/src/components/sections/ManualValidationQrPaymentHelp.vue
@@ -1,0 +1,71 @@
+<template>
+    <div class="qr-payment-help">
+        <button
+            type="button"
+            class="qr-payment-help__toggle"
+            :aria-expanded="helpOpen ? 'true' : 'false'"
+            @click="helpOpen = !helpOpen"
+        >
+            {{ $t('comoPagarElQR') }}
+        </button>
+        <div v-if="helpOpen" class="qr-payment-help__content">
+            <h4 class="qr-payment-help__title">{{ $t('comoHacerPagoQRTitulo') }}</h4>
+            <p class="qr-payment-help__paragraph">{{ $t('comoHacerPagoQRCelular') }}</p>
+            <p class="qr-payment-help__paragraph">
+                {{ $t('comoHacerPagoQRComputadoraPrefix') }}<a
+                    :href="carpoolearAppUrl"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >{{ $t('comoHacerPagoQRComputadoraLink') }}</a>{{ $t('comoHacerPagoQRComputadoraSuffix') }}
+            </p>
+        </div>
+    </div>
+</template>
+
+<script>
+import { CARPOOLEAR_APP_URL } from '../../utils/qrPaymentHelp';
+
+export default {
+    name: 'ManualValidationQrPaymentHelp',
+    data() {
+        return {
+            helpOpen: false,
+            carpoolearAppUrl: CARPOOLEAR_APP_URL
+        };
+    }
+};
+</script>
+
+<style scoped>
+.qr-payment-help {
+    margin-top: 0.75rem;
+    text-align: left;
+}
+
+.qr-payment-help__toggle {
+    background: none;
+    border: none;
+    padding: 0;
+    color: #337ab7;
+    text-decoration: underline;
+    cursor: pointer;
+    font-size: inherit;
+}
+
+.qr-payment-help__content {
+    margin-top: 0.75rem;
+}
+
+.qr-payment-help__title {
+    margin: 0 0 0.5rem;
+    font-size: 1rem;
+    font-weight: 700;
+    color: #333;
+}
+
+.qr-payment-help__paragraph {
+    margin: 0 0 0.75rem;
+    line-height: 1.5;
+    color: #333;
+}
+</style>

--- a/src/components/sections/ManualValidationQrPaymentHelp.vue
+++ b/src/components/sections/ManualValidationQrPaymentHelp.vue
@@ -29,9 +29,13 @@ export default {
     name: 'ManualValidationQrPaymentHelp',
     data() {
         return {
-            helpOpen: false,
-            carpoolearAppUrl: CARPOOLEAR_APP_URL
+            helpOpen: false
         };
+    },
+    computed: {
+        carpoolearAppUrl() {
+            return CARPOOLEAR_APP_URL;
+        }
     }
 };
 </script>

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -955,6 +955,9 @@ const messages = {
         manualValidationPayClosing:
             'Esto nos permitirá verificar tu cuenta correctamente.',
         manualValidationPagarMercadoPago: 'Pagar con Mercado Pago',
+        copiarLinkDePago: 'Copiar link de pago',
+        enviarLinkDePago: 'Enviar link de pago',
+        linkDePagoCopiado: 'Link de pago copiado',
         manualValidationVolverOpcionesDesktop:
             'Volver a opciones de verificación',
         manualValidationPagoProcesado: 'Pago procesado correctamente',
@@ -2733,6 +2736,9 @@ const messages = {
         manualValidationPayClosing:
             'Esto nos permitirá verificar tu cuenta correctamente.',
         manualValidationPagarMercadoPago: 'Pagar con Mercado Pago',
+        copiarLinkDePago: 'Copiar link de pago',
+        enviarLinkDePago: 'Enviar link de pago',
+        linkDePagoCopiado: 'Link de pago copiado',
         manualValidationVolverOpcionesDesktop:
             'Volver a opciones de verificación',
         manualValidationPagoProcesado: 'Pago procesado correctamente',
@@ -4393,6 +4399,9 @@ const messages = {
         manualValidationPayClosing:
             'This allows us to verify your account correctly.',
         manualValidationPagarMercadoPago: 'Pay with Mercado Pago',
+        copiarLinkDePago: 'Copy payment link',
+        enviarLinkDePago: 'Send payment link',
+        linkDePagoCopiado: 'Payment link copied',
         manualValidationVolverOpcionesDesktop: 'Back to verification options',
         manualValidationPagoProcesado: 'Payment processed successfully',
         manualValidationUploadIntro:

--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -935,6 +935,15 @@ const messages = {
         costoValidacionManual: 'Costo de la verificación manual',
         pagarYContinuar: 'Pagar y continuar',
         pagarConQR: 'Pagar con QR',
+        comoPagarElQR: '¿Cómo pagar el QR?',
+        comoHacerPagoQRTitulo: '¿Cómo hacer el pago con QR?',
+        comoHacerPagoQRCelular:
+            'Desde tu celular, le podes hacer una captura de pantalla al QR, luego tomas esa captura y se la enviás a otra persona amiga/familiar que tengas al lado. Puede ser cualquier app de chat que utilices (whatsapp o telegram). Cuando lo reciban, pedile que abran la captura en sus teléfonos así lo escaneas desde el tuyo, o también te lo podes enviar a tu misma cuenta de chat si podes levantar whatsapp web o telegram web en una computadora y escanear la imagen QR desde ahí.',
+        comoHacerPagoQRComputadoraPrefix:
+            'Desde una computadora, abris Carpoolear ',
+        comoHacerPagoQRComputadoraLink: 'www.carpoolear.com.ar/app',
+        comoHacerPagoQRComputadoraSuffix:
+            ' desde un navegador. Luego vas a la verificación de cuenta y apretás para generar pago con el QR. Ahora escanealo con tu celular desde cualquier billetera virtual.',
         manualValidationPayIntro1:
             'Primero deberás realizar el pago de la verificación manual, que tiene un costo de {cost}.',
         manualValidationPayIntro2:
@@ -2704,6 +2713,15 @@ const messages = {
         costoValidacionManual: 'Costo de la verificación manual',
         pagarYContinuar: 'Pagar y continuar',
         pagarConQR: 'Pagar con QR',
+        comoPagarElQR: '¿Cómo pagar el QR?',
+        comoHacerPagoQRTitulo: '¿Cómo hacer el pago con QR?',
+        comoHacerPagoQRCelular:
+            'Desde tu celular, le podes hacer una captura de pantalla al QR, luego tomas esa captura y se la enviás a otra persona amiga/familiar que tengas al lado. Puede ser cualquier app de chat que utilices (whatsapp o telegram). Cuando lo reciban, pedile que abran la captura en sus teléfonos así lo escaneas desde el tuyo, o también te lo podes enviar a tu misma cuenta de chat si podes levantar whatsapp web o telegram web en una computadora y escanear la imagen QR desde ahí.',
+        comoHacerPagoQRComputadoraPrefix:
+            'Desde una computadora, abris Carpoolear ',
+        comoHacerPagoQRComputadoraLink: 'www.carpoolear.com.ar/app',
+        comoHacerPagoQRComputadoraSuffix:
+            ' desde un navegador. Luego vas a la verificación de cuenta y apretás para generar pago con el QR. Ahora escanealo con tu celular desde cualquier billetera virtual.',
         manualValidationPayIntro1:
             'Primero deberás realizar el pago de la verificación manual, que tiene un costo de {cost}.',
         manualValidationPayIntro2:
@@ -4356,6 +4374,14 @@ const messages = {
         costoValidacionManual: 'Manual verification cost',
         pagarYContinuar: 'Pay and continue',
         pagarConQR: 'Pay with QR',
+        comoPagarElQR: 'How to pay with QR?',
+        comoHacerPagoQRTitulo: 'How to pay with QR',
+        comoHacerPagoQRCelular:
+            'From your phone, take a screenshot of the QR, then send that screenshot to a friend or family member next to you. You can use any chat app (WhatsApp or Telegram). When they receive it, ask them to open the screenshot on their phone so you can scan it from yours, or send it to your own chat account if you can open WhatsApp Web or Telegram Web on a computer and scan the QR image from there.',
+        comoHacerPagoQRComputadoraPrefix: 'From a computer, open Carpoolear ',
+        comoHacerPagoQRComputadoraLink: 'www.carpoolear.com.ar/app',
+        comoHacerPagoQRComputadoraSuffix:
+            ' in a browser. Then go to account verification and generate the QR payment. Scan it with your phone from any digital wallet.',
         manualValidationPayIntro1:
             'First you need to pay for manual verification, which costs {cost}.',
         manualValidationPayIntro2:

--- a/src/language/manualValidationPaymentLinkCopy.test.js
+++ b/src/language/manualValidationPaymentLinkCopy.test.js
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import messages from './i18n';
+
+describe('manual validation Mercado Pago payment link copy', () => {
+    it.each(['arg', 'chl'])(
+        '%s locale has copy and share payment link labels',
+        (locale) => {
+            expect(messages[locale].copiarLinkDePago).toBe('Copiar link de pago');
+            expect(messages[locale].enviarLinkDePago).toBe('Enviar link de pago');
+            expect(messages[locale].linkDePagoCopiado).toBe('Link de pago copiado');
+        }
+    );
+
+    it('en locale has copy and share payment link labels', () => {
+        expect(messages.en.copiarLinkDePago).toBe('Copy payment link');
+        expect(messages.en.enviarLinkDePago).toBe('Send payment link');
+        expect(messages.en.linkDePagoCopiado).toBe('Payment link copied');
+    });
+});

--- a/src/language/qrPaymentHelpCopy.test.js
+++ b/src/language/qrPaymentHelpCopy.test.js
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import messages from './i18n';
+
+describe('QR payment how-to copy', () => {
+    it.each(['arg', 'chl'])('%s locale has QR payment how-to copy', (locale) => {
+        expect(messages[locale].comoPagarElQR).toBe('¿Cómo pagar el QR?');
+        expect(messages[locale].comoHacerPagoQRTitulo).toBe(
+            '¿Cómo hacer el pago con QR?'
+        );
+        expect(messages[locale].comoHacerPagoQRCelular).toContain(
+            'captura de pantalla al QR'
+        );
+        expect(messages[locale].comoHacerPagoQRComputadoraPrefix).toContain(
+            'Desde una computadora'
+        );
+        expect(messages[locale].comoHacerPagoQRComputadoraLink).toBe(
+            'www.carpoolear.com.ar/app'
+        );
+        expect(messages[locale].comoHacerPagoQRComputadoraSuffix).toContain(
+            'billetera virtual'
+        );
+    });
+
+    it('en locale has QR payment how-to copy', () => {
+        expect(messages.en.comoPagarElQR).toBe('How to pay with QR?');
+        expect(messages.en.comoHacerPagoQRTitulo).toBe('How to pay with QR');
+        expect(messages.en.comoHacerPagoQRCelular).toContain('screenshot');
+        expect(messages.en.comoHacerPagoQRComputadoraPrefix).toContain(
+            'From a computer'
+        );
+        expect(messages.en.comoHacerPagoQRComputadoraLink).toBe(
+            'www.carpoolear.com.ar/app'
+        );
+        expect(messages.en.comoHacerPagoQRComputadoraSuffix).toContain(
+            'digital wallet'
+        );
+    });
+});

--- a/src/utils/copyTextToClipboard.js
+++ b/src/utils/copyTextToClipboard.js
@@ -1,0 +1,14 @@
+export async function copyTextToClipboard(text) {
+    if (!text) {
+        return false;
+    }
+    if (
+        typeof navigator === 'undefined' ||
+        !navigator.clipboard ||
+        typeof navigator.clipboard.writeText !== 'function'
+    ) {
+        return false;
+    }
+    await navigator.clipboard.writeText(text);
+    return true;
+}

--- a/src/utils/copyTextToClipboard.test.js
+++ b/src/utils/copyTextToClipboard.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const helperPath = path.resolve(__dirname, 'copyTextToClipboard.js');
+
+describe('copyTextToClipboard', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('writes text to the clipboard and returns true', async () => {
+        expect(fs.existsSync(helperPath)).toBe(true);
+        const { copyTextToClipboard } = await import('./copyTextToClipboard.js');
+        const writeText = vi.fn().mockResolvedValue(undefined);
+        vi.stubGlobal('navigator', {
+            clipboard: { writeText }
+        });
+
+        const result = await copyTextToClipboard('https://checkout.example/pay');
+
+        expect(writeText).toHaveBeenCalledWith('https://checkout.example/pay');
+        expect(result).toBe(true);
+    });
+
+    it('returns false when there is no text to copy', async () => {
+        expect(fs.existsSync(helperPath)).toBe(true);
+        const { copyTextToClipboard } = await import('./copyTextToClipboard.js');
+        const writeText = vi.fn();
+        vi.stubGlobal('navigator', {
+            clipboard: { writeText }
+        });
+
+        expect(await copyTextToClipboard('')).toBe(false);
+        expect(writeText).not.toHaveBeenCalled();
+    });
+
+    it('returns false when clipboard is unavailable', async () => {
+        expect(fs.existsSync(helperPath)).toBe(true);
+        const { copyTextToClipboard } = await import('./copyTextToClipboard.js');
+        vi.stubGlobal('navigator', {});
+
+        expect(await copyTextToClipboard('https://checkout.example/pay')).toBe(
+            false
+        );
+    });
+});

--- a/src/utils/qrPaymentHelp.js
+++ b/src/utils/qrPaymentHelp.js
@@ -1,0 +1,1 @@
+export const CARPOOLEAR_APP_URL = 'https://www.carpoolear.com.ar/app';

--- a/src/utils/qrPaymentHelp.test.js
+++ b/src/utils/qrPaymentHelp.test.js
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const helperPath = path.resolve(__dirname, 'qrPaymentHelp.js');
+
+describe('QR payment help', () => {
+    it('points to the public Carpoolear app URL', async () => {
+        expect(fs.existsSync(helperPath)).toBe(true);
+        const { CARPOOLEAR_APP_URL } = await import('./qrPaymentHelp.js');
+        expect(CARPOOLEAR_APP_URL).toBe('https://www.carpoolear.com.ar/app');
+    });
+});


### PR DESCRIPTION
## Summary
- Add a collapsible “¿Cómo pagar el QR?” help section on manual verification, shown before selecting QR and again after the QR panel opens.
- After choosing Mercado Pago payment, keep the pay button and add “Copiar link de pago” and “Enviar link de pago”, then poll until payment is confirmed.
- Companion backend copy update: STS-Rosario/carpoolear_backend branch `verificacion-cuenta-textos`.

## Test plan
- [ ] Open verificación de cuenta payment and confirm the QR help link expands with the two how-to paragraphs and the app URL opens in a new tab.
- [ ] Select Pagar con QR and confirm the same help is available in the QR panel.
- [ ] Select Pagar con Mercado Pago and confirm pay, copy-link, and share-link actions work; paying via the copied link still advances the flow.
- [ ] Confirm lint and `npm run build:web` succeed.