### PR TITLE
Harden remaining production Vue crashes from client logs

### DIFF
--- a/src/components/PendingPaymentRequest.view.test.js
+++ b/src/components/PendingPaymentRequest.view.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const viewPath = path.resolve(__dirname, 'PendingPaymentRequest.vue');
+const viewSource = fs.readFileSync(viewPath, 'utf8');
+
+describe('PendingPaymentRequest.vue destination city', () => {
+    it('does not read trip.points without a helper', () => {
+        expect(viewSource).not.toMatch(
+            /trip\.points\[trip\.points\.length/
+        );
+        expect(viewSource).toContain('getTripDestinationCity');
+        expect(viewSource).toContain("from '../utils/ongoingTrip'");
+    });
+});

--- a/src/components/PendingPaymentRequest.vue
+++ b/src/components/PendingPaymentRequest.vue
@@ -6,12 +6,7 @@
                     <h3>{{ $t('pendingPaymentConfirmarTuAsiento') }}</h3>
                     {{ $t('pendingPaymentTeHanAceptadoEnElViajeHacia') }}
                     <strong>
-                        {{
-                            trip.points[trip.points.length - 1].json_address
-                                ? trip.points[trip.points.length - 1]
-                                      .json_address.name
-                                : trip.points[trip.points.length - 1].address
-                        }}
+                        {{ getTripDestinationCity(trip) }}
                         {{ $t('pendingRequestDelDia') }} {{ dayjs(trip.trip_date).format('DD/MM/YYYY') }} {{ $t('pendingRequestALas') }}
                         {{ dayjs(trip.trip_date).format('HH:mm') }}
                     </strong>
@@ -46,6 +41,7 @@ import { useRootStore } from '../stores/root';
 import { usePassengerStore } from '../stores/passenger';
 import dialogs from '../services/dialogs.js';
 import dayjs from '../dayjs';
+import { getTripDestinationCity } from '../utils/ongoingTrip';
 export default {
     data() {
         return {
@@ -68,6 +64,7 @@ export default {
     },
     methods: {
         dayjs,
+        getTripDestinationCity,
         ...mapActions(useRootStore, {
             getTrip: 'getTrip'
         }),

--- a/src/components/PendingRequest.view.test.js
+++ b/src/components/PendingRequest.view.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const viewPath = path.resolve(__dirname, 'PendingRequest.vue');
+const viewSource = fs.readFileSync(viewPath, 'utf8');
+
+describe('PendingRequest.vue destination city', () => {
+    it('does not read trip.points without a helper', () => {
+        expect(viewSource).not.toMatch(
+            /trip\.points\[trip\.points\.length/
+        );
+        expect(viewSource).toContain('getTripDestinationCity');
+        expect(viewSource).toContain("from '../utils/ongoingTrip'");
+    });
+});

--- a/src/components/PendingRequest.vue
+++ b/src/components/PendingRequest.vue
@@ -83,9 +83,7 @@
             <div class="pending-request-card__content">
                 <strong>{{ user.name }}</strong>
                 {{ $t('pendingRequestQuiereSubirseAlViaje') }}
-                <strong>{{
-                    trip.points[trip.points.length - 1].json_address.ciudad
-                }}</strong>
+                <strong>{{ getTripDestinationCity(trip) }}</strong>
                 {{ $t('pendingRequestDelDia') }} {{ dayjs(trip.trip_date).format('DD/MM/YYYY') }} {{ $t('pendingRequestALas') }}
                 {{ dayjs(trip.trip_date).format('HH:mm') }}.
                 <div class="pending-request-card__actions">
@@ -137,6 +135,7 @@ import dialogs from '../services/dialogs.js';
 import spinner from './Spinner.vue';
 import bus from '../services/bus-event.js';
 import dayjs from '../dayjs';
+import { getTripDestinationCity } from '../utils/ongoingTrip';
 import AppButton from './ui/AppButton.vue';
 
 export default {
@@ -156,6 +155,7 @@ export default {
     },
     methods: {
         dayjs,
+        getTripDestinationCity,
         ...mapActions(usePassengerStore, {
             passengerAccept: 'accept',
             passengerReject: 'reject'

--- a/src/components/RatePending.view.test.js
+++ b/src/components/RatePending.view.test.js
@@ -36,3 +36,13 @@ describe('RatePending.vue neutral ratings', () => {
         );
     });
 });
+
+describe('RatePending.vue destination city', () => {
+    it('does not read trip.points without a helper', () => {
+        expect(viewSource).not.toMatch(
+            /trip\.points\[trip\.points\.length/
+        );
+        expect(viewSource).toContain('getTripDestinationCity');
+        expect(viewSource).toContain("from '../utils/ongoingTrip'");
+    });
+});

--- a/src/components/RatePending.vue
+++ b/src/components/RatePending.vue
@@ -22,9 +22,7 @@
                     <span v-if="rate.user_to_type === DRIVER">{{ $t('ratePendingConductor') }}</span>
                     <span v-if="rate.user_to_type === PASSENGER">{{ $t('ratePendingPasajero') }}</span>
                     {{ $t('ratePendingEnElViajeHacia') }}
-                    <strong>{{
-                        trip.points[trip.points.length - 1].json_address.ciudad
-                    }}</strong>
+                    <strong>{{ getTripDestinationCity(trip) }}</strong>
                     {{ $t('ratePendingElDia') }}
                     <strong>{{
                         dayjs(trip.trip_date).format('dddd DD [de] MMMM')
@@ -91,6 +89,7 @@ import {
     canSubmitRatingVote,
     getRequiredCommentMessageKey
 } from '../utils/tripRating';
+import { getTripDestinationCity } from '../utils/ongoingTrip';
 import AppButton from './ui/AppButton.vue';
 import AppTextarea from './ui/AppTextarea.vue';
 
@@ -118,6 +117,7 @@ export default {
 
     methods: {
         dayjs,
+        getTripDestinationCity,
         ...mapActions(useRatesStore, {
             emit: 'vote'
         }),

--- a/src/components/elements/TripDriver.view.test.js
+++ b/src/components/elements/TripDriver.view.test.js
@@ -5,6 +5,19 @@ import path from 'node:path';
 const viewPath = path.resolve(__dirname, 'TripDriver.vue');
 const source = fs.readFileSync(viewPath, 'utf8');
 
+describe('TripDriver profile and image when auth or driver is missing', () => {
+    it('resolves profile id and image through helpers instead of reading user.id unguarded', () => {
+        expect(source).toContain('getTripDriverProfileId');
+        expect(source).toContain('getTripDriverImage');
+        expect(source).not.toMatch(
+            /return this\.trip\.user\.id === this\.user\.id/
+        );
+        expect(source).not.toMatch(
+            /return this\.user\.id === this\.trip\.user\.id/
+        );
+    });
+});
+
 describe('TripDriver profile navigation', () => {
     it('uses router-link with a shared visible-link class instead of click handlers', () => {
         expect(source).toContain('trip-driver-profile-link');

--- a/src/components/elements/TripDriver.vue
+++ b/src/components/elements/TripDriver.vue
@@ -263,6 +263,10 @@ import {
     getSeatsPillLabel,
     getSeatsPillTone
 } from '../../utils/tripCardDisplay.js';
+import {
+    getTripDriverImage,
+    getTripDriverProfileId
+} from '../../utils/tripDriverProfile.js';
 
 export default {
     name: 'TripDriver',
@@ -282,9 +286,7 @@ export default {
             isMobile: 'isMobile'
         }),
         getUserProfile() {
-            return this.trip.user.id === this.user.id
-                ? 'me'
-                : this.trip.user.id;
+            return getTripDriverProfileId(this.trip, this.user);
         },
         driverProfileRoute() {
             return {
@@ -296,9 +298,7 @@ export default {
             };
         },
         getUserImage() {
-            return this.user.id === this.trip.user.id
-                ? this.user.image
-                : this.trip.user.image;
+            return getTripDriverImage(this.trip, this.user);
         },
         driverRatings() {
             if (!this.trip?.user) {

--- a/src/components/views/ConversationList.view.test.js
+++ b/src/components/views/ConversationList.view.test.js
@@ -99,6 +99,14 @@ describe('ConversationList.vue messages redesign', () => {
         );
     });
 
+    it('does not read window.Notification.permission on mount when the API is missing', () => {
+        expect(viewSource).not.toContain('window.Notification.permission');
+        expect(viewSource).toContain('isWebNotificationPermissionGranted');
+        expect(viewSource).toMatch(
+            /mounted\(\)\s*\{[\s\S]*isWebNotificationPermissionGranted\(\)/
+        );
+    });
+
     it('sizes the conversation list scroll area below the header so load-more stays reachable', () => {
         const cssPath = path.resolve(
             __dirname,

--- a/src/components/views/ConversationList.vue
+++ b/src/components/views/ConversationList.vue
@@ -270,6 +270,7 @@ import {
 import AppButton from '../ui/AppButton.vue';
 import AppInput from '../ui/AppInput.vue';
 import { debounce } from '../../services/utility';
+import { isWebNotificationPermissionGranted } from '../../utils/notificationPermission';
 
 export default {
     name: 'conversation-list',
@@ -424,7 +425,7 @@ export default {
 
     mounted() {
         this.conversationsSearch();
-        if (!this.config.web_push_notification || window.Notification.permission !== 'granted') {
+        if (!this.config.web_push_notification || !isWebNotificationPermissionGranted()) {
             this.thread = new Thread(() => {
                 this.unreadMessage();
             });

--- a/src/components/views/MyTrips.view.test.js
+++ b/src/components/views/MyTrips.view.test.js
@@ -72,4 +72,9 @@ describe('MyTrips donation after positive rating', () => {
         expect(source).toMatch(/name:\s*'donate-after-rating'/);
         expect(source).toMatch(/params:\s*\{\s*tripId/);
     });
+
+    it('does not read needs_sellado when the rated trip is missing', () => {
+        expect(source).not.toMatch(/!data\.trip\.needs_sellado/);
+        expect(source).toContain('data.trip?.needs_sellado');
+    });
 });

--- a/src/components/views/MyTrips.vue
+++ b/src/components/views/MyTrips.vue
@@ -347,7 +347,7 @@ export default {
                     this.config &&
                     this.config.donation &&
                     this.config.donation.month_days > 0 &&
-                    !data.trip.needs_sellado
+                    !data.trip?.needs_sellado
                 ) {
                     this.redirectToDonationPrompt(data.trip_id);
                 }

--- a/src/components/views/Trips.view.test.js
+++ b/src/components/views/Trips.view.test.js
@@ -296,3 +296,11 @@ describe('Trips.vue empty search and nearby section', () => {
         expect(viewSource).not.toContain('isComplementary(');
     });
 });
+
+describe('Trips.vue search box when the ref is missing', () => {
+    it('clears the search box through a helper that tolerates a missing ref', () => {
+        expect(viewSource).toContain('clearSearchBox');
+        expect(viewSource).toContain("from '../../utils/searchBox.js'");
+        expect(viewSource).not.toMatch(/this\.\$refs\.searchBox\.clear\(\)/);
+    });
+});

--- a/src/components/views/Trips.vue
+++ b/src/components/views/Trips.vue
@@ -585,6 +585,7 @@ import { splitFriendTrips } from '../../utils/splitFriendTrips.js';
 import { splitTripsBySearchDate } from '../../utils/tripSearchDateSplit.js';
 import { shouldShowSplitDonationPanel } from '../../utils/tripsSplitDonationBanner.js';
 import { readAllowPreferenceParamsFromQuery } from '../../utils/searchAdvancedFilters.js';
+import { clearSearchBox } from '../../utils/searchBox.js';
 import AppButton from '../ui/AppButton.vue';
 import { useActionbarsStore } from '../../stores/actionbars';
 
@@ -939,9 +940,7 @@ export default {
             this.setMobileSearchHeader(false);
             this.alreadySubscribe = false;
             this.search({ is_passenger: false });
-            if (this.$refs.searchBox) {
-                this.$refs.searchBox.clear();
-            }
+            clearSearchBox(this.$refs.searchBox);
         },
         onScrollBottom() {
             if (this.morePages && !this.lookSearch) {
@@ -1097,9 +1096,7 @@ export default {
             }
             this.search(this.searchParams.data);
         } else {
-            if (this.$refs.searchBox) {
-                this.$refs.searchBox.clear();
-            }
+            clearSearchBox(this.$refs.searchBox);
         }
 
         const queryParams = this.getSearchParamsFromQuery();
@@ -1199,7 +1196,7 @@ export default {
                     this.refreshTrips(false);
                     this.lookSearch = false;
                     this.resultaOfSearch = false;
-                    this.$refs.searchBox.clear();
+                    clearSearchBox(this.$refs.searchBox);
                 }
             }
         }

--- a/src/utils/donationAfterRating.js
+++ b/src/utils/donationAfterRating.js
@@ -10,13 +10,15 @@ export function shouldPromptDonationAfterRating({ user, tripId, tripsRated }) {
         return true;
     }
 
-    const donationForTrip = user.donations.find(
+    const donations = (user.donations || []).filter(Boolean);
+
+    const donationForTrip = donations.find(
         (donation) => Number(donation.trip_id) === normalizedTripId
     );
     if (donationForTrip) {
         return false;
     }
 
-    const tripDonations = user.donations.filter((donation) => donation.trip_id !== null);
+    const tripDonations = donations.filter((donation) => donation.trip_id !== null);
     return tripDonations.length < tripRatedLimit;
 }

--- a/src/utils/donationAfterRating.test.js
+++ b/src/utils/donationAfterRating.test.js
@@ -47,4 +47,17 @@ describe('shouldPromptDonationAfterRating', () => {
             })
         ).toBe(false);
     });
+
+    it('ignores empty donation entries without reading trip_id', () => {
+        expect(
+            shouldPromptDonationAfterRating({
+                user: {
+                    monthly_donate: false,
+                    donations: [undefined, null, { trip_id: 1 }]
+                },
+                tripId: 42,
+                tripsRated: 2
+            })
+        ).toBe(true);
+    });
 });

--- a/src/utils/notificationPermission.js
+++ b/src/utils/notificationPermission.js
@@ -31,6 +31,14 @@ export function isPlainWeb() {
     return !isNativePlatform() && !isPWA();
 }
 
+export function isWebNotificationPermissionGranted() {
+    return Boolean(
+        typeof window !== 'undefined' &&
+            window.Notification &&
+            window.Notification.permission === 'granted'
+    );
+}
+
 // Returns the dynamic module (a non-thenable ES module namespace), NOT the
 // plugin object. The @capacitor/push-notifications export is a Capacitor Proxy
 // that returns a wrapper for every property — including `then` — so awaiting

--- a/src/utils/notificationPermission.test.js
+++ b/src/utils/notificationPermission.test.js
@@ -86,6 +86,51 @@ describe('isPWA', () => {
     });
 });
 
+describe('isWebNotificationPermissionGranted', () => {
+    afterEach(() => {
+        vi.resetModules();
+    });
+
+    it('returns false when the Notification API is missing', async () => {
+        globalThis.window = {};
+        const { isWebNotificationPermissionGranted } = await import(
+            './notificationPermission.js'
+        );
+        expect(isWebNotificationPermissionGranted()).toBe(false);
+    });
+
+    it('returns false when window is undefined', async () => {
+        const previousWindow = globalThis.window;
+        // eslint-disable-next-line no-global-assign
+        globalThis.window = undefined;
+        const { isWebNotificationPermissionGranted } = await import(
+            './notificationPermission.js'
+        );
+        expect(isWebNotificationPermissionGranted()).toBe(false);
+        globalThis.window = previousWindow;
+    });
+
+    it('returns false when permission is denied', async () => {
+        globalThis.window = {
+            Notification: { permission: 'denied' }
+        };
+        const { isWebNotificationPermissionGranted } = await import(
+            './notificationPermission.js'
+        );
+        expect(isWebNotificationPermissionGranted()).toBe(false);
+    });
+
+    it('returns true when web notification permission is granted', async () => {
+        globalThis.window = {
+            Notification: { permission: 'granted' }
+        };
+        const { isWebNotificationPermissionGranted } = await import(
+            './notificationPermission.js'
+        );
+        expect(isWebNotificationPermissionGranted()).toBe(true);
+    });
+});
+
 describe('getNotificationPermissionStatus', () => {
     afterEach(() => {
         vi.clearAllMocks();

--- a/src/utils/ongoingTrip.js
+++ b/src/utils/ongoingTrip.js
@@ -149,3 +149,10 @@ export function getTripLocationLabels(trip) {
         toPoint
     };
 }
+
+export function getTripDestinationCity(trip) {
+    if (trip && trip.points && trip.points.length > 0) {
+        return getLocationName(trip.points[trip.points.length - 1]);
+    }
+    return getTripLocationLabels(trip).toCity;
+}

--- a/src/utils/ongoingTrip.test.js
+++ b/src/utils/ongoingTrip.test.js
@@ -3,6 +3,7 @@ import dayjs from '../dayjs';
 import {
     estimatedTimeToMinutes,
     getRatingAvailableAt,
+    getTripDestinationCity,
     getTripLocationLabels,
     isRatingAvailable,
     isWithinOngoingTripWindow,
@@ -211,5 +212,36 @@ describe('getTripLocationLabels', () => {
             toRegion: 'CABA',
             toPoint: 'Plaza Principal'
         });
+    });
+});
+
+describe('getTripDestinationCity', () => {
+    it('returns the last point city when points exist', () => {
+        expect(
+            getTripDestinationCity({
+                points: [
+                    { json_address: { ciudad: 'Rosario' } },
+                    { json_address: { ciudad: 'Córdoba' } }
+                ]
+            })
+        ).toBe('Córdoba');
+    });
+
+    it('returns an empty string when trip is missing', () => {
+        expect(getTripDestinationCity(undefined)).toBe('');
+        expect(getTripDestinationCity(null)).toBe('');
+    });
+
+    it('does not read points on an incomplete trip', () => {
+        expect(getTripDestinationCity({})).toBe('');
+        expect(getTripDestinationCity({ points: [] })).toBe('');
+    });
+
+    it('falls back to to_town when points are missing', () => {
+        expect(
+            getTripDestinationCity({
+                to_town: 'Mendoza, Mendoza, Argentina'
+            })
+        ).toBe('Mendoza');
     });
 });

--- a/src/utils/searchBox.js
+++ b/src/utils/searchBox.js
@@ -1,0 +1,5 @@
+export function clearSearchBox(searchBox) {
+    if (searchBox && typeof searchBox.clear === 'function') {
+        searchBox.clear();
+    }
+}

--- a/src/utils/searchBox.test.js
+++ b/src/utils/searchBox.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from 'vitest';
+import { clearSearchBox } from './searchBox.js';
+
+describe('clearSearchBox', () => {
+    it('does nothing when the search box is missing', () => {
+        expect(() => clearSearchBox(undefined)).not.toThrow();
+        expect(() => clearSearchBox(null)).not.toThrow();
+        expect(() => clearSearchBox({})).not.toThrow();
+    });
+
+    it('calls clear when the search box is present', () => {
+        const searchBox = { clear: vi.fn() };
+        clearSearchBox(searchBox);
+        expect(searchBox.clear).toHaveBeenCalledOnce();
+    });
+});

--- a/src/utils/tripDriverProfile.js
+++ b/src/utils/tripDriverProfile.js
@@ -1,0 +1,21 @@
+export function getTripDriverProfileId(trip, authUser) {
+    const driver = trip?.user;
+    if (!driver) {
+        return null;
+    }
+    if (!authUser || authUser.id == null) {
+        return driver.id;
+    }
+    return authUser.id === driver.id ? 'me' : driver.id;
+}
+
+export function getTripDriverImage(trip, authUser) {
+    const driver = trip?.user;
+    if (!driver) {
+        return '';
+    }
+    if (!authUser || authUser.id == null) {
+        return driver.image || '';
+    }
+    return authUser.id === driver.id ? authUser.image : driver.image;
+}

--- a/src/utils/tripDriverProfile.test.js
+++ b/src/utils/tripDriverProfile.test.js
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+    getTripDriverImage,
+    getTripDriverProfileId
+} from './tripDriverProfile.js';
+
+const driver = { id: 10, image: 'driver.jpg' };
+const trip = { user: driver };
+const authUser = { id: 10, image: 'me.jpg' };
+const otherUser = { id: 99, image: 'other.jpg' };
+
+describe('getTripDriverProfileId', () => {
+    it('returns null when the trip has no driver', () => {
+        expect(getTripDriverProfileId(null, authUser)).toBe(null);
+        expect(getTripDriverProfileId({}, authUser)).toBe(null);
+    });
+
+    it('returns the driver id when the auth user is missing', () => {
+        expect(getTripDriverProfileId(trip, null)).toBe(10);
+        expect(getTripDriverProfileId(trip, {})).toBe(10);
+    });
+
+    it('returns me when the auth user is the driver', () => {
+        expect(getTripDriverProfileId(trip, authUser)).toBe('me');
+    });
+
+    it('returns the driver id when the auth user is someone else', () => {
+        expect(getTripDriverProfileId(trip, otherUser)).toBe(10);
+    });
+});
+
+describe('getTripDriverImage', () => {
+    it('returns an empty string when the trip has no driver', () => {
+        expect(getTripDriverImage(null, authUser)).toBe('');
+        expect(getTripDriverImage({}, authUser)).toBe('');
+    });
+
+    it('returns the driver image when the auth user is missing', () => {
+        expect(getTripDriverImage(trip, null)).toBe('driver.jpg');
+        expect(getTripDriverImage(trip, {})).toBe('driver.jpg');
+    });
+
+    it('returns the auth user image when they are the driver', () => {
+        expect(getTripDriverImage(trip, authUser)).toBe('me.jpg');
+    });
+
+    it('returns the driver image when the auth user is someone else', () => {
+        expect(getTripDriverImage(trip, otherUser)).toBe('driver.jpg');
+    });
+});


### PR DESCRIPTION
## Summary
Follow-up to #654 for the remaining production Vue crashes from the 2026-08-30 client logs:

- Skip `window.Notification.permission` in `ConversationList` when the Notification API is missing (WebViews)
- Resolve trip destination city without reading missing `points` (`RatePending`, `PendingRequest`, `PendingPaymentRequest`)
- Skip the post-rating donation prompt for sparse donations and missing trips (`MyTrips`)
- Resolve trip driver profile and image without crashing on missing users (`TripDriver`)
- Skip `searchBox.clear()` when the trips search ref is missing (`Trips`)

`getInstallModalContent` in `Trips.vue` was already safe; those stacks came from older Capacitor bundles.

## Test plan
- [ ] `npm run test:unit -- --run src/utils/notificationPermission.test.js src/components/views/ConversationList.view.test.js`
- [ ] `npm run test:unit -- --run src/utils/ongoingTrip.test.js src/components/RatePending.view.test.js src/components/PendingRequest.view.test.js src/components/PendingPaymentRequest.view.test.js`
- [ ] `npm run test:unit -- --run src/utils/donationAfterRating.test.js src/components/views/MyTrips.view.test.js`
- [ ] `npm run test:unit -- --run src/utils/tripDriverProfile.test.js src/components/elements/TripDriver.view.test.js`
- [ ] `npm run test:unit -- --run src/utils/searchBox.test.js src/components/views/Trips.view.test.js`
- [ ] Open Messages on a WebView without Notification API (or desktop with the API mocked off) and confirm unread polling still starts
- [ ] Open My trips with incomplete trip payloads and confirm pending rate/request cards still render
- [ ] Rate a trip and confirm the donation prompt still appears only when the trip and donation data are present
- [ ] Open a trip card with a missing driver user and confirm the driver block does not crash
- [ ] Search trips, then change filters so the search box should clear, including if the search box is not mounted