### PR TITLE
Show Cerrado for closed manuals after MercadoPago verification

### DIFF
--- a/src/components/sections/IdentityValidation.view.test.js
+++ b/src/components/sections/IdentityValidation.view.test.js
@@ -331,3 +331,9 @@ describe('IdentityValidation manual admin review note', () => {
         );
     });
 });
+
+describe('IdentityValidation closed manual after MercadoPago', () => {
+    it('treats closed review status as terminal so pending notices are not shown', () => {
+        expect(viewSource).toContain('isManualIdentityValidationTerminalStatus');
+    });
+});

--- a/src/components/sections/IdentityValidation.vue
+++ b/src/components/sections/IdentityValidation.vue
@@ -512,7 +512,7 @@ import {
     MERCADO_PAGO_MY_APPS_URL,
     shouldShowMercadoPagoIntegrationDisconnectHint
 } from '../../utils/mercadoPagoIntegrationDisconnectHint';
-import { isManualRejectedWithChoiceCards, canManualResubmitWithoutPayment, getManualValidationResubmitRoute, getManualValidationRestartRoute } from '../../utils/manualIdentityValidationStatus';
+import { isManualRejectedWithChoiceCards, canManualResubmitWithoutPayment, getManualValidationResubmitRoute, getManualValidationRestartRoute, isManualIdentityValidationTerminalStatus } from '../../utils/manualIdentityValidationStatus';
 import IdentityValidationAdminReviewNote from '../IdentityValidationAdminReviewNote.vue';
 import ManualIdentityValidationPayOptions from './ManualIdentityValidationPayOptions.vue';
 import AppButton from '../ui/AppButton.vue';
@@ -592,7 +592,7 @@ export default {
             );
         },
         /**
-         * Paid + docs sent + not yet approved/rejected — still in admin queue.
+         * Paid + docs sent + not yet approved/rejected/closed — still in admin queue.
          * Must not be hidden behind the green "already verified" banner (user may still
          * carry identity_validated from MP or stale cache while manual review runs).
          */
@@ -600,17 +600,13 @@ export default {
             if (!this.identityValidationManualEnabled) return false;
             const m = this.manualStatus;
             if (!m || !m.has_submission || !m.paid || !m.submitted_at) return false;
-            if (m.review_status === 'approved' || m.review_status === 'rejected') {
-                return false;
-            }
-            return true;
+            return !isManualIdentityValidationTerminalStatus(m.review_status);
         },
-        /** Docs submitted, awaiting admin (not approved/rejected). */
+        /** Docs submitted, awaiting admin (not approved/rejected/closed). */
         showManualValidationSubmittedNotice() {
             const m = this.manualStatus;
             if (!m || !m.submitted_at) return false;
-            const rs = m.review_status;
-            return rs !== 'approved' && rs !== 'rejected';
+            return !isManualIdentityValidationTerminalStatus(m.review_status);
         },
         /** Blue card: right after upload redirect (?result=manual_submitted). */
         showManualPendingReviewBlue() {

--- a/src/components/sections/IdentityValidation.vue
+++ b/src/components/sections/IdentityValidation.vue
@@ -512,7 +512,13 @@ import {
     MERCADO_PAGO_MY_APPS_URL,
     shouldShowMercadoPagoIntegrationDisconnectHint
 } from '../../utils/mercadoPagoIntegrationDisconnectHint';
-import { isManualRejectedWithChoiceCards, canManualResubmitWithoutPayment, getManualValidationResubmitRoute, getManualValidationRestartRoute, isManualIdentityValidationTerminalStatus } from '../../utils/manualIdentityValidationStatus';
+import {
+    isManualRejectedWithChoiceCards,
+    canManualResubmitWithoutPayment,
+    getManualValidationResubmitRoute,
+    getManualValidationRestartRoute,
+    isManualIdentityValidationTerminalStatus
+} from '../../utils/manualIdentityValidationStatus';
 import IdentityValidationAdminReviewNote from '../IdentityValidationAdminReviewNote.vue';
 import ManualIdentityValidationPayOptions from './ManualIdentityValidationPayOptions.vue';
 import AppButton from '../ui/AppButton.vue';

--- a/src/components/views/AdminManualIdentityValidationReview.view.test.js
+++ b/src/components/views/AdminManualIdentityValidationReview.view.test.js
@@ -52,6 +52,11 @@ describe('AdminManualIdentityValidationReview view', () => {
         expect(viewSource).toContain('hasManualIdentityValidationStateChanges');
     });
 
+    it('labels closed review status as cerrado', () => {
+        expect(viewSource).toContain("status === 'closed'");
+        expect(viewSource).toContain('estadoCerrado');
+    });
+
     it('confirms mark pending when request is already pending', () => {
         expect(viewSource).toContain('confirmReview');
         expect(viewSource).toContain('@click="confirmReview(\'pending\')"');

--- a/src/components/views/AdminManualIdentityValidationReview.vue
+++ b/src/components/views/AdminManualIdentityValidationReview.vue
@@ -337,6 +337,7 @@ export default {
             if (status === 'awaiting_photos') return this.$t('estadoEsperandoFotos');
             if (status === 'approved') return this.$t('estadoAprobado');
             if (status === 'rejected') return this.$t('estadoRechazado');
+            if (status === 'closed') return this.$t('estadoCerrado');
             return status || '-';
         },
         getActionDateLabel(reviewStatus) {

--- a/src/utils/adminManualIdentityValidationDisplay.js
+++ b/src/utils/adminManualIdentityValidationDisplay.js
@@ -11,6 +11,7 @@ export function isManualIdentityValidationAwaitingPhotos(item) {
 }
 
 export function getManualIdentityValidationStatusLabel(item, t) {
+    if (item.review_status === 'closed') return t('estadoCerrado');
     if (!item.paid) return t('estadoPendientePago');
     if (isManualIdentityValidationAwaitingPhotos(item)) return t('estadoEsperandoFotos');
     const status = item.review_status;

--- a/src/utils/adminManualIdentityValidationDisplay.js
+++ b/src/utils/adminManualIdentityValidationDisplay.js
@@ -17,6 +17,7 @@ export function getManualIdentityValidationStatusLabel(item, t) {
     if (status === 'pending') return t('estadoPendienteRevision');
     if (status === 'approved' || status === 'approve') return t('estadoAprobado');
     if (status === 'rejected' || status === 'reject') return t('estadoRechazado');
+    if (status === 'closed') return t('estadoCerrado');
     return status || '-';
 }
 
@@ -25,6 +26,7 @@ export function getManualIdentityValidationStatusBadgeClass(item) {
     const status = item.review_status;
     if (status === 'approved' || status === 'approve') return 'label label-success';
     if (status === 'rejected' || status === 'reject') return 'label label-danger';
+    if (status === 'closed') return 'label label-default';
     if (!item.paid) return 'label label-default';
     return 'label label-warning';
 }

--- a/src/utils/adminManualIdentityValidationDisplay.js
+++ b/src/utils/adminManualIdentityValidationDisplay.js
@@ -18,7 +18,6 @@ export function getManualIdentityValidationStatusLabel(item, t) {
     if (status === 'pending') return t('estadoPendienteRevision');
     if (status === 'approved' || status === 'approve') return t('estadoAprobado');
     if (status === 'rejected' || status === 'reject') return t('estadoRechazado');
-    if (status === 'closed') return t('estadoCerrado');
     return status || '-';
 }
 

--- a/src/utils/adminManualIdentityValidationDisplay.test.js
+++ b/src/utils/adminManualIdentityValidationDisplay.test.js
@@ -40,6 +40,22 @@ describe('adminManualIdentityValidationDisplay', () => {
         })).toBe('label label-warning');
     });
 
+    it('labels closed paid requests as cerrado', () => {
+        expect(getManualIdentityValidationStatusLabel({
+            paid: true,
+            review_status: 'closed',
+            submitted_at: '2026-06-18 10:00:00'
+        }, t)).toBe('estadoCerrado');
+    });
+
+    it('uses default badge for closed requests', () => {
+        expect(getManualIdentityValidationStatusBadgeClass({
+            paid: true,
+            review_status: 'closed',
+            submitted_at: '2026-06-18 10:00:00'
+        })).toBe('label label-default');
+    });
+
     it('formats waiting time from submitted_at to now', () => {
         const now = new Date('2026-06-18 12:30:00').getTime();
         const result = formatManualIdentityValidationWaitingTime({

--- a/src/utils/adminManualIdentityValidationDisplay.test.js
+++ b/src/utils/adminManualIdentityValidationDisplay.test.js
@@ -48,6 +48,14 @@ describe('adminManualIdentityValidationDisplay', () => {
         }, t)).toBe('estadoCerrado');
     });
 
+    it('labels unpaid closed requests as cerrado', () => {
+        expect(getManualIdentityValidationStatusLabel({
+            paid: false,
+            review_status: 'closed',
+            submitted_at: null
+        }, t)).toBe('estadoCerrado');
+    });
+
     it('uses default badge for closed requests', () => {
         expect(getManualIdentityValidationStatusBadgeClass({
             paid: true,

--- a/src/utils/adminManualIdentityValidationStateEdit.js
+++ b/src/utils/adminManualIdentityValidationStateEdit.js
@@ -2,7 +2,8 @@ export const MANUAL_IDENTITY_VALIDATION_REVIEW_STATUS_OPTIONS = [
     { value: 'awaiting_photos', labelKey: 'estadoEsperandoFotos' },
     { value: 'pending', labelKey: 'estadoPendiente' },
     { value: 'approved', labelKey: 'estadoAprobado' },
-    { value: 'rejected', labelKey: 'estadoRechazado' }
+    { value: 'rejected', labelKey: 'estadoRechazado' },
+    { value: 'closed', labelKey: 'estadoCerrado' }
 ];
 
 export function hasPhotosSubmitted(item) {

--- a/src/utils/adminManualIdentityValidationStateEdit.test.js
+++ b/src/utils/adminManualIdentityValidationStateEdit.test.js
@@ -12,7 +12,8 @@ describe('adminManualIdentityValidationStateEdit', () => {
             { value: 'awaiting_photos', labelKey: 'estadoEsperandoFotos' },
             { value: 'pending', labelKey: 'estadoPendiente' },
             { value: 'approved', labelKey: 'estadoAprobado' },
-            { value: 'rejected', labelKey: 'estadoRechazado' }
+            { value: 'rejected', labelKey: 'estadoRechazado' },
+            { value: 'closed', labelKey: 'estadoCerrado' }
         ]);
     });
 

--- a/src/utils/adminManualIdentityValidationsList.js
+++ b/src/utils/adminManualIdentityValidationsList.js
@@ -55,7 +55,7 @@ export function saveShowResolvedManualIdentityValidations(showResolved, storage)
     );
 }
 
-const RESOLVED_REVIEW_STATUSES = new Set(['approved', 'approve', 'rejected', 'reject']);
+const RESOLVED_REVIEW_STATUSES = new Set(['approved', 'approve', 'rejected', 'reject', 'closed']);
 
 export function isManualIdentityValidationResolved(item) {
     const reviewStatus = item?.['review_status'];

--- a/src/utils/adminManualIdentityValidationsList.test.js
+++ b/src/utils/adminManualIdentityValidationsList.test.js
@@ -26,6 +26,10 @@ describe('adminManualIdentityValidationsList', () => {
             expect(isManualIdentityValidationResolved({ review_status: 'reject' })).toBe(true);
         });
 
+        it('treats closed as resolved', () => {
+            expect(isManualIdentityValidationResolved({ review_status: 'closed' })).toBe(true);
+        });
+
         it('treats pending and other statuses as unresolved', () => {
             expect(isManualIdentityValidationResolved(pending)).toBe(false);
             expect(isManualIdentityValidationResolved({ review_status: null })).toBe(false);

--- a/src/utils/identityValidationSuccessBanner.js
+++ b/src/utils/identityValidationSuccessBanner.js
@@ -1,11 +1,10 @@
-import { isManualIdentityValidationRejected } from './manualIdentityValidationStatus.js';
+import { isManualIdentityValidationRejected, isManualIdentityValidationTerminalStatus } from './manualIdentityValidationStatus.js';
 
 function isManualDocsPendingAdminReview(manualStatus) {
     if (!manualStatus || !manualStatus.has_submission || !manualStatus.paid || !manualStatus.submitted_at) {
         return false;
     }
-    const reviewStatus = manualStatus.review_status;
-    return reviewStatus !== 'approved' && reviewStatus !== 'rejected';
+    return !isManualIdentityValidationTerminalStatus(manualStatus.review_status);
 }
 
 export function shouldShowIdentityVerificationSuccessBanner({

--- a/src/utils/identityValidationSuccessBanner.test.js
+++ b/src/utils/identityValidationSuccessBanner.test.js
@@ -54,6 +54,21 @@ describe('shouldShowIdentityVerificationSuccessBanner', () => {
         ).toBe(false);
     });
 
+    it('returns true when a verified user has a closed manual request', () => {
+        expect(
+            shouldShowIdentityVerificationSuccessBanner({
+                user: verifiedUser,
+                manualStatus: {
+                    has_submission: true,
+                    paid: true,
+                    submitted_at: '2026-06-02 12:00:00',
+                    review_status: 'closed'
+                },
+                resultMessage: 'success'
+            })
+        ).toBe(true);
+    });
+
     it('returns true for a verified user without blocking manual state', () => {
         expect(
             shouldShowIdentityVerificationSuccessBanner({

--- a/src/utils/manualIdentityValidationStatus.js
+++ b/src/utils/manualIdentityValidationStatus.js
@@ -1,5 +1,11 @@
 import { isUserIdentityVerified } from './userIdentityVerification.js';
 
+const TERMINAL_MANUAL_REVIEW_STATUSES = new Set(['approved', 'rejected', 'closed']);
+
+export function isManualIdentityValidationTerminalStatus(reviewStatus) {
+    return TERMINAL_MANUAL_REVIEW_STATUSES.has(reviewStatus);
+}
+
 export function isManualIdentityValidationRejected(manualStatus, user = null) {
     if (isUserIdentityVerified(user)) {
         return false;
@@ -63,7 +69,7 @@ export function shouldShowManualValidationAlreadySubmitted(manualStatus) {
     if (canManualResubmitWithoutPayment(manualStatus)) {
         return false;
     }
-    if (manualStatus.review_status === 'rejected') {
+    if (manualStatus.review_status === 'rejected' || manualStatus.review_status === 'closed') {
         return false;
     }
 

--- a/src/utils/manualIdentityValidationStatus.test.js
+++ b/src/utils/manualIdentityValidationStatus.test.js
@@ -158,6 +158,16 @@ describe('shouldShowManualValidationAlreadySubmitted', () => {
             })
         ).toBe(false);
     });
+
+    it('returns false when the manual request was closed', () => {
+        expect(
+            shouldShowManualValidationAlreadySubmitted({
+                submitted_at: '2026-06-19 09:42:00',
+                review_status: 'closed',
+                can_resubmit_without_payment: false
+            })
+        ).toBe(false);
+    });
 });
 
 describe('getManualValidationRestartRoute', () => {


### PR DESCRIPTION
## Summary
- Add `closed` to the admin manual identity state dropdown, labeled Cerrado (`estadoCerrado`).
- Treat closed manuals as resolved in the admin list and show Cerrado even when the request was never paid.
- After MercadoPago verification succeeds, do not show leftover "pending review" or "already submitted" notices for a closed request.

Companion backend PR: https://github.com/STS-Rosario/carpoolear_backend/pull/400

## Test plan
- [x] `npx vitest run` on the touched admin/identity helper and view tests (103 passed)
- [ ] With the backend deployed, complete MercadoPago verification while a manual request is open and confirm the identity screen shows success
- [ ] In admin, set a request to Cerrado and confirm the list hides it unless "show resolved" is on
- [ ] With "show resolved", unpaid closed leftovers show Cerrado (not Pendiente de pago)